### PR TITLE
`newtonrhapson`: add kwargs of `field.extract()` for default `fun` and `jac`

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ All notable changes to this project will be documented in this file. The format 
 
 ## [Unreleased]
 
+### Added
+- Add kwargs of `field.extract()` to `fun` and `jac` of `newtonrhapson`.
+
 ### Changed
 - Set default number of `threads` in `MatadiMaterial` to `multiprocessing.cpu_count()`.
 

--- a/felupe/tools/_newton.py
+++ b/felupe/tools/_newton.py
@@ -182,6 +182,7 @@ def newtonrhapson(
     f = fun(x, *args, **kwargs)
 
     if verbose:
+        print()
         print("Newton-Rhapson solver")
         print("=====================")
         print()
@@ -219,14 +220,14 @@ def newtonrhapson(
 
         if success:
             if not timing:
-                print("\nSolution converged in %d iterations." % (iteration + 1))
+                print("\nSolution converged in %d iterations.\n" % (iteration + 1))
             break
 
         if np.isnan(norm):
             raise ValueError("Norm of unknowns is NaN.")
 
     if 1 + iteration == maxiter and not success:
-        raise ValueError("Maximum number of iterations reached (not converged).")
+        raise ValueError("Maximum number of iterations reached (not converged).\n")
 
     Res = Result(x=x, fun=f, success=success, iterations=1 + iteration)
 
@@ -236,7 +237,7 @@ def newtonrhapson(
     if timing:
         time_finish = perf_counter()
         print(
-            "\nSolution converged in %d iterations within %1.4g seconds."
+            "\nSolution converged in %d iterations within %1.4g seconds.\n"
             % (iteration + 1, time_finish - time_start)
         )
 

--- a/felupe/tools/_newton.py
+++ b/felupe/tools/_newton.py
@@ -46,13 +46,15 @@ class Result:
         self.iterations = iterations
 
 
-def fun(x, umat, parallel=False):
+def fun(x, umat, parallel=False, grad=True, add_identity=True, sym=False):
     "Force residuals from assembly of equilibrium (weak form)."
 
     if "mixed" in str(type(x)):
 
         L = IntegralFormMixed(
-            fun=umat.gradient(*x.extract()),
+            fun=umat.gradient(
+                *x.extract(grad=grad, add_identity=add_identity, sym=sym)
+            ),
             v=x,
             dV=x[0].region.dV,
         )
@@ -60,19 +62,22 @@ def fun(x, umat, parallel=False):
     else:
 
         L = IntegralForm(
-            fun=umat.gradient(x.extract()), v=x, dV=x.region.dV, grad_v=True
+            fun=umat.gradient(x.extract(grad=grad, add_identity=add_identity, sym=sym)),
+            v=x,
+            dV=x.region.dV,
+            grad_v=True,
         )
 
     return L.assemble(parallel=parallel).toarray()[:, 0]
 
 
-def jac(x, umat, parallel=False):
+def jac(x, umat, parallel=False, grad=True, add_identity=True, sym=False):
     "Tangent stiffness matrix from assembly of linearized equilibrium."
 
     if "mixed" in str(type(x)):
 
         a = IntegralFormMixed(
-            fun=umat.hessian(*x.extract()),
+            fun=umat.hessian(*x.extract(grad=grad, add_identity=add_identity, sym=sym)),
             v=x,
             dV=x[0].region.dV,
             u=x,
@@ -81,7 +86,7 @@ def jac(x, umat, parallel=False):
     else:
 
         a = IntegralForm(
-            fun=umat.hessian(x.extract()),
+            fun=umat.hessian(x.extract(grad=grad, add_identity=add_identity, sym=sym)),
             v=x,
             dV=x.region.dV,
             u=x,

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -179,7 +179,7 @@ def test_newton_simple():
 def test_newton():
 
     # create a hexahedron-region on a cube
-    region = fe.RegionHexahedron(fe.Cube(n=3))
+    region = fe.RegionHexahedron(fe.Cube(n=6))
 
     # add a displacement field and apply a uniaxial elongation on the cube
     displacement = fe.Field(region, dim=3)
@@ -197,13 +197,39 @@ def test_newton():
         ext0=ext0,
         timing=True,
         verbose=True,
+        kwargs={"parallel": True},
+    )
+
+
+def test_newton_linearelastic():
+
+    # create a hexahedron-region on a cube
+    region = fe.RegionHexahedron(fe.Cube(n=6))
+
+    # add a displacement field and apply a uniaxial elongation on the cube
+    displacement = fe.Field(region, dim=3)
+    boundaries, dof0, dof1, ext0 = fe.dof.uniaxial(displacement, move=0.2, clamped=True)
+
+    # define the constitutive material behavior
+    umat = fe.LinearElastic(E=1.0, nu=0.3)
+
+    # newton-rhapson procedure
+    res = fe.newtonrhapson(
+        displacement,
+        umat=umat,
+        dof1=dof1,
+        dof0=dof0,
+        ext0=ext0,
+        timing=True,
+        verbose=True,
+        kwargs={"grad": True, "sym": True, "add_identity": False},
     )
 
 
 def test_newton_mixed():
 
     # create a hexahedron-region on a cube
-    mesh = fe.Cube(n=3)
+    mesh = fe.Cube(n=6)
     region = fe.RegionHexahedron(mesh)
     region0 = fe.RegionConstantHexahedron(fe.mesh.convert(mesh, 0))
 
@@ -236,3 +262,4 @@ if __name__ == "__main__":
     test_newton_simple()
     test_newton()
     test_newton_mixed()
+    test_newton_linearelastic()


### PR DESCRIPTION
fixes #138 in order to use a linear elastic material in combination with `newtonrhapson`.