### PR TITLE
Docs: Fix tutorial "shear"

### DIFF
--- a/felupe/tools/_post.py
+++ b/felupe/tools/_post.py
@@ -33,9 +33,9 @@ from scipy.sparse import issparse
 def force(field, r, boundary):
     if issparse(r):
         r = r.toarray()
-    return (((np.split(r, field.offsets)[0]).reshape(-1, field[0].dim))[boundary.points]).sum(
-        0
-    )
+    return (
+        ((np.split(r, field.offsets)[0]).reshape(-1, field[0].dim))[boundary.points]
+    ).sum(0)
 
 
 def moment(field, r, boundary, point=np.zeros(3)):

--- a/felupe/tools/_post.py
+++ b/felupe/tools/_post.py
@@ -30,15 +30,15 @@ from scipy.interpolate import interp1d
 from scipy.sparse import issparse
 
 
-def force(field, r, boundary, offsets=[]):
+def force(field, r, boundary):
     if issparse(r):
         r = r.toarray()
-    return (((np.split(r, offsets)[0]).reshape(-1, field[0].dim))[boundary.points]).sum(
+    return (((np.split(r, field.offsets)[0]).reshape(-1, field[0].dim))[boundary.points]).sum(
         0
     )
 
 
-def moment(field, r, boundary, point=np.zeros(3), offsets=[]):
+def moment(field, r, boundary, point=np.zeros(3)):
     if issparse(r):
         r = r.toarray()
     point = point.reshape(1, 3)
@@ -46,7 +46,7 @@ def moment(field, r, boundary, point=np.zeros(3), offsets=[]):
     indices = np.array([(1, 2), (2, 0), (0, 1)])
 
     displacements = field[0].values
-    force = (np.split(r, offsets)[0]).reshape(-1, 3)
+    force = (np.split(r, field.offsets)[0]).reshape(-1, 3)
 
     d = ((point + displacements) - point)[boundary.points]
     f = force[boundary.points]

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -138,8 +138,8 @@ def test_solve_mixed_check():
         gradient=W_mixed.gradient([F, p, J]),
     )
 
-    force = fe.tools.force(fields, b, bounds["symx"])
-    moment = fe.tools.moment(fields, b, bounds["symx"])
+    force = fe.tools.force(f, b, bounds["symx"])
+    moment = fe.tools.moment(f, b, bounds["symx"])
 
     for a in [2, 3, 4, 5]:
         curve = fe.tools.curve(np.arange(a), np.ones(a) * force[0])


### PR DESCRIPTION
fixes #234 

also removes `offsets` arguments from `tools.force()` and `tools.moment()` and use `field.offsets` instead.