### PR TITLE
Add MINI element

### DIFF
--- a/felupe/element.py
+++ b/felupe/element.py
@@ -486,6 +486,26 @@ class Triangle(TriangleElement):
         return np.array([[-1, -1], [1, 0], [0, 1]], dtype=float)
 
 
+class TriangleMINI(TriangleElement):
+    def __init__(self):
+        super().__init__()
+        self.npoints = 4
+        self.nbasis = 3
+
+    def basis(self, rs):
+        "linear triangle basis functions"
+        r, s = rs
+        return np.array([1 - r - s, r, s, 27 * r * s * (1 - r - s)])
+
+    def basisprime(self, rs):
+        "linear triangle derivative of basis functions"
+        r, s = rs
+        return np.array([[-1, -1], 
+                         [ 1,  0], 
+                         [ 0,  1], 
+                         [27 * (s * (1 - r - s) - r * s),
+                          27 * (r * (1 - r - s) - r * s)]], dtype=float)
+
 class Tetra(TetraElement):
     def __init__(self):
         super().__init__()
@@ -501,6 +521,26 @@ class Tetra(TetraElement):
         "linear tetrahedral derivative of basis functions"
         r, s, t = rst
         return np.array([[-1, -1, -1], [1, 0, 0], [0, 1, 0], [0, 0, 1]], dtype=float)
+
+
+class TetraMINI(TetraElement):
+    def __init__(self):
+        super().__init__()
+        self.npoints = 5
+        self.nbasis = 4
+
+    def basis(self, rst):
+        "linear tetrahedral basis functions"
+        r, s, t = rst
+        return np.array([1 - r - s - t, r, s, t, 256 * r * s * t * (1 - r - s -t)])
+
+    def basisprime(self, rst):
+        "linear tetrahedral derivative of basis functions"
+        r, s, t = rst
+        return np.array([[-1, -1, -1], [1, 0, 0], [0, 1, 0], [0, 0, 1],
+                         [256 * (s * t * (1 - r - s - t) - r * s * t),
+                          256 * (r * t * (1 - r - s - t) - r * s * t),
+                          256 * (r * s * (1 - r - s - t) - r * s * t)]], dtype=float)
 
 
 class QuadraticTriangle(TriangleElement):

--- a/felupe/element.py
+++ b/felupe/element.py
@@ -34,11 +34,12 @@ from copy import deepcopy as copy
 class ArbitraryOrderLagrange:
     "Lagrange quad/hexahdron finite element of arbitrary order."
 
-    def __init__(self, order, ndim):
+    def __init__(self, order, ndim, interval=(-1, 1)):
         self.ndim = ndim
         self.order = order
         self.npoints = (order + 1) ** ndim
         self.nbasis = self.npoints
+        self.interval = interval
 
         self._nbasis = order + 1
 
@@ -87,7 +88,8 @@ class ArbitraryOrderLagrange:
     def _points(self, n):
         "Equidistant n points in interval [-1, 1]."
         i = np.arange(n)
-        return 2 * i / (n - 1) - 1
+        #return 2 * i / (n - 1) - 1
+        return np.linspace(*self.interval, n)
 
     def _polynomial(self, r, n):
         "Lagrange-Polynomial of order n evaluated at coordinate r."
@@ -430,37 +432,12 @@ class TriQuadraticHexahedron(Hexahedron):
         self.npoints = 27
         self.nbasis = 27
         self.lagrange = ArbitraryOrderLagrange(order=2, ndim=3)
-        self.permute = np.array(
-            [
-                0,
-                2,
-                8,
-                6,
-                18,
-                20,
-                26,
-                24,  # vertices
-                1,
-                5,
-                7,
-                3,
-                19,
-                23,
-                25,
-                21,
-                9,
-                11,
-                17,
-                15,  # edges
-                12,
-                14,
-                10,
-                16,
-                4,
-                22,  # faces
-                13,  # volume
-            ]
-        )
+        self.vertices = np.array([0, 2, 8, 6, 18, 20, 26, 24])
+        self.edges = np.array([1, 5, 7, 3, 19, 23, 25, 21, 9, 11, 17, 15])
+        self.faces = np.array([12, 14, 10, 16, 4, 22])
+        self.volume = np.array([13])
+        self.permute = np.concatenate((self.vertices, self.edges,
+                                       self.faces, self.volume))
 
     def basis(self, rst):
         return self.lagrange.basis(rst)[self.permute]

--- a/felupe/quadrature.py
+++ b/felupe/quadrature.py
@@ -103,6 +103,15 @@ class QuadraticTetrahedron(Scheme):
         super().__init__(points.T, scheme.weights / 6)
 
 
+class CubicTetrahedron(Scheme):
+    def __init__(self):
+        scheme = quadpy.t3.schemes["hammer_marlowe_stroud_2"]()
+        tetra = np.array([[0, 0, 0], [1, 0, 0], [0, 1, 0], [0, 0, 1]])
+
+        points = np.dot(tetra.T, scheme.points)
+        super().__init__(points.T, scheme.weights / 6)
+
+
 class QuadPyScheme(Scheme):
     def __init__(self, scheme):
         super().__init__(scheme.points.T, scheme.weights)


### PR DESCRIPTION
initial support with

```python
import numpy as np
import felupe as fe
import felupe.math as fm

import meshzoo

points, cells = fe.mesh.fix(*meshzoo.cube_tetra((0,0,0), (1,1,1), 7), "tetra")
points_mini = np.zeros((len(cells), points.shape[1]))
cells_mini = np.arange(len(cells)).reshape(-1,1) + len(points)

points_ = np.vstack((points, points_mini))
cells_ = np.hstack((cells, cells_mini))

mesh0 = fe.mesh.Mesh(points, cells, cell_type="tetra")
mesh = fe.mesh.Mesh(points_, cells_, cell_type="tetra")

element0 = fe.element.Tetra()
element = fe.element.TetraMINI()
quadrature = fe.quadrature.CubicTetrahedron()

region0 = fe.Region(mesh0, element0, quadrature)
region = fe.Region(mesh, element, quadrature)
```