### PR TITLE
Add Mesh-Tool: `triangulate()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ All notable changes to this project will be documented in this file. The format 
 - Add `parallel` keyword to constitutive models (`NeoHooke`, `LinearElasticTensorNotation` and `ThreeFieldVariation`).
 - Add `RegionBoundary` along with template regions for `Quad` and `Hexahedron` and `GaussLegendreBoundary`.
 - Add optional normal vector argument for function and gradient methods of `AreaChange`.
+- Add a new Mesh-tool `triangulate()`, applicable on Quad and Hexahedron meshes.
 
 ### Changed
 - Enforce consistent arguments for functions inside `mesh.tools` (`points, cells, cell_data` or `Mesh`).

--- a/docs/felupe/global/region.rst
+++ b/docs/felupe/global/region.rst
@@ -6,7 +6,7 @@ Region
    :undoc-members:
    :inherited-members:
    
-.. .. autoclass:: felupe.RegionBoundary
+.. autoclass:: felupe.RegionBoundary
    :members:
    :undoc-members:
    :inherited-members:

--- a/docs/felupe/mesh/mesh.rst
+++ b/docs/felupe/mesh/mesh.rst
@@ -17,4 +17,4 @@ felupe.mesh
    :inherited-members:
 
 .. automodule:: felupe.mesh
-   :members: expand, rotate, revolve, sweep, mirror, convert, collect_edges, collect_faces, collect_volumes, add_midpoints_edges, add_midpoints_faces, add_midpoints_volumes
+   :members: expand, rotate, revolve, sweep, mirror, triangulate, convert, collect_edges, collect_faces, collect_volumes, add_midpoints_edges, add_midpoints_faces, add_midpoints_volumes

--- a/felupe/mesh/__init__.py
+++ b/felupe/mesh/__init__.py
@@ -5,6 +5,7 @@ from ._tools import (
     revolve,
     sweep,
     mirror,
+    triangulate,
 )
 from ._convert import (
     convert,

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -198,6 +198,30 @@ def test_mirror():
         assert np.isclose(r.dV.sum(), s.dV.sum())
 
 
+def test_triangulate():
+
+    m = fe.Rectangle(n=3)
+    n = fe.mesh.triangulate(m)
+
+    rm = fe.RegionQuad(m)
+    rn = fe.RegionTriangle(n)
+
+    assert np.isclose(rm.dV.sum(), rn.dV.sum())
+
+    for mode in [0, 3]:
+        m = fe.Cube(n=3)
+        n = fe.mesh.triangulate(m)
+
+        rm = fe.RegionHexahedron(m)
+        rn = fe.RegionTetra(n)
+
+        assert np.isclose(rm.dV.sum(), rn.dV.sum())
+
+    with pytest.raises(NotImplementedError):
+        n = fe.mesh.triangulate(m, mode=-1)
+
+
 if __name__ == "__main__":
     test_meshes()
     test_mirror()
+    test_triangulate()

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -210,7 +210,7 @@ def test_triangulate():
 
     for mode in [0, 3]:
         m = fe.Cube(n=3)
-        n = fe.mesh.triangulate(m)
+        n = fe.mesh.triangulate(m, mode=mode)
 
         rm = fe.RegionHexahedron(m)
         rn = fe.RegionTetra(n)


### PR DESCRIPTION
Convert a Quad or a Hexahedron mesh to a Triangle or a Tetra mesh.

Fixes #201