### PR TITLE
Fix Axisymmetry with mixed-field formulations

### DIFF
--- a/felupe/field.py
+++ b/felupe/field.py
@@ -66,6 +66,7 @@ class Field:
     def __init__(self, region, dim=1, values=0):
         self.region = region
         self.dim = dim
+        self.kind = "default"
 
         # init values
         if type(values) == np.ndarray:
@@ -190,6 +191,7 @@ class FieldAxisymmetric(Field):
         super().__init__(region, dim=dim, values=values)
         self.scalar = Field(region)
         self.radius = self.scalar.interpolate(region.mesh.nodes[:, 1])
+        self.kind = "axisymmetric"
 
     def _grad_2d(self):
         "gradient dudX_IJpe"

--- a/felupe/field.py
+++ b/felupe/field.py
@@ -63,9 +63,13 @@ class Indices:
 class Field:
     "n-dimensional field in region."
 
-    def __init__(self, region, dim=1, values=0):
+    def __init__(self, region, dim=1, values=0, **kwargs):
         self.region = region
         self.dim = dim
+
+        # set optional user-defined attributes
+        for key, value in kwargs.items():
+            setattr(self, key, value)
 
         # init values
         if type(values) == np.ndarray:

--- a/felupe/field.py
+++ b/felupe/field.py
@@ -66,7 +66,6 @@ class Field:
     def __init__(self, region, dim=1, values=0):
         self.region = region
         self.dim = dim
-        self.kind = "default"
 
         # init values
         if type(values) == np.ndarray:
@@ -191,7 +190,6 @@ class FieldAxisymmetric(Field):
         super().__init__(region, dim=dim, values=values)
         self.scalar = Field(region)
         self.radius = self.scalar.interpolate(region.mesh.nodes[:, 1])
-        self.kind = "axisymmetric"
 
     def _grad_2d(self):
         "gradient dudX_IJpe"

--- a/felupe/forms.py
+++ b/felupe/forms.py
@@ -30,73 +30,6 @@ from scipy.sparse import csr_matrix as sparsematrix
 from scipy.sparse import bmat, vstack
 
 
-class IntegralFormAxisymmetric:
-    def __init__(self, fun, field, dA):
-        R = field.radius
-        self.dA = 2 * np.pi * dA
-
-        if len(fun.shape) - 2 == 2:
-
-            self.mode = 1
-
-            fun_2d = fun[:2, :2]
-            fun_t = fun[(2,), (2,)]
-
-            form_2d = IntegralForm(fun_2d, field, R * self.dA, grad_v=True)
-            form_t = IntegralForm(fun_t, field.scalar, self.dA)
-
-            self.forms = [form_2d, form_t]
-
-        elif len(fun.shape) - 2 == 4:
-
-            self.mode = 2
-
-            fun_2d2d = fun[:2, :2, :2, :2]
-            fun_2dt = fun[:2, :2, 2, 2]
-            fun_t2d = fun[2, 2, :2, :2]
-            fun_tt = fun[2, 2, 2, 2]
-
-            form_2d2d = IntegralForm(fun_2d2d, field, R * self.dA, field, True, True)
-            form_tt = IntegralForm(
-                fun_tt / R, field.scalar, self.dA, field.scalar, False, False
-            )
-            form_t2d = IntegralForm(
-                fun_t2d, field.scalar, self.dA, field.scalar, False, True
-            )
-            form_2dt = IntegralForm(fun_2dt, field, self.dA, field.scalar, True, False)
-
-            self.forms = [form_2d2d, form_tt, form_t2d, form_2dt]
-
-    def integrate(self, parallel=False):
-        values = [form.integrate(parallel=parallel) for form in self.forms]
-
-        if self.mode == 1:
-            values[0] += np.pad(values[1], ((0, 0), (1, 0), (0, 0)))
-
-        elif self.mode == 2:
-            a, b, e = values[1].shape
-            values[1] = values[1].reshape(a, 1, b, 1, e)
-            values[1] = np.pad(values[1], ((0, 0), (1, 0), (0, 0), (1, 0), (0, 0)))
-
-            a, b, i, e = values[2].shape
-            values[2] = values[2].reshape(a, 1, b, i, e)
-            values[2] = np.pad(values[2], ((0, 0), (1, 0), (0, 0), (0, 0), (0, 0)))
-
-            a, i, b, e = values[3].shape
-            values[3] = values[3].reshape(a, i, b, 1, e)
-            values[3] = np.pad(values[3], ((0, 0), (0, 0), (0, 0), (1, 0), (0, 0)))
-
-            for i in range(1, len(values)):
-                values[0] += values[i]
-
-        return values[0]
-
-    def assemble(self, values=None, parallel=False):
-        if values is None:
-            values = self.integrate(parallel=parallel)
-        return self.forms[0].assemble(values)
-
-
 class IntegralFormMixed:
     def __init__(self, fun, fields, dV, grad=None):
 
@@ -283,6 +216,73 @@ class IntegralForm:
                     return np.einsum(
                         "aJpe,iJkLpe,bLpe,pe->aibke", vb, fun, ub, dV, optimize=True
                     )
+
+
+class IntegralFormAxisymmetric(IntegralForm):
+    def __init__(self, fun, v, dA, u=None, grad_v=True, grad_u=True):
+
+        if not grad_v or not grad_u:
+            raise NotImplementedError(
+                "Axisymmetric Form is only implemented as v.grad()."
+            )
+
+        R = v.radius
+        self.dV = 2 * np.pi * R * dA
+
+        if u is None:
+
+            self.mode = 1
+
+            form_a = IntegralForm(fun[:-1, :-1], v, self.dV, grad_v=True)
+            form_b = IntegralForm(fun[(2,), (2,)] / R, v.scalar, self.dV)
+
+            self.forms = [form_a, form_b]
+
+        else:
+
+            self.mode = 2
+
+            form_aa = IntegralForm(fun[:-1, :-1, :-1, :-1], v, self.dV, u, True, True)
+            form_bb = IntegralForm(
+                fun[-1, -1, -1, -1] / R ** 2, v.scalar, self.dV, u.scalar, False, False
+            )
+            form_ba = IntegralForm(
+                fun[-1, -1, :-1, :-1] / R, v.scalar, self.dV, u, False, True
+            )
+            form_ab = IntegralForm(
+                fun[:-1, :-1, -1, -1] / R, v, self.dV, u.scalar, True, False
+            )
+
+            self.forms = [form_aa, form_bb, form_ba, form_ab]
+
+    def integrate(self, parallel=False):
+        values = [form.integrate(parallel=parallel) for form in self.forms]
+
+        if self.mode == 1:
+            values[0] += np.pad(values[1], ((0, 0), (1, 0), (0, 0)))
+
+        elif self.mode == 2:
+            a, b, e = values[1].shape
+            values[1] = values[1].reshape(a, 1, b, 1, e)
+            values[1] = np.pad(values[1], ((0, 0), (1, 0), (0, 0), (1, 0), (0, 0)))
+
+            a, b, i, e = values[2].shape
+            values[2] = values[2].reshape(a, 1, b, i, e)
+            values[2] = np.pad(values[2], ((0, 0), (1, 0), (0, 0), (0, 0), (0, 0)))
+
+            a, i, b, e = values[3].shape
+            values[3] = values[3].reshape(a, i, b, 1, e)
+            values[3] = np.pad(values[3], ((0, 0), (0, 0), (0, 0), (1, 0), (0, 0)))
+
+            for i in range(1, len(values)):
+                values[0] += values[i]
+
+        return values[0]
+
+    def assemble(self, values=None, parallel=False):
+        if values is None:
+            values = self.integrate(parallel=parallel)
+        return self.forms[0].assemble(values)
 
 
 try:


### PR DESCRIPTION
As discussed in #6, now the following is possible:

```python
import numpy as np
import felupe as fe
import felupe.math as fm

mesh  = fe.mesh.Rectangle(a=(0,0.5), b=(1,1.5), n=11)
mesh0 = fe.mesh.convert(mesh)

element0 = fe.element.Quad0()
element1 = fe.element.Quad1()
quadrature = fe.quadrature.GaussLegendre(order=1, dim=2)

region0 = fe.Region(mesh0, element0, quadrature)
region  = fe.Region(mesh,  element1, quadrature)

dA = region.dV

displacement = fe.FieldAxisymmetric(region, dim=2)
pressure     = fe.Field(region0, dim=1)
volumeratio  = fe.Field(region0, dim=1, values=1)

fields = (displacement, pressure, volumeratio)

f1 = lambda x: np.isclose(x, 1)

boundaries = fe.doftools.symmetry(displacement)
boundaries["right"] = fe.Boundary(displacement, fx=f1, skip=(1, 0, 0))
boundaries["move" ] = fe.Boundary(displacement, fx=f1, skip=(0, 1, 1), value=-0.3)

dof0, dof1, unstack = fe.doftools.partition(fields, boundaries)
u0ext = fe.doftools.apply(displacement, boundaries, dof0)

neohooke = fe.constitution.df_da0.NeoHooke(mu=1.0, bulk=5000.0)
umat = fe.constitution.variation.upJ(neohooke.P, neohooke.A)

for iteration in range(8):
    
    dudX = displacement.grad()
    
    F = fm.identity(dudX) + dudX
    p = pressure.interpolate()
    J = volumeratio.interpolate()
    
    f = umat.f(F, p, J)
    A = umat.A(F, p, J)
    
    linearform   = fe.IntegralFormMixed(f, fields, dA)
    bilinearform = fe.IntegralFormMixed(A, fields, dA)
    
    r = linearform.assemble().toarray()[:, 0]
    K = bilinearform.assemble()
    
    system = fe.solve.partition(fields, K, dof1, dof0, r)
    dfields = np.split(fe.solve.solve(*system, u0ext), unstack)
    
    for field, dfield in zip(fields, dfields):
        field += dfield

    norm = np.linalg.norm(dfields[0])
    print("\n",iteration, norm,"\n")

    if norm < 1e-12:
        break

fe.utils.save(region, fields, F=F, r=r, f=f, unstack=unstack, filename="result.vtk")

```

`IntegralFormMixed` now handles the fields correctly. That means if the first field, which is the one associated to displacements, is `FieldAxisymmetric` then all mixed weak form expressions are treated for the axisymmetric case.

I think this is very intuitive to use! And, of cource, quadratic convergence behavior is archieved in this example.