### PR TITLE
rename mesh.as_discontinous() to mesh.disconnect()

### DIFF
--- a/felupe/mesh/_mesh.py
+++ b/felupe/mesh/_mesh.py
@@ -61,7 +61,7 @@ class Mesh:
             self.points_without_cells = np.array([], dtype=int)
             self.points_with_cells = np.arange(self.npoints)
 
-    def as_discontinous(self):
+    def disconnect(self):
         "Return a new instance of a Mesh with disconnected cells."
 
         points = self.points[self.cells].reshape(-1, self.dim)

--- a/felupe/tools/_project.py
+++ b/felupe/tools/_project.py
@@ -91,7 +91,7 @@ def project(values, region, average=True):
     u = values.T.reshape(-1, dim)
 
     # disconnected mesh
-    m = region.mesh.as_discontinous()
+    m = region.mesh.disconnect()
 
     # region on disconnected mesh with inverse quadrature scheme
     r = Region(m, region.element, region.quadrature.inv(), grad=False)

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -90,7 +90,7 @@ def test_meshes():
     assert m.points.shape == (26, 2)
     assert m.cells.shape == (16, 4)
 
-    m_dg = m.as_discontinous()
+    m_dg = m.disconnect()
     assert m_dg.dim == m.dim
     assert m_dg.npoints == m.cells.size
 


### PR DESCRIPTION
Wasn't merged in v.1.3.0. 

fixes #118