### PR TITLE
Enhance `newtonrhapson()`: Add `body` argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ All notable changes to this project will be documented in this file. The format 
 ### Added
 - Add `SolidBody.evaluate.kirchhoff_stress()` method. Contrary to the Cauchy stress method, this gives correct results in incompressible plane stress.
 - Add `SolidBodyTensor` for tensor-based material definitions with state variables.
+- Add `body` argument to `newtonrhapson()`.
 
 ### Fixed
 - Fix `tovoigt()` helper for data with more or less than two trailing axes and 2D tensors.

--- a/README.md
+++ b/README.md
@@ -28,11 +28,12 @@ region = fe.RegionHexahedron(fe.Cube(n=11))
 displacement = fe.Field(region, dim=3)
 boundaries, dof0, dof1, ext0 = fe.dof.uniaxial(displacement, move=0.2, clamped=True)
 
-# define the constitutive material behavior
+# define the constitutive material behavior and create a solid body
 umat = fe.NeoHooke(mu=1.0, bulk=2.0)
+solid = fe.SolidBody(umat, displacement)
 
 # newton-rhapson procedure
-res = fe.newtonrhapson(displacement, umat=umat, dof1=dof1, dof0=dof0, ext0=ext0)
+res = fe.newtonrhapson(body=body, dof1=dof1, dof0=dof0, ext0=ext0)
 
 # save result
 fe.save(region, res.x, filename="result.vtk")

--- a/felupe/tools/_newton.py
+++ b/felupe/tools/_newton.py
@@ -129,7 +129,7 @@ def check(dx, x, f, tol):
 
 
 def newtonrhapson(
-    x0,
+    x0=None,
     fun=fun,
     jac=jac,
     solve=solve,
@@ -184,9 +184,12 @@ def newtonrhapson(
     if timing:
         time_start = perf_counter()
 
-    # copy x0
-    x = x0
-    # x = deepcopy(x0)
+    if x0 is not None:
+        # copy x0
+        x = x0
+    else:
+        # copy field of body
+        x = body.field
 
     if umat is not None:
         kwargs["umat"] = umat

--- a/felupe/tools/_newton.py
+++ b/felupe/tools/_newton.py
@@ -46,6 +46,18 @@ class Result:
         self.iterations = iterations
 
 
+def fun_body(body, x=None, parallel=False, jit=False):
+    "Force residuals from assembly of equilibrium (weak form)."
+
+    return body.assemble.vector(field=x, parallel=parallel, jit=jit).toarray()[:, 0]
+
+
+def jac_body(body, parallel=False, jit=False):
+    "Tangent stiffness matrix from assembly of linearized equilibrium."
+
+    return body.assemble.matrix(parallel=parallel, jit=jit)
+
+
 def fun(x, umat, parallel=False, jit=False, grad=True, add_identity=True, sym=False):
     "Force residuals from assembly of equilibrium (weak form)."
 
@@ -130,6 +142,7 @@ def newtonrhapson(
     kwargs_check={},
     tol=np.sqrt(np.finfo(float).eps),
     umat=None,
+    body=None,
     dof1=None,
     dof0=None,
     offsets=None,
@@ -179,7 +192,10 @@ def newtonrhapson(
         kwargs["umat"] = umat
 
     # pre-evaluate function at given unknowns "x"
-    f = fun(x, *args, **kwargs)
+    if body is not None:
+        f = fun_body(body, x, *args, **kwargs)
+    else:
+        f = fun(x, *args, **kwargs)
 
     if verbose:
         print()
@@ -193,7 +209,10 @@ def newtonrhapson(
     for iteration in range(maxiter):
 
         # evaluate jacobian at unknowns "x"
-        K = jac(x, *args, **kwargs)
+        if body is not None:
+            K = jac_body(body, *args, **kwargs)
+        else:
+            K = jac(x, *args, **kwargs)
 
         # solve linear system and update solution
         sig = inspect.signature(solve)
@@ -210,7 +229,10 @@ def newtonrhapson(
         x = update(x, dx)
 
         # evaluate function at unknowns "x"
-        f = fun(x, *args, **kwargs)
+        if body is not None:
+            f = fun_body(body, x, *args, **kwargs)
+        else:
+            f = fun(x, *args, **kwargs)
 
         # check success of solution
         norm, success = check(dx, x, f, tol, **kwargs_check)

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -323,7 +323,7 @@ def test_newton_body():
 
     # newton-rhapson procedure
     res = fe.newtonrhapson(
-        x0=field, body=body, kwargs={}, dof1=dof1, dof0=dof0, ext0=ext0, offsets=offsets
+        body=body, kwargs={}, dof1=dof1, dof0=dof0, ext0=ext0, offsets=offsets
     )
 
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -225,6 +225,7 @@ def test_newton_plane():
         ext0=ext0,
         timing=True,
         verbose=True,
+        kwargs={},
     )
 
     # define the constitutive material behavior
@@ -239,6 +240,7 @@ def test_newton_plane():
         ext0=ext0,
         timing=True,
         verbose=True,
+        kwargs={},
     )
 
 
@@ -293,7 +295,35 @@ def test_newton_mixed():
 
     # newton-rhapson procedure
     res = fe.newtonrhapson(
-        x0=field, umat=umat, dof1=dof1, dof0=dof0, ext0=ext0, offsets=offsets
+        x0=field, umat=umat, kwargs={}, dof1=dof1, dof0=dof0, ext0=ext0, offsets=offsets
+    )
+
+
+def test_newton_body():
+
+    # create a hexahedron-region on a cube
+    mesh = fe.Cube(n=6)
+    region = fe.RegionHexahedron(mesh)
+    region0 = fe.RegionConstantHexahedron(fe.mesh.convert(mesh, 0))
+
+    # add a displacement field and apply a uniaxial elongation on the cube
+    u = fe.Field(region, dim=3)
+    p = fe.Field(region0)
+    J = fe.Field(region0, values=1)
+    field = fe.FieldMixed((u, p, J))
+
+    boundaries, dof0, dof1, offsets, ext0 = fe.dof.uniaxial(
+        field, move=0.2, clamped=True
+    )
+
+    # define the constitutive material behavior
+    nh = fe.NeoHooke(mu=1.0, bulk=2.0)
+    umat = fe.ThreeFieldVariation(nh)
+    body = fe.SolidBody(umat, field)
+
+    # newton-rhapson procedure
+    res = fe.newtonrhapson(
+        x0=field, body=body, kwargs={}, dof1=dof1, dof0=dof0, ext0=ext0, offsets=offsets
     )
 
 
@@ -305,3 +335,4 @@ if __name__ == "__main__":
     test_newton_mixed()
     test_newton_plane()
     test_newton_linearelastic()
+    test_newton_body()


### PR DESCRIPTION
This adds support for any solid body (e.g. `SolidBody`, `SolidBodyTensor` or `SolidBodyPressure`) with `body.assemble.vector()` and `body.assemble.matrix()` methods.

fixes #225 