### PR TITLE
Add a region on the boundary faces/edges on a mesh

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ All notable changes to this project will be documented in this file. The format 
 
 
 # License
-FElupe - finite element analysis (C) 2021 Andreas Dutzler, Graz (Austria).
+FElupe - finite element analysis (C) 2022 Andreas Dutzler, Graz (Austria).
 
 This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
 

--- a/docs/felupe/global/quadrature.rst
+++ b/docs/felupe/global/quadrature.rst
@@ -6,6 +6,11 @@ Quadrature
    :undoc-members:
    :show-inheritance:
 
+.. autoclass:: felupe.GaussLegendreBoundary
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 .. autoclass:: felupe.TriangleQuadrature
    :members:
    :undoc-members:

--- a/docs/felupe/global/region.rst
+++ b/docs/felupe/global/region.rst
@@ -6,12 +6,27 @@ Region
    :undoc-members:
    :inherited-members:
    
+.. .. autoclass:: felupe.RegionBoundary
+   :members:
+   :undoc-members:
+   :inherited-members:
+   
 .. autoclass:: felupe.RegionQuad
    :members:
    :undoc-members:
    :show-inheritance:
+   
+.. autoclass:: felupe.RegionQuadBoundary
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
-.. autoclass:: felupe.RegionHexahedron
+.. autoclass:: felupe.RegionHexahedronBoundary
+   :members:
+   :undoc-members:
+   :show-inheritance:
+   
+   .. autoclass:: felupe.RegionHexahedron
    :members:
    :undoc-members:
    :show-inheritance:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -86,7 +86,7 @@ Install Python, fire up a terminal and run ``pip install felupe[all]``, where ``
 License
 -------
 
-FElupe - finite element analysis (C) 2021 Andreas Dutzler, Graz (Austria).
+FElupe - finite element analysis (C) 2022 Andreas Dutzler, Graz (Austria).
 
 This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
 

--- a/felupe/__init__.py
+++ b/felupe/__init__.py
@@ -11,8 +11,11 @@ from . import region
 
 from .region import (
     Region,
+    RegionBoundary,
     RegionQuad,
     RegionHexahedron,
+    RegionQuadBoundary,
+    RegionHexahedronBoundary,
     RegionConstantQuad,
     RegionConstantHexahedron,
     RegionQuadraticHexahedron,
@@ -76,6 +79,7 @@ from .element import (
 )
 from .quadrature import (
     GaussLegendre,
+    GaussLegendreBoundary,
     Triangle as TriangleQuadrature,
     Tetrahedron as TetrahedronQuadrature,
 )

--- a/felupe/_assembly/_base.py
+++ b/felupe/_assembly/_base.py
@@ -162,7 +162,7 @@ class IntegralForm:
         v, u = self.v, self.u
         dV = self.dV
         fun = self.fun
-        
+
         if parallel:
             einsum = einsumt
         else:
@@ -195,17 +195,15 @@ class IntegralForm:
         else:
 
             if not grad_v and not grad_u:
-                out = einsum(
-                    "ape,...pe,bpe,pe->a...be", vb, fun, ub, dV, optimize=True
-                )
+                out = einsum("ape,...pe,bpe,pe->a...be", vb, fun, ub, dV, optimize=True)
                 if len(out.shape) == 5:
                     return einsum("aijbe->aibje", out)
                 else:
                     return out
             elif grad_v and not grad_u:
                 return einsum(
-                        "aJpe,iJ...pe,bpe,pe->aib...e", vb, fun, ub, dV, optimize=True
-                    )
+                    "aJpe,iJ...pe,bpe,pe->aib...e", vb, fun, ub, dV, optimize=True
+                )
             elif not grad_v and grad_u:
                 return einsum(
                     "a...pe,...kLpe,bLpe,pe->a...bke",

--- a/felupe/quadrature/__init__.py
+++ b/felupe/quadrature/__init__.py
@@ -1,4 +1,7 @@
 from ._base import Scheme
 from ._triangle import Triangle
 from ._tetra import Tetrahedron
-from ._gausslegendre import GaussLegendre
+from ._gausslegendre import (
+    GaussLegendre,
+    GaussLegendreBoundary,
+)

--- a/felupe/quadrature/_gausslegendre.py
+++ b/felupe/quadrature/_gausslegendre.py
@@ -138,6 +138,9 @@ class GaussLegendreBoundary(GaussLegendre):
                 np.hstack((p, np.ones((len(p), 1)))),
             ]
 
+        else:
+            raise ValueError("Wrong dimension.")
+
         # stack quadrature points
         self.points = np.vstack(points_list)
         self.nfaces = len(points_list)

--- a/felupe/quadrature/_gausslegendre.py
+++ b/felupe/quadrature/_gausslegendre.py
@@ -85,3 +85,68 @@ class GaussLegendre(Scheme):
         points[self.points != 0] = 1 / points[self.points != 0]
 
         return Scheme(points, self.weights)
+
+
+class GaussLegendreBoundary(GaussLegendre):
+    "A n-dimensional Gauss-Legendre quadrature rule on boundaries."
+
+    def __init__(self, order: int, dim: int, permute: bool = True):
+        """Arbitrary `order` Gauss-Legendre quadrature rule of `dim` 1, 2 or 3
+        on the interval [-1, 1] as approximation of
+
+            ∫ f(x) dx ≈ ∑ f(x_a) w_a                                    (1)
+
+        with `a` quadrature points `x_a` and corresponding weights `w_a`.
+
+        """
+
+        super().__init__(order=order, dim=dim - 1, permute=permute)
+        p = self.points
+
+        # reset dimension
+        self.dim = dim
+
+        if self.dim == 2:
+            # quadrature points projected onto four edges of a quad
+            points_list = [
+                np.hstack((-np.ones((len(p), 1)), p)),
+                np.hstack((np.ones((len(p), 1)), p)),
+                np.hstack((p, -np.ones((len(p), 1)))),
+                np.hstack((p, np.ones((len(p), 1)))),
+            ]
+
+        elif self.dim == 3:
+            # quadrature points projected onto six faces of a hexahedron
+            points_list = [
+                np.hstack((-np.ones((len(p), 1)), p)),
+                np.hstack((np.ones((len(p), 1)), p)),
+                np.hstack(
+                    (
+                        p[:, 0].reshape(-1, 1),
+                        -np.ones((len(p), 1)),
+                        p[:, 1].reshape(-1, 1),
+                    )
+                ),
+                np.hstack(
+                    (
+                        p[:, 0].reshape(-1, 1),
+                        np.ones((len(p), 1)),
+                        p[:, 1].reshape(-1, 1),
+                    )
+                ),
+                np.hstack((p, -np.ones((len(p), 1)))),
+                np.hstack((p, np.ones((len(p), 1)))),
+            ]
+
+        # stack quadrature points
+        self.points = np.vstack(points_list)
+        self.nfaces = len(points_list)
+
+        # adopt weights
+        self.weights = np.tile(
+            self.weights,
+            self.nfaces,
+        )
+
+        # update properties
+        self.npoints = len(self.points)

--- a/felupe/region/__init__.py
+++ b/felupe/region/__init__.py
@@ -1,7 +1,10 @@
 from ._region import Region
+from ._boundary import RegionBoundary
 from ._templates import (
     RegionQuad,
     RegionHexahedron,
+    RegionQuadBoundary,
+    RegionHexahedronBoundary,
     RegionConstantQuad,
     RegionConstantHexahedron,
     RegionQuadraticHexahedron,

--- a/felupe/region/_boundary.py
+++ b/felupe/region/_boundary.py
@@ -1,0 +1,264 @@
+# -*- coding: utf-8 -*-
+"""
+ _______  _______  ___      __   __  _______  _______ 
+|       ||       ||   |    |  | |  ||       ||       |
+|    ___||    ___||   |    |  | |  ||    _  ||    ___|
+|   |___ |   |___ |   |    |  |_|  ||   |_| ||   |___ 
+|    ___||    ___||   |___ |       ||    ___||    ___|
+|   |    |   |___ |       ||       ||   |    |   |___ 
+|___|    |_______||_______||_______||___|    |_______|
+
+This file is part of felupe.
+
+Felupe is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Felupe is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Felupe.  If not, see <http://www.gnu.org/licenses/>.
+
+"""
+
+import numpy as np
+
+from ..math import cross
+from ._region import Region
+
+
+class RegionBoundary(Region):
+    r"""
+    A numeric boundary-region as a combination of a mesh, an element and a
+    numeric integration scheme (quadrature). The gradients of the element shape
+    functions are evaluated at all integration points of each cell in the region
+    if the optional gradient argument is True.
+
+    .. math::
+
+       \frac{\partial X^I}{\partial r^J} &= X_a^I \frac{\partial h_a}{\partial r^J}
+
+       \frac{\partial h_a}{\partial X^J} &= \frac{\partial h_a}{\partial r^I} \frac{\partial r^I}{\partial X^J}
+
+       dV &= \det\left(\frac{\partial X^I}{\partial r^J}\right) w
+
+
+    Parameters
+    ----------
+    mesh : Mesh
+        A mesh with points and cells.
+    element : Element
+        The finite element formulation to be applied on the cells.
+    quadrature: Quadrature
+        An element-compatible numeric integration scheme with points and weights.
+    grad : bool, optional
+        A flag to invoke gradient evaluation (default is True).
+    only_surface: bool, optional
+        A flag to use only the enclosing outline of the region (default is True).
+    mask: ndarray or None, optional
+        A boolean array to select a specific set of points (default is None).
+
+    Attributes
+    ----------
+    mesh : Mesh
+        A mesh with points and cells.
+    element : Finite element
+        The finite element formulation to be applied on the cells.
+    quadrature: Quadrature scheme
+        An element-compatible numeric integration scheme with points and weights.
+    h : ndarray
+        Element shape function array ``h_ap`` of shape function ``a`` evaluated at quadrature point ``p``.
+    dhdr : ndarray
+        Partial derivative of element shape function array ``dhdr_aJp`` with shape function ``a`` w.r.t. natural element coordinate ``J`` evaluated at quadrature point ``p`` for every cell ``c`` (geometric gradient or **Jacobian** transformation between ``X`` and ``r``).
+    dXdr : ndarray
+        Geometric gradient ``dXdr_IJpc`` as partial derivative of undeformed coordinate ``I`` w.r.t. natural element coordinate ``J`` evaluated at quadrature point ``p`` for every cell ``c`` (geometric gradient or **Jacobian** transformation between ``X`` and ``r``).
+    drdX : ndarray
+        Inverse of dXdr.
+    dA : ndarray
+        Numeric *Differential area vectors*.
+    normals : ndarray
+        Area unit normal vectors.
+    dV : ndarray
+        Numeric *Differential volume element* as norm of *Differential area vectors*.
+    dhdX : ndarray
+        Partial derivative of element shape functions ``dhdX_aJpc`` of shape function ``a`` w.r.t. undeformed coordinate ``J`` evaluated at quadrature point ``p`` for every cell ``c``.
+    """
+
+    def __init__(
+        self, mesh, element, quadrature, grad=True, only_surface=True, mask=None
+    ):
+
+        self.only_surface = only_surface
+        self.mask = mask
+
+        # number of faces
+        self.nfaces = quadrature.nfaces
+
+        if mesh.cell_type == "quad":
+
+            # edges (generalized "faces") of a quad
+            i = [3, 1, 0, 2]
+            j = [0, 2, 1, 3]
+
+            faces = np.dstack(
+                (
+                    mesh.cells[:, i],
+                    mesh.cells[:, j],
+                )
+            )
+            faces = faces.reshape(-1, faces.shape[-1])
+
+            # complementary edges for quad faces (generalized "volumes")
+            t = [1, 0, 3, 2]
+            k = np.array(i)[t]
+            l = np.array(j)[t]
+
+            volumes = np.dstack(
+                (
+                    mesh.cells[:, i],
+                    mesh.cells[:, j],
+                    mesh.cells[:, k],
+                    mesh.cells[:, l],
+                )
+            )
+
+        elif mesh.cell_type == "hexahedron":
+
+            # faces of hexahedron
+            i = [0, 1, 1, 2, 0, 4]
+            j = [3, 2, 0, 3, 1, 5]
+            k = [7, 6, 4, 7, 2, 6]
+            l = [4, 5, 5, 6, 3, 7]
+
+            faces = np.dstack(
+                (
+                    mesh.cells[:, i],
+                    mesh.cells[:, j],
+                    mesh.cells[:, k],
+                    mesh.cells[:, l],
+                )
+            )
+
+            # complementary faces for hexahedron volumes
+            t = [1, 0, 3, 2, 5, 4]
+            m = np.array(i)[t]
+            n = np.array(j)[t]
+            p = np.array(k)[t]
+            q = np.array(l)[t]
+
+            volumes = np.dstack(
+                (
+                    mesh.cells[:, i],
+                    mesh.cells[:, j],
+                    mesh.cells[:, k],
+                    mesh.cells[:, l],
+                    mesh.cells[:, m],
+                    mesh.cells[:, n],
+                    mesh.cells[:, p],
+                    mesh.cells[:, q],
+                )
+            )
+
+        else:
+            raise NotImplementedError("Cell type not supported.")
+
+        faces = faces.reshape(-1, faces.shape[-1])
+        volumes = volumes.reshape(-1, volumes.shape[-1])
+        self._faces = faces
+
+        if self.only_surface:
+            # sort faces, get indices of unique faces and counts
+            faces_sorted = np.sort(faces, axis=1)
+            faces_unique, index, counts = np.unique(faces_sorted, True, False, True, 0)
+
+            self._index = index
+            self._mask = counts == 1
+        else:
+            self._index = np.arange(len(faces))
+            self._mask = np.ones_like(self._index, dtype=bool)
+
+        self._selection = self._index[self._mask]
+
+        # merge with point-mask
+        if mask is not None:
+            point_selection = np.arange(len(mesh.points))[mask]
+            self._selection = self._selection[
+                np.all(np.isin(self._faces[self._selection], point_selection), axis=1)
+            ]
+
+        # get faces and volumes on boundary (unique faces with one count)
+        volumes_boundary = volumes[self._selection]
+
+        # init region and faces
+        super().__init__(mesh, element, quadrature, grad=grad)
+
+        # reshape data
+        self.h = self._reshape(self.h)
+
+        if grad:
+            self.dA, self.dV, self.normals = self._init_faces()
+
+            self.dhdr = self._reshape(self.dhdr)
+            self.dhdX = self._reshape(self.dhdX)
+            self.dXdr = self._reshape(self.dXdr)
+
+        ## create mesh on boundary
+        mesh_boundary = mesh.copy()
+        mesh_boundary.update(volumes_boundary)
+        self.mesh = mesh_boundary
+
+    def _reshape(self, A):
+        "Reshape data."
+
+        # reshape functions for all boundary cells
+        B = A.reshape(*A.shape[:-2], self.nfaces, -1, A.shape[-1])
+        a = np.arange(len(B.shape))
+
+        a[-3:] = a[[-2, -3, -1]]
+        C = B.transpose(a)
+        D = C.reshape(*A.shape[:-2], -1, self.nfaces * A.shape[-1])
+
+        # slice faces on boundary
+        return D.T[self._selection].T
+
+    def _init_faces(self):
+        "Initialize (norm of) face normals of cells."
+
+        if self.mesh.cell_type == "quad":
+            dA_1 = self.dXdr[:, 1][::-1]
+            dA_2 = self.dXdr[:, 0][::-1]
+            dA_faces = np.array([-dA_1, dA_1, -dA_2, dA_2])
+
+        elif self.mesh.cell_type == "hexahedron":
+            dA_1 = cross(self.dXdr[:, 1], self.dXdr[:, 2])
+            dA_2 = cross(self.dXdr[:, 2], self.dXdr[:, 0])
+            dA_3 = cross(self.dXdr[:, 0], self.dXdr[:, 1])
+            dA_faces = np.array(
+                [
+                    -dA_1,
+                    dA_1,
+                    -dA_2,
+                    dA_2,
+                    -dA_3,
+                    dA_3,
+                ]
+            )
+
+        dA = np.stack(dA_faces) * self.quadrature.weights.reshape(-1, 1)
+        nfaces, dim, nqpoints, ncells = dA.shape
+        nqpoints_per_face = nqpoints // nfaces
+        dA = np.einsum(
+            "ijk...->ikj...", dA.reshape(nfaces, dim, nfaces, nqpoints_per_face, ncells)
+        )
+        dA = np.einsum("ijkl...->jilk...", [dA[a, a] for a in range(dA.shape[0])])
+        dA = dA.reshape(dim, nqpoints, ncells)
+
+        dA = dA.reshape(dim, -1, nfaces * ncells).T[self._selection].T
+        dV = np.linalg.norm(dA, axis=0)
+        normals = dA / dV
+
+        return dA, dV, normals

--- a/felupe/region/_region.py
+++ b/felupe/region/_region.py
@@ -32,7 +32,10 @@ from ..math import det, inv
 
 class Region:
     r"""
-    A numeric region as a combination of a mesh, an element and a numeric integration scheme (quadrature). The gradients of the element shape functions are evaluated at all integration points of each cell in the region if the optional gradient argument is True.
+    A numeric region as a combination of a mesh, an element and a numeric
+    integration scheme (quadrature). The gradients of the element shape
+    functions are evaluated at all integration points of each cell in the
+    region if the optional gradient argument is True.
 
     .. math::
 
@@ -83,7 +86,9 @@ class Region:
         self.quadrature = quadrature
 
         # element shape function
-        self.element.h = np.array([self.element.function(p) for p in self.quadrature.points]).T
+        self.element.h = np.array(
+            [self.element.function(p) for p in self.quadrature.points]
+        ).T
         self.h = np.tile(np.expand_dims(self.element.h, -1), self.mesh.ncells)
 
         # partial derivative of element shape function

--- a/felupe/region/_templates.py
+++ b/felupe/region/_templates.py
@@ -28,6 +28,7 @@ along with Felupe.  If not, see <http://www.gnu.org/licenses/>.
 import numpy as np
 
 from ._region import Region
+from ._boundary import RegionBoundary
 from ..element import (
     ConstantQuad,
     Quad,
@@ -45,6 +46,7 @@ from ..element import (
 )
 from ..quadrature import (
     GaussLegendre,
+    GaussLegendreBoundary,
     Triangle as TriangleQuadrature,
     Tetrahedron as TetraQuadrature,
 )
@@ -77,6 +79,19 @@ class RegionQuad(Region):
         super().__init__(mesh, element, quadrature)
 
 
+class RegionQuadBoundary(RegionBoundary):
+    "A region with a quad element."
+
+    def __init__(self, mesh, only_surface=True, mask=None):
+
+        element = Quad()
+        quadrature = GaussLegendreBoundary(order=1, dim=2)
+
+        super().__init__(
+            mesh, element, quadrature, only_surface=only_surface, mask=mask
+        )
+
+
 class RegionConstantHexahedron(Region):
     "A region with a constant hexahedron element."
 
@@ -101,6 +116,19 @@ class RegionHexahedron(Region):
         quadrature = GaussLegendre(order=1, dim=3)
 
         super().__init__(mesh, element, quadrature)
+
+
+class RegionHexahedronBoundary(RegionBoundary):
+    "A region with a hexahedron element."
+
+    def __init__(self, mesh, only_surface=True, mask=None):
+
+        element = Hexahedron()
+        quadrature = GaussLegendreBoundary(order=1, dim=3)
+
+        super().__init__(
+            mesh, element, quadrature, only_surface=only_surface, mask=mask
+        )
 
 
 class RegionQuadraticHexahedron(Region):

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -30,7 +30,7 @@ import felupe as fe
 
 
 def test_meshes():
-    
+
     m = fe.Mesh(
         points=np.array(
             [
@@ -42,18 +42,18 @@ def test_meshes():
         cells=np.array([[0, 1, 2]]),
         cell_type="triangle",
     )
-    
+
     fe.mesh.convert(m, order=0)
     fe.mesh.convert(m, order=0, calc_points=True)
     fe.mesh.convert(m, order=2)
     fe.mesh.convert(m, order=2, calc_midfaces=True)
-    
+
     m = fe.Mesh(
         points=np.array([[0, 0, 0], [1, 0, 0], [0, 1, 0], [0, 0, 1]]),
         cells=np.array([[0, 1, 2, 3]]),
         cell_type="tetra",
     )
-    
+
     fe.mesh.convert(m, order=0)
     fe.mesh.convert(m, order=0, calc_points=True)
     fe.mesh.convert(m, order=2)

--- a/tests/test_quadrature.py
+++ b/tests/test_quadrature.py
@@ -56,6 +56,34 @@ def test_gausslegendre():
         fe.GaussLegendre(order=1, dim=4)
 
 
+def test_gausslegendre_boundary():
+
+    with pytest.raises(ValueError):
+        q11 = fe.GaussLegendreBoundary(order=1, dim=1)
+        assert q11.points.shape == (2, 1)
+        assert q11.weights.sum() == 2
+
+    for permute in [False, True]:
+        q12 = fe.GaussLegendreBoundary(order=1, dim=2, permute=permute)
+        assert q12.points.shape == (8, 2)
+        assert np.isclose(q12.weights.sum(), 8)
+
+        q13 = fe.GaussLegendreBoundary(order=1, dim=3, permute=permute)
+        assert q13.points.shape == (24, 3)
+        assert np.isclose(q13.weights.sum(), 24)
+
+        q23 = fe.GaussLegendreBoundary(order=2, dim=3, permute=permute)
+        assert q23.points.shape == (54, 3)
+        assert np.isclose(q23.weights.sum(), 24)
+
+    q23 = fe.GaussLegendreBoundary(order=2, dim=3)
+    assert q23.inv().points.shape == q23.points.shape
+    assert np.allclose(q23.weights, q23.inv().weights)
+
+    with pytest.raises(ValueError):
+        fe.GaussLegendreBoundary(order=1, dim=4)
+
+
 def test_triangle():
     q = fe.TriangleQuadrature(order=1)
     assert q.points.shape == (1, 2)
@@ -92,5 +120,6 @@ def test_tetra():
 
 if __name__ == "__main__":
     test_gausslegendre()
+    test_gausslegendre_boundary()
     test_triangle()
     test_tetra()

--- a/tests/test_region.py
+++ b/tests/test_region.py
@@ -28,6 +28,8 @@ along with Felupe.  If not, see <http://www.gnu.org/licenses/>.
 import numpy as np
 import felupe as fe
 
+import pytest
+
 
 def test_region():
 
@@ -35,6 +37,10 @@ def test_region():
     r = fe.RegionQuad(mesh)
     r = fe.RegionQuadBoundary(mesh)
     r = fe.RegionConstantQuad(mesh)
+    
+    mesh.cell_type = "some_fancy_cell_type"
+    with pytest.raises(NotImplementedError):
+        r = fe.RegionBoundary(mesh, fe.Quad(), fe.GaussLegendreBoundary(order=1, dim=2))
 
     mesh = fe.Cube()
     r = fe.RegionHexahedron(mesh)

--- a/tests/test_region.py
+++ b/tests/test_region.py
@@ -33,10 +33,12 @@ def test_region():
 
     mesh = fe.Rectangle()
     r = fe.RegionQuad(mesh)
+    r = fe.RegionQuadBoundary(mesh)
     r = fe.RegionConstantQuad(mesh)
 
     mesh = fe.Cube()
     r = fe.RegionHexahedron(mesh)
+    r = fe.RegionHexahedronBoundary(mesh)
     r = fe.RegionConstantHexahedron(mesh)
 
     mesh2 = fe.mesh.convert(mesh, 2, True, False, False)

--- a/tests/test_region.py
+++ b/tests/test_region.py
@@ -45,6 +45,9 @@ def test_region():
     mesh = fe.Cube()
     r = fe.RegionHexahedron(mesh)
     r = fe.RegionHexahedronBoundary(mesh)
+    r = fe.RegionHexahedronBoundary(mesh, only_surface=False)
+    r = fe.RegionHexahedronBoundary(mesh, mask=[0, 3])
+    r = fe.RegionHexahedronBoundary(mesh, only_surface=False, mask=[0, 3])
     r = fe.RegionConstantHexahedron(mesh)
 
     mesh2 = fe.mesh.convert(mesh, 2, True, False, False)

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -187,7 +187,7 @@ def test_newton():
 
     # define the constitutive material behavior
     umat = fe.NeoHooke(mu=1.0, bulk=2.0)
-    
+
     for kwargs in [{"parallel": True}, {"jit": True}]:
 
         # newton-rhapson procedure


### PR DESCRIPTION
Introduce a Region class for Boundaries, optionally only on the outline of the model and in combination with a point mask.
- [x] Region for boundaries
- [x] Quadrature on boundary faces/edges
- [x] Template regions for Quad and Hexahedron
- [x] Add tests

Fixes #168  for Quad and Hexahedron.