### PR TITLE
Add function decorator for weakforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ All notable changes to this project will be documented in this file. The format 
 - Add optional normal vector argument for function and gradient methods of `AreaChange`.
 - Add a new Mesh-tool `triangulate()`, applicable on Quad and Hexahedron meshes.
 - Add a new Mesh-method `Mesh.as_meshio()`.
+- Add a function decorator `@Form(...)` for linear and bilinear form objects.
 
 ### Changed
 - Enforce consistent arguments for functions inside `mesh` (`points, cells, cell_data` or `Mesh`).

--- a/felupe/__init__.py
+++ b/felupe/__init__.py
@@ -36,6 +36,8 @@ from ._assembly import (
     BilinearForm,
     LinearFormMixed,
     BilinearFormMixed,
+    BaseForm,
+    Form,
 )
 from ._basis import (
     Basis,

--- a/felupe/_assembly/__init__.py
+++ b/felupe/_assembly/__init__.py
@@ -1,4 +1,11 @@
 from ._base import IntegralForm
 from ._axi import IntegralFormAxisymmetric
 from ._mixed import IntegralFormMixed
-from ._form import LinearForm, BilinearForm, LinearFormMixed, BilinearFormMixed
+from ._form import (
+    LinearForm,
+    BilinearForm,
+    LinearFormMixed,
+    BilinearFormMixed,
+    BaseForm,
+    Form,
+)

--- a/felupe/_assembly/_base.py
+++ b/felupe/_assembly/_base.py
@@ -206,12 +206,7 @@ class IntegralForm:
                 )
             elif not grad_v and grad_u:
                 return einsum(
-                    "a...pe,...kLpe,bLpe,pe->a...bke",
-                    vb,
-                    fun,
-                    ub,
-                    dV,
-                    optimize=True,
+                    "a...pe,...kLpe,bLpe,pe->a...bke", vb, fun, ub, dV, optimize=True,
                 )
             else:  # grad_v and grad_u
                 if jit:
@@ -319,6 +314,7 @@ try:
                                         )
 
         return out
+
 
 except:
     pass

--- a/felupe/_assembly/_form.py
+++ b/felupe/_assembly/_form.py
@@ -598,7 +598,11 @@ class BaseForm:
                 # mixed-field input
                 if isinstance(v, FieldMixed):
                     self.v = BasisMixed(v)
-                    form = LinearFormMixed(self.v, self.grad_v, self.dx)
+                    form = LinearFormMixed(self.v, self.grad_v)
+
+                    # evaluate weakform to list of weakforms
+                    if isinstance(self.weakform, type(lambda x: x)):
+                        self.weakform = self.weakform()
 
                 # single-field input
                 elif isinstance(v, Field):
@@ -611,12 +615,14 @@ class BaseForm:
             else:
 
                 # mixed-field input
-                if isinstance(v, BasisMixed):
+                if isinstance(v, FieldMixed):
                     self.v = BasisMixed(v)
                     self.u = BasisMixed(u)
-                    form = BilinearFormMixed(
-                        self.v, self.u, self.grad_v, self.grad_u, self.dx
-                    )
+                    form = BilinearFormMixed(self.v, self.u, self.grad_v, self.grad_u)
+
+                    # evaluate weakform to list of weakforms
+                    if isinstance(self.weakform, type(lambda x: x)):
+                        self.weakform = self.weakform()
 
                 # single-field input
                 elif isinstance(v, Field):
@@ -673,7 +679,7 @@ class BaseForm:
 
         kwargs = dict(parallel=parallel, sym=sym)
 
-        if self.u is None:
+        if self.u is None or isinstance(self.v, BasisMixed):
             kwargs.pop("sym")
 
         return self.form.integrate(
@@ -713,7 +719,7 @@ class BaseForm:
 
         kwargs = dict(parallel=parallel, sym=sym)
 
-        if self.u is None:
+        if self.u is None or isinstance(self.u, BasisMixed):
             kwargs.pop("sym")
 
         return self.form.assemble(

--- a/felupe/_assembly/_form.py
+++ b/felupe/_assembly/_form.py
@@ -37,6 +37,9 @@ from threading import Thread
 from ._base import IntegralForm
 from ._mixed import IntegralFormMixed
 
+from .._basis import Basis, BasisMixed
+from .._field import Field, FieldMixed
+
 
 class LinearForm:
     r"""A linear form object with methods for integration and assembly of
@@ -186,7 +189,7 @@ class BilinearForm:
             A callable function ``weakform(v, *args, **kwargs)``.
         args : tuple, optional
             Optional arguments for callable weakform
-        kawargs : dict, optional
+        kwargs : dict, optional
             Optional named arguments for callable weakform
         parallel : bool, optional (default is False)
             Flag to activate parallel threading.
@@ -287,7 +290,7 @@ class BilinearForm:
             A callable function ``weakform(v, *args, **kwargs)``.
         args : tuple, optional
             Optional arguments for callable weakform
-        kawargs : dict, optional
+        kwargs : dict, optional
             Optional named arguments for callable weakform
         parallel : bool, optional (default is False)
             Flag to activate parallel threading.
@@ -350,7 +353,7 @@ class LinearFormMixed:
             A callable function ``weakform(v, *args, **kwargs)``.
         args : tuple, optional
             Optional arguments for callable weakform
-        kawargs : dict, optional
+        kwargs : dict, optional
             Optional named arguments for callable weakform
         parallel : bool, optional (default is False)
             Flag to activate parallel threading.
@@ -375,7 +378,7 @@ class LinearFormMixed:
             A callable function ``weakform(v, *args, **kwargs)``.
         args : tuple, optional
             Optional arguments for callable weakform
-        kawargs : dict, optional
+        kwargs : dict, optional
             Optional named arguments for callable weakform
         parallel : bool, optional (default is False)
             Flag to activate parallel threading.
@@ -500,3 +503,253 @@ class BilinearFormMixed:
         values = self.integrate(weakform, args, kwargs, parallel=parallel)
 
         return self._form.assemble(values)
+
+
+class BaseForm:
+    r"""A linear or bilinear form object based on a weak-form with 
+    methods for integration and assembly of vectors / sparse matrices.
+    
+    Linear Form:
+
+    ..  math::
+
+        L(v) = \int_\Omega f \cdot v \ dx
+        
+    Bilinear Form:
+    
+    ..  math::
+
+        a(v, u) = \int_\Omega v \cdot f \cdot u \ dx
+
+    Parameters
+    ----------
+    v : Field or FieldMixed
+        An object with interpolation or gradients of a field. May be 
+        updated during integration / assembly.
+    u : Field or FieldMixed
+        An object with interpolation or gradients of a field. May be 
+        updated during integration / assembly.
+    grad_v : bool, optional (default is False)
+        Flag to use the gradient of ``v``.
+    grad_u : bool, optional (default is False)
+        Flag to use the gradient of ``u``.
+    dx : ndarray or None, optional (default is None)
+        Array with (numerical) differential volumes.
+    args : tuple, optional (default is ())
+        Tuple with initial optional weakform-arguments. May be updated during
+        integration / assembly.
+    kwargs : dict, optional (default is {})
+        Dictionary with initial optional weakform-keyword-arguments. May be updated during
+        integration / assembly.
+
+    """
+
+    def __init__(
+        self,
+        weakform,
+        v,
+        u=None,
+        grad_v=False,
+        grad_u=False,
+        dx=None,
+        args=(),
+        kwargs={},
+    ):
+
+        # set attributes
+        self.grad_u = grad_u
+        self.grad_v = grad_v
+        self.dx = dx
+        self.weakform = weakform
+
+        # init underlying linear or bilinear (mixed) form
+        self._init_or_update_forms(v, u, args, kwargs)
+
+    def _init_or_update_forms(self, v, u, args, kwargs):
+        "Init or update the underlying form object."
+
+        # update args and kwargs for weakform
+        if args is not None:
+            self.args = args
+        if kwargs is not None:
+            self.kwargs = kwargs
+
+        if v is not None:
+
+            # linear form
+            if u is None:
+
+                self.u = None
+
+                # mixed-field input
+                if isinstance(v, FieldMixed):
+                    self.v = BasisMixed(v)
+                    self.form = LinearFormMixed(self.v, self.grad_v, self.dx)
+
+                # single-field input
+                elif isinstance(v, Field):
+                    self.v = Basis(v)
+                    self.form = LinearForm(self.v, self.grad_v, self.dx)
+
+                else:
+                    raise TypeError("Unknown type of Field ``v``.")
+
+            else:
+
+                # mixed-field input
+                if isinstance(v, BasisMixed):
+                    self.v = BasisMixed(v)
+                    self.u = BasisMixed(u)
+                    self.form = BilinearFormMixed(
+                        self.v, self.u, self.grad_v, self.grad_u, self.dx
+                    )
+
+                # single-field input
+                elif isinstance(v, Field):
+                    self.v = Basis(v)
+                    self.u = Basis(u)
+                    self.form = BilinearForm(
+                        self.v, self.u, self.grad_v, self.grad_u, self.dx
+                    )
+
+                else:
+                    raise TypeError("Unknown type of Field ``v``.")
+
+    def integrate(self, v=None, u=None, args=(), kwargs={}, parallel=False, sym=False):
+        r"""Return evaluated (but not assembled) integrals.
+
+        Parameters
+        ----------
+        v : Field, FieldMixed or None, optional
+            An object with interpolation or gradients of a field as specified
+            by boolean flag ``self.grad_v`` (default is None).
+        u : Field, FieldMixed or None, optional
+            An object with interpolation or gradients of a field as specified
+            by boolean flag ``self.grad_v`` (default is None).
+        args : tuple, optional (default is ())
+            Tuple with optional weakform-arguments.
+        kwargs : dict, optional (default is {})
+            Dictionary with optional weakform-keyword-arguments.
+        parallel : bool, optional (default is False)
+            Flag to activate parallel threading.
+        sym : bool, optional (default is False)
+            Flag to active symmetric integration/assembly
+            for bilinear forms.
+
+        Returns
+        -------
+        values : ndarray
+            Integrated (but not assembled) vector / matrix values.
+        """
+
+        self._init_or_update_forms(v, u, args, kwargs)
+
+        kwargs = dict(parallel=parallel, sym=sym)
+
+        if self.u is None:
+            kwargs.pop("sym")
+
+        return self.form.integrate(
+            self.weakform, args=self.args, kwargs=self.kwargs, **kwargs
+        )
+
+    def assemble(
+        self, v=None, u=None, args=None, kwargs=None, parallel=False, sym=False
+    ):
+        r"""Return the assembled integral as vector / sparse matrix.
+
+        Parameters
+        ----------
+        v : Field, FieldMixed or None, optional
+            An object with interpolation or gradients of a field as specified
+            by boolean flag ``self.grad_v`` (default is None).
+        u : Field, FieldMixed or None, optional
+            An object with interpolation or gradients of a field as specified
+            by boolean flag ``self.grad_v`` (default is None).
+        args : tuple, optional (default is ())
+            Tuple with optional weakform-arguments.
+        kwargs : dict, optional (default is {})
+            Dictionary with optional weakform-keyword-arguments.
+        parallel : bool, optional (default is False)
+            Flag to activate parallel threading.
+        sym : bool, optional (default is False)
+            Flag to active symmetric integration/assembly 
+            for bilinear forms.
+
+        Returns
+        -------
+        values : csr_matrix
+            The assembled vector / sparse matrix.
+        """
+
+        self._init_or_update_forms(v, u, args, kwargs)
+
+        kwargs = dict(parallel=parallel, sym=sym)
+
+        if self.u is None:
+            kwargs.pop("sym")
+
+        return self.form.assemble(
+            self.weakform, args=self.args, kwargs=self.kwargs, **kwargs
+        )
+
+
+def Form(v, u=None, grad_v=False, grad_u=False, dx=None, args=(), kwargs={}):
+    r"""A linear or bilinear form object as function decorator on a weak-form
+    with methods for integration and assembly of vectors or sparse matrices.
+    
+    Linear Form:
+
+    ..  math::
+
+        L(v) = \int_\Omega f \cdot v \ dx
+        
+    Bilinear Form:
+    
+    ..  math::
+
+        a(v, u) = \int_\Omega v \cdot f \cdot u \ dx
+
+    Parameters
+    ----------
+    v : Field or FieldMixed
+        An object with interpolation or gradients of a field. May be 
+        updated during integration / assembly.
+    u : Field or FieldMixed
+        An object with interpolation or gradients of a field. May be 
+        updated during integration / assembly.
+    grad_v : bool, optional (default is False)
+        Flag to use the gradient of ``v``.
+    grad_u : bool, optional (default is False)
+        Flag to use the gradient of ``u``.
+    dx : ndarray or None, optional (default is None)
+        Array with (numerical) differential volumes.
+    args : tuple, optional (default is ())
+        Tuple with initial optional weakform-arguments. May be updated during
+        integration / assembly.
+    kwargs : dict, optional (default is {})
+        Dictionary with initial optional weakform-keyword-arguments. May be 
+        updated during integration / assembly.
+    
+    Returns
+    -------
+    BaseForm
+        A form object based on LinearForm, LinearFormMixed, BilinearForm or 
+        BilinearFormMixed with methods for integration and assembly.
+
+    """
+
+    def form(weakform):
+
+        return BaseForm(
+            weakform=weakform,
+            v=v,
+            u=u,
+            grad_v=grad_v,
+            grad_u=grad_u,
+            dx=dx,
+            args=args,
+            kwargs=kwargs,
+        )
+
+    return form

--- a/felupe/_field/_axi.py
+++ b/felupe/_field/_axi.py
@@ -135,9 +135,7 @@ class FieldAxisymmetric(Field):
         # w.r.t. undeformed coordinate "J" evaluated at quadrature point "p"
         # for each cell "e"
         g = np.einsum(
-            "ca...,aJpc->...Jpc",
-            self.values[self.region.mesh.cells],
-            self.region.dhdX,
+            "ca...,aJpc->...Jpc", self.values[self.region.mesh.cells], self.region.dhdX,
         )
 
         if sym:

--- a/felupe/_field/_base.py
+++ b/felupe/_field/_base.py
@@ -125,9 +125,7 @@ class Field:
         # w.r.t. undeformed coordinates "J" evaluated at quadrature point "p"
         # for each cell "c"
         g = np.einsum(
-            "ca...,aJpc->...Jpc",
-            self.values[self.region.mesh.cells],
-            self.region.dhdX,
+            "ca...,aJpc->...Jpc", self.values[self.region.mesh.cells], self.region.dhdX,
         )
 
         if sym:

--- a/felupe/element/_triangle.py
+++ b/felupe/element/_triangle.py
@@ -104,11 +104,7 @@ class QuadraticTriangle(Element):
 
         dhdr_a = np.array([[-1, -1], [1, 0], [0, 1]], dtype=float)
         dhdr_b = np.array(
-            [
-                [4 * (t1 - t2), -4 * t2],
-                [4 * t3, 4 * t2],
-                [-4 * t3, 4 * (t1 - t2)],
-            ]
+            [[4 * (t1 - t2), -4 * t2], [4 * t3, 4 * t2], [-4 * t3, 4 * (t1 - t2)],]
         )
         dhdr = np.vstack((dhdr_a, dhdr_b))
         dhdr[0] += -dhdr[3] / 2 - dhdr[5] / 2

--- a/felupe/math/__init__.py
+++ b/felupe/math/__init__.py
@@ -32,6 +32,4 @@ from ._field import (
     grad,
 )
 
-from ._spatial import (
-    rotation_matrix,
-)
+from ._spatial import rotation_matrix

--- a/felupe/mesh/_convert.py
+++ b/felupe/mesh/_convert.py
@@ -251,11 +251,7 @@ def add_midpoints_edges(points, cells, cell_type):
     }
 
     # collect edges
-    points_edges, cells_edges, _ = collect_edges(
-        points,
-        cells,
-        cell_type,
-    )
+    points_edges, cells_edges, _ = collect_edges(points, cells, cell_type,)
 
     # add offset to point index for edge-midpoints
     # in additional cells array
@@ -285,11 +281,7 @@ def add_midpoints_faces(points, cells, cell_type):
     }
 
     # collect faces
-    points_faces, cells_faces, _ = collect_faces(
-        points,
-        cells,
-        cell_type,
-    )
+    points_faces, cells_faces, _ = collect_faces(points, cells, cell_type,)
 
     # add offset to point index for faces-midpoints
     # in additional cells array
@@ -318,11 +310,7 @@ def add_midpoints_volumes(points, cells, cell_type):
     }
 
     # collect volumes
-    points_volumes, cells_volumes, _ = collect_volumes(
-        points,
-        cells,
-        cell_type,
-    )
+    points_volumes, cells_volumes, _ = collect_volumes(points, cells, cell_type,)
 
     # add offset to point index for volumes-midpoints
     # in additional cells array

--- a/felupe/mesh/_tools.py
+++ b/felupe/mesh/_tools.py
@@ -364,13 +364,7 @@ def triangulate(points, cells, cell_type, mode=3):
         j = [1, 1]
         k = [3, 2]
 
-        cells_new = np.dstack(
-            (
-                cells[:, i],
-                cells[:, j],
-                cells[:, k],
-            )
-        )
+        cells_new = np.dstack((cells[:, i], cells[:, j], cells[:, k],))
 
         cell_type_new = "triangle"
 
@@ -393,14 +387,7 @@ def triangulate(points, cells, cell_type, mode=3):
         else:
             raise NotImplementedError(f"Mode {mode} not implemented.")
 
-        cells_new = np.dstack(
-            (
-                cells[:, i],
-                cells[:, j],
-                cells[:, k],
-                cells[:, l],
-            )
-        )
+        cells_new = np.dstack((cells[:, i], cells[:, j], cells[:, k], cells[:, l],))
 
         cell_type_new = "tetra"
 

--- a/felupe/region/_boundary.py
+++ b/felupe/region/_boundary.py
@@ -111,12 +111,7 @@ class RegionBoundary(Region):
             i = [3, 1, 0, 2]
             j = [0, 2, 1, 3]
 
-            cells_faces = np.dstack(
-                (
-                    mesh.cells[:, i],
-                    mesh.cells[:, j],
-                )
-            )
+            cells_faces = np.dstack((mesh.cells[:, i], mesh.cells[:, j],))
 
             # complementary edges for the creation of "boundary" quads
             # (rotated quads with 1st edge as n-th edge of one original quad)

--- a/felupe/tools/_save.py
+++ b/felupe/tools/_save.py
@@ -92,9 +92,7 @@ def save(
 
     mesh = meshio.Mesh(
         points=mesh.points,
-        cells=[
-            (mesh.cell_type, mesh.cells),
-        ],
+        cells=[(mesh.cell_type, mesh.cells),],
         point_data=point_data,
         cell_data=cell_data,
     )

--- a/tests/test_bilinearform.py
+++ b/tests/test_bilinearform.py
@@ -196,6 +196,7 @@ def test_form_decorator():
             L.assemble(**options)
             L.assemble(kwargs=dict(coords=coords), **options)
             L.assemble(args=(coords,), kwargs={}, **options)
+            L.assemble(args=(coords,), kwargs=None, **options)
             L.assemble(**options)
             
             a.assemble(**options)

--- a/tests/test_form.py
+++ b/tests/test_form.py
@@ -26,8 +26,8 @@ along with Felupe.  If not, see <http://www.gnu.org/licenses/>.
 """
 
 import numpy as np
-
 import felupe as fe
+import pytest
 
 
 def pre():
@@ -310,6 +310,54 @@ def test_mixed():
 
             assert b.shape == (z, 1)
 
+def test_form_decorator():
+    
+    mesh = fe.mesh.triangulate(fe.Rectangle(n=6))
+    region = fe.RegionTriangle(mesh)
+    field = fe.Field(region)
+    coords = fe.Field(
+        region, dim=mesh.dim, values=mesh.points
+    ).interpolate()
+    fieldmixed = fe.FieldsMixed(fe.RegionQuad(fe.Rectangle(n=6)))
+
+    @fe.Form(v=field, u=field, grad_v=True, grad_u=True)
+    def a(dv, du):
+        return fe.math.ddot(dv, du)
+
+    @fe.Form(v=field, kwargs=dict(coords=coords))
+    def L(v, coords):
+        x, y = coords
+        f = np.sin(np.pi * x) * np.sin(np.pi * y)
+        return f * v
+
+    for parallel in [False, True]:
+        for sym in [False, True]:
+            
+            options = dict(parallel=parallel, sym=sym)
+            L.assemble(**options)
+            L.assemble(kwargs=dict(coords=coords), **options)
+            L.assemble(args=(coords,), kwargs={}, **options)
+            
+            print(L.args, L.kwargs)
+            L.assemble(**options)
+            
+            a.assemble(**options)
+            a.assemble(field, field, **options)
+            
+            L.integrate(**options)
+            L.integrate(kwargs=dict(coords=coords), **options)
+            
+            a.integrate(**options)
+            a.integrate(field, field, **options)
+    
+    with pytest.raises(TypeError):
+        L.assemble(v=mesh)
+    
+    with pytest.raises(TypeError):
+        a.assemble(v=mesh)
+    
+    with pytest.raises(TypeError):
+        a.assemble(v=field, u=None)
 
 if __name__ == "__main__":
     test_linearform()
@@ -318,3 +366,4 @@ if __name__ == "__main__":
     test_bilinearform_broadcast()
     test_axi()
     test_mixed()
+    test_form_decorator()

--- a/tests/test_form.py
+++ b/tests/test_form.py
@@ -337,8 +337,6 @@ def test_form_decorator():
             L.assemble(**options)
             L.assemble(kwargs=dict(coords=coords), **options)
             L.assemble(args=(coords,), kwargs={}, **options)
-            
-            print(L.args, L.kwargs)
             L.assemble(**options)
             
             a.assemble(**options)

--- a/tests/test_form.py
+++ b/tests/test_form.py
@@ -310,53 +310,6 @@ def test_mixed():
 
             assert b.shape == (z, 1)
 
-def test_form_decorator():
-    
-    mesh = fe.mesh.triangulate(fe.Rectangle(n=6))
-    region = fe.RegionTriangle(mesh)
-    field = fe.Field(region)
-    coords = fe.Field(
-        region, dim=mesh.dim, values=mesh.points
-    ).interpolate()
-    fieldmixed = fe.FieldsMixed(fe.RegionQuad(fe.Rectangle(n=6)))
-
-    @fe.Form(v=field, u=field, grad_v=True, grad_u=True)
-    def a(dv, du):
-        return fe.math.ddot(dv, du)
-
-    @fe.Form(v=field, kwargs=dict(coords=coords))
-    def L(v, coords):
-        x, y = coords
-        f = np.sin(np.pi * x) * np.sin(np.pi * y)
-        return f * v
-
-    for parallel in [False, True]:
-        for sym in [False, True]:
-            
-            options = dict(parallel=parallel, sym=sym)
-            L.assemble(**options)
-            L.assemble(kwargs=dict(coords=coords), **options)
-            L.assemble(args=(coords,), kwargs={}, **options)
-            L.assemble(**options)
-            
-            a.assemble(**options)
-            a.assemble(field, field, **options)
-            
-            L.integrate(**options)
-            L.integrate(kwargs=dict(coords=coords), **options)
-            
-            a.integrate(**options)
-            a.integrate(field, field, **options)
-    
-    with pytest.raises(TypeError):
-        L.assemble(v=mesh)
-    
-    with pytest.raises(TypeError):
-        a.assemble(v=mesh)
-    
-    with pytest.raises(TypeError):
-        a.assemble(v=field, u=None)
-
 if __name__ == "__main__":
     test_linearform()
     test_linearform_broadcast()
@@ -364,4 +317,3 @@ if __name__ == "__main__":
     test_bilinearform_broadcast()
     test_axi()
     test_mixed()
-    test_form_decorator()


### PR DESCRIPTION
introduce a new function decorator `@Form()`:

```python
import numpy as np
from felupe.math import ddot
import felupe as fem

mesh = fem.mesh.triangulate(fem.Rectangle(n=6))
region = fem.RegionTriangle(mesh)
field = fem.Field(region)
coords = fem.Field(
    region, dim=mesh.dim, values=mesh.points
).interpolate()

@fem.Form(v=field, u=field, grad_v=True, grad_u=True)
def a(dv, du):
    return ddot(dv, du)

@fem.Form(v=field)
def L(v, coords):
    x, y = coords
    f = np.sin(np.pi * x) * np.sin(np.pi * y)
    return f * v

L.assemble(v=field, kwargs={"coords": coords})
a.assemble(v=field, u=field)
```

fixes #207 