### PR TITLE
Enhance mesh.convert capabilities: convert to order=0 and order=2

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -9,7 +9,7 @@ import felupe as fe
 
 n = 51
 mesh = fe.mesh.Rectangle(n=n)
-element = fe.element.Quad1()
+element = fe.element.Quad()
 quadrature = fe.quadrature.GaussLegendre(order=1, dim=2)
 
 region = fe.Region(mesh, element, quadrature)
@@ -52,7 +52,7 @@ A = bilinearform.assemble()
 b = linearform.assemble()
 ```
 
-As already mentioned all boundary nodes are fixed.
+As already mentioned all boundary points are fixed.
 
 ```python
 f0, f1 = lambda x: np.isclose(x, 0), lambda x: np.isclose(x, 1)
@@ -104,19 +104,19 @@ We take the [Getting Started](quickstart.md) example and modify it accordingly. 
 
 ```python
 neohooke = fe.constitution.NeoHooke(mu=1.0, bulk=5000.0)
-umat = fe.constitution.ThreeFieldVariation(neohooke.P, neohooke.A)
+umat = fe.constitution.variation.upJ(neohooke.P, neohooke.A)
 ```
 
-We create a meshed cube and a converted version for the elementwise constant fields. Two element definitions are necessary: one for the displacements and one for the pressure and volume ratio. Both elements use the same quadrature rule. Two regions are created, which will be further used by the creation of the fields.
+We create a meshed cube and a converted version for the piecewise constant fields per cell. Two element definitions are necessary: one for the displacements and one for the pressure and volume ratio. Both elements use the same quadrature rule. Two regions are created, which will be further used by the creation of the fields.
 
 
 ```python
 mesh  = fe.mesh.Cube(n=6)
-mesh0 = fe.mesh.convert(mesh)
+mesh0 = fe.mesh.convert(mesh, order=0)
 
-element0 = fe.element.Hex0()
-element1 = fe.element.Hex1()
-quadrature = fe.quadrature.Linear(dim=3)
+element0 = fe.element.ConstantHexahedron()
+element1 = fe.element.Hexahedron()
+quadrature = fe.quadrature.GaussLegendre(order=1, dim=3)
 
 region0 = fe.Region(mesh0, element0, quadrature)
 region  = fe.Region(mesh,  element1, quadrature)

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -212,7 +212,7 @@ For axisymmetric analyses an axisymmetric vector-valued field has to be created 
 import felupe as fe
 
 mesh = fe.mesh.Rectangle(n=3)
-element = fe.element.Quad1()
+element = fe.element.Quad()
 quadrature = fe.quadrature.GaussLegendre(order=1, dim=2)
 
 region  = fe.Region(mesh, element, quadrature)
@@ -291,11 +291,11 @@ $$ \bm{H}_{2D}(r,s) = \bm{h}(r) \otimes \bm{h}(s)$$
 
 $$ \bm{H}_{3D}(r,s,t) = \bm{h}(r) \otimes \bm{h}(s) \otimes \bm{h}(t)$$
 
-### Node numbering
-A linear hexahedron has nodes arranged in a way that the connectivity starts at `[-1,-1,-1]` where nodes are connected counterclockwise at`z=-1` in a first step. Finally the same applies for `z=1`. For arbitrary order elements the first axis goes from `-1` to `1`, then the second axis  from `-1` to `1` and finally the third axis  from `-1` to `1`.
+### Point numbering
+A linear hexahedron has points arranged in a way that the connectivity starts at `[-1,-1,-1]` where nodes are connected counterclockwise at`z=-1` in a first step. Finally the same applies for `z=1`. For arbitrary order elements the first axis goes from `-1` to `1`, then the second axis  from `-1` to `1` and finally the third axis  from `-1` to `1`. This is due to VTK compatibility.
 
 ```python
-# Linear hexahedron with eight nodes
+# Linear hexahedron with eight points
 
 nodes = np.array([
     [-1,-1,-1], #0

--- a/docs/mesh.md
+++ b/docs/mesh.md
@@ -1,34 +1,34 @@
 # Simple mesh module of FElupe
 
-FElupe provides a simple mesh generation module `felupe.mesh`. A Mesh instance contains essentially two arrays: one with nodes (points) and another one containing the element connectivities (cells). Only a single cell type is supported per mesh. Optionally the element type is specified which is used if the mesh is saved as VTK or XDMF file. These element types are identical to cell types used in `meshio`: `line`, `quad` and `hexahedron` for linear elements or `VTK_LAGRANGE_HEXAHEDRON` for elements with arbitrary order.
+FElupe provides a simple mesh generation module `felupe.mesh`. A Mesh instance contains essentially two arrays: one with **points** (*nodes*) and another one containing the cell connectivities, called **cells**. Only a single cell type is supported per mesh. Optionally the element type is specified which is used if the mesh is saved as VTK or XDMF file. These element types are identical to cell types used in `meshio`: `line`, `quad` and `hexahedron` for linear elements or `VTK_LAGRANGE_HEXAHEDRON` for elements with arbitrary order.
 
 ```python
 import numpy as np
 import felupe as fe
 
-nodes = np.array([
-    [ 0, 0], # node 1
-    [ 1, 0], # node 2
-    [ 0, 1], # node 3
-    [ 1, 1], # node 4
+points = np.array([
+    [ 0, 0], # point 1
+    [ 1, 0], # point 2
+    [ 0, 1], # point 3
+    [ 1, 1], # point 4
 ])
 
-connectivity = np.array([
-    [ 0, 1, 3, 2], # connectivity of first element
+cells = np.array([
+    [ 0, 1, 3, 2], # connectivity of first cell
 ])
 
-m = fe.mesh.Mesh(nodes, connectivity, etype="quad")
+m = fe.mesh.Mesh(points, cells, cell_type="quad")
 ```
 
 ## Generate a cube by hand
-First we start with the generation of a line from `1` to `3` with `n=2` nodes. Next, we expand the line to a rectangle. The `z` argument in expand represents the total expansion. Again, an expansion of our rectangle leads to a hexahedron. Several other useful tools are available beside `expand`: `rotate`, `revolve` and `sweep`. With these simple tools at hand, i.e. rectangles, cubes or cylinders may be constructed.
+First we start with the generation of a line from `1` to `3` with `n=2` points. Next, we expand the line to a rectangle. The `z` argument in expand represents the total expansion. Again, an expansion of our rectangle leads to a hexahedron. Several other useful tools are available beside `expand`: `rotate`, `revolve` and `sweep`. With these simple tools at hand, i.e. rectangles, cubes or cylinders may be constructed.
 
 ```python
 line = fe.mesh.line_line(a=1, b=3, n=2)
 rect = fe.mesh.expand(line, n=2, z=5)
 hexa = fe.mesh.expand(rect, n=2, z=3)
 
-m = fe.mesh.Mesh(*hexa, etype="hexahedron")
+m = fe.mesh.Mesh(*hexa, cell_type="hexahedron")
 ```
 
 ## Generate lines, rectangles and cubes

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -8,8 +8,8 @@ Start setting up a problem in FElupe by the creation of a numeric **Region** wit
 import felupe as fe
 
 mesh = fe.mesh.Cube(n=9)
-element = fe.element.Hex1()
-quadrature = fe.quadrature.Linear(dim=3)
+element = fe.element.Hexahedron()
+quadrature = fe.quadrature.GaussLegendre(order=1, dim=3)
 ```
 
 ## Region

--- a/felupe/element.py
+++ b/felupe/element.py
@@ -95,32 +95,32 @@ class ArbitraryOrderLagrange:
         return r ** m / factorial(m)
 
 
-class Line:
+class LineElement:
     def __init__(self):
         self.ndim = 1
 
 
-class Quad:
+class QuadElement:
     def __init__(self):
         self.ndim = 2
 
 
-class Hex:
+class HexahedronElement:
     def __init__(self):
         self.ndim = 3
 
 
-class Tri:
+class TriangleElement:
     def __init__(self):
         self.ndim = 2
 
 
-class Tet:
+class TetraElement:
     def __init__(self):
         self.ndim = 3
 
 
-class Line1(Line):
+class Line(LineElement):
     def __init__(self):
         super().__init__()
         self.npoints = 2
@@ -137,7 +137,7 @@ class Line1(Line):
         return np.array([[-1], [1]]) * 0.5
 
 
-class Quad0(Quad):
+class ConstantQuad(QuadElement):
     def __init__(self):
         super().__init__()
         self.npoints = 4
@@ -152,7 +152,7 @@ class Quad0(Quad):
         return np.array([[0, 0, 0]])
 
 
-class Quad1(Quad):
+class Quad(QuadElement):
     def __init__(self):
         super().__init__()
         self.npoints = 4
@@ -189,7 +189,7 @@ class Quad1(Quad):
         )
 
 
-class Hex0(Hex):
+class ConstantHexahedron(HexahedronElement):
     def __init__(self):
         super().__init__()
         self.npoints = 8
@@ -204,7 +204,7 @@ class Hex0(Hex):
         return np.array([[0, 0, 0]])
 
 
-class Hex1(Hex):
+class Hexahedron(HexahedronElement):
     def __init__(self):
         super().__init__()
         self.npoints = 8
@@ -249,7 +249,7 @@ class Hex1(Hex):
         )
 
 
-class Hex2s(Hex):
+class QuadraticHexahedron(HexahedronElement):
     def __init__(self):
         super().__init__()
         self.npoints = 20
@@ -424,7 +424,52 @@ class Hex2s(Hex):
         )
 
 
-class Tri1(Tri):
+class TriQuadraticHexahedron(Hexahedron):
+    def __init__(self):
+        super().__init__()
+        self.npoints = 27
+        self.nbasis = 27
+        self.lagrange = ArbitraryOrderLagrange(order=2, ndim=3)
+        self.permute = np.array(
+            [
+                0,
+                2,
+                8,
+                6,
+                18,
+                20,
+                26,
+                24,  # vertices
+                1,
+                5,
+                7,
+                3,
+                19,
+                23,
+                25,
+                21,
+                9,
+                11,
+                17,
+                15,  # edges
+                12,
+                14,
+                10,
+                16,
+                4,
+                22,  # faces
+                13,  # volume
+            ]
+        )
+
+    def basis(self, rst):
+        return self.lagrange.basis(rst)[self.permute]
+
+    def basisprime(self, rst):
+        return self.lagrange.basisprime(rst)[self.permute, :]
+
+
+class Triangle(TriangleElement):
     def __init__(self):
         super().__init__()
         self.npoints = 3
@@ -441,7 +486,7 @@ class Tri1(Tri):
         return np.array([[-1, -1], [1, 0], [0, 1]], dtype=float)
 
 
-class Tet1(Tet):
+class Tetra(TetraElement):
     def __init__(self):
         super().__init__()
         self.npoints = 4
@@ -458,7 +503,7 @@ class Tet1(Tet):
         return np.array([[-1, -1, -1], [1, 0, 0], [0, 1, 0], [0, 0, 1]], dtype=float)
 
 
-class Tri2(Tri):
+class QuadraticTriangle(TriangleElement):
     def __init__(self):
         super().__init__()
         self.npoints = 6
@@ -493,7 +538,7 @@ class Tri2(Tri):
         return dhdr
 
 
-class Tet2(Tet):
+class QuadraticTetra(TetraElement):
     def __init__(self):
         super().__init__()
         self.npoints = 10

--- a/felupe/mesh.py
+++ b/felupe/mesh.py
@@ -647,54 +647,38 @@ def collect_faces(points, cells, cell_type):
     if cell_type not in supported_cell_types:
         raise TypeError("Cell type not implemented.")
 
-    number_of_faces = {"triangle": 1, "tetra": 4, "quad": 1, "hexahedron": 6}
-
-    if cell_type == "triangle":
+    if "triangle" in cell_type:
         # k-th face is (i[k], j[k], k[k])
-        i = [
-            0,
-        ][: number_of_faces[cell_type]]
-        j = [
-            1,
-        ][: number_of_faces[cell_type]]
-        k = [
-            2,
-        ][: number_of_faces[cell_type]]
+        i = [0, ]
+        j = [1, ]
+        k = [2, ]
 
         faces_to_stack = cells[:, i], cells[:, j], cells[:, k]
 
-    if cell_type == "tetra":
+    if "tetra" in cell_type:
         # k-th face is (i[k], j[k], k[k])
         # ordering?
-        i = [0, 0, 0, 1][: number_of_faces[cell_type]]
-        j = [1, 1, 2, 2][: number_of_faces[cell_type]]
-        k = [2, 3, 3, 3][: number_of_faces[cell_type]]
+        i = [0, 0, 0, 1]
+        j = [1, 1, 2, 2]
+        k = [2, 3, 3, 3]
 
         faces_to_stack = cells[:, i], cells[:, j], cells[:, k]
 
-    elif cell_type == "quad":
+    elif "quad" in cell_type:
         # k-th edge is (i[k], j[k], k[k], l[k])
-        i = [
-            0,
-        ][: number_of_faces[cell_type]]
-        j = [
-            1,
-        ][: number_of_faces[cell_type]]
-        k = [
-            2,
-        ][: number_of_faces[cell_type]]
-        l = [
-            3,
-        ][: number_of_faces[cell_type]]
+        i = [0, ]
+        j = [1, ]
+        k = [2, ]
+        l = [3, ]
 
         faces_to_stack = cells[:, i], cells[:, j], cells[:, k], cells[:, l]
 
     elif cell_type == "hexahedron":
-        # k-th edge is (i[k], j[k])
-        i = [0, 1, 1, 2, 0, 4][: number_of_faces[cell_type]]
-        j = [3, 2, 0, 3, 1, 5][: number_of_faces[cell_type]]
-        k = [7, 6, 4, 7, 2, 6][: number_of_faces[cell_type]]
-        l = [4, 5, 5, 4, 3, 7][: number_of_faces[cell_type]]
+        # k-th edge is (i[k], j[k], k[k], l[k])
+        i = [0, 1, 1, 2, 0, 4]
+        j = [3, 2, 0, 3, 1, 5]
+        k = [7, 6, 4, 7, 2, 6]
+        l = [4, 5, 5, 4, 3, 7]
 
         faces_to_stack = cells[:, i], cells[:, j], cells[:, k], cells[:, l]
 

--- a/felupe/mesh.py
+++ b/felupe/mesh.py
@@ -562,19 +562,32 @@ def sweep(mesh, decimals=None):
         return points_new, cells_new
 
 
-def convert(mesh, order=0, calc_points=False):
+def convert(mesh, order=0, calc_points=False, calc_midfaces=False, calc_midvolumes=False):
     "Convert mesh to a given order (currently only order=0 supported)."
 
-    if order != 0:
+    if order == 0:
+        
+        if calc_points:
+            points = np.stack([np.mean(mesh.points[cell], axis=0) for cell in mesh.cells])
+        else:
+            points = np.zeros((mesh.ncells, mesh.ndim), dtype=int)
+        
+        cells = np.arange(mesh.ncells).reshape(-1, 1)
+        cell_type = mesh.cell_type
+            
+    elif order == 2:
+        
+        points, cells, cell_type = add_midpoints_edges(mesh.points, mesh.cells, mesh.cell_type)
+        
+        if calc_midfaces:
+            points, cells, cell_type = add_midpoints_faces(mesh.points, mesh.cells, mesh.cell_type)
+        
+        if calc_midvolumes:
+            points, cells, cell_type = add_midpoints_volumes(mesh.points, mesh.cells, mesh.cell_type)
+        
+    else:
         raise NotImplementedError("Unsupported order conversion.")
 
-    if calc_points:
-        points = np.stack([np.mean(mesh.points[cell], axis=0) for cell in mesh.cells])
-    else:
-        points = np.zeros((mesh.ncells, mesh.ndim), dtype=int)
-
-    cells = np.arange(mesh.ncells).reshape(-1, 1)
-    cell_type = "None"
     return Mesh(points, cells, cell_type)
 
 

--- a/felupe/utils.py
+++ b/felupe/utils.py
@@ -40,7 +40,6 @@ from .math import identity, grad, dot, transpose, eigvals, det, interpolate, nor
 from .field import Field
 
 from .mesh import revolve
-from .element import Quad1, Hex1
 from .region import Region
 from .quadrature import GaussLegendre
 

--- a/scripts/script_performance_neohooke.py
+++ b/scripts/script_performance_neohooke.py
@@ -13,13 +13,13 @@ from timeit import timeit
 n = 2
 
 m = mesh  = fe.mesh.Cube(n=n)
-e = fe.element.Hex1()
-q = fe.quadrature.Linear(3)
+e = fe.element.Hexahedron()
+q = fe.quadrature.GaussLegendre(order=1, dim=3)
 
 def pre(n):
     m = fe.mesh.Cube(n=n)
-    e = fe.element.Hex1()
-    q = fe.quadrature.Linear(3)
+    e = fe.element.Hexahedron()
+    q = fe.quadrature.GaussLegendre(order=1, dim=3)
     return m, e, q
 
 print('|   DOF   | Assembly | Linear solve |')

--- a/scripts/script_performance_poisson.py
+++ b/scripts/script_performance_poisson.py
@@ -13,12 +13,12 @@ from timeit import timeit
 n = 151
 
 m = fe.mesh.Rectangle(n=n)
-e = fe.element.Quad1()
+e = fe.element.Quad()
 q = fe.quadrature.GaussLegendre(order=1, dim=2)
 
 def pre(n):
     m = fe.mesh.Rectangle(n=n)
-    e = fe.element.Quad1()
+    e = fe.element.Quad()
     q = fe.quadrature.GaussLegendre(order=1, dim=2)
     return m, e, q
 

--- a/scripts/script_readme.py
+++ b/scripts/script_readme.py
@@ -9,8 +9,8 @@ import numpy as np
 import felupe as fe
 
 mesh = fe.mesh.Cube(n=9)
-element = fe.element.Hex1()
-quadrature = fe.quadrature.Linear(dim=3)
+element = fe.element.Hexahedron()
+quadrature = fe.quadrature.GaussLegendre(order=1, dim=3)
 
 region = fe.Region(mesh, element, quadrature)
 


### PR DESCRIPTION
* **IMPORTANT** includes new element class namings; fixes #40 - docs and scripts also updated.

* hexahedrons can be converted to hexahedron20 or hexahedron27, and so on... e.g. `fe.mesh.convert(mesh, oder=2, calc_midfaces=True, calc_midvolumes=True`) converts a `hexahedron` mesh to a `hexahedron27` mesh.