### PR TITLE
Add `FieldPlaneStrain`

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ All notable changes to this project will be documented in this file. The format 
 - Support list of linked fields in Newton-Rhapson solver `newtonrhapson(fields=[field_1, field_2])`.
 - Automatic init of state variables in `SolidBodyTensor`.
 - Add `mesh.runouts()` for the creation of runouts of rubber-blocks of rubber-metal structures.
+- Add `FieldPlaneStrain` which is a 2d-field and returns gradients of shape `(3, 3)` (for plane strain problems with 3d user materials).
 
 ### Changed
 - Move `MultiPointConstraint` to mechanics module and unify handling with `SolidBody`.

--- a/felupe/_assembly/_base.py
+++ b/felupe/_assembly/_base.py
@@ -163,6 +163,9 @@ class IntegralForm:
         dV = self.dV
         fun = self.fun
 
+        if len(fun) > v.dim:
+            fun = fun[tuple([slice(v.dim)] * (len(fun.shape) - 2))]
+
         if parallel:
             einsum = einsumt
         else:

--- a/felupe/_assembly/_mixed.py
+++ b/felupe/_assembly/_mixed.py
@@ -30,6 +30,7 @@ from scipy.sparse import bmat, vstack
 
 from .._field._base import Field
 from .._field._axi import FieldAxisymmetric
+from .._field._planestrain import FieldPlaneStrain
 from ._base import IntegralForm
 from ._axi import IntegralFormAxisymmetric
 
@@ -49,9 +50,11 @@ class IntegralFormMixed:
             self.u = None
             self.nu = None
 
-        IntForm = {Field: IntegralForm, FieldAxisymmetric: IntegralFormAxisymmetric}[
-            type(self.v[0])
-        ]
+        IntForm = {
+            Field: IntegralForm,
+            FieldPlaneStrain: IntegralForm,
+            FieldAxisymmetric: IntegralFormAxisymmetric,
+        }[type(self.v[0])]
 
         if isinstance(self.v[0], FieldAxisymmetric):
             for i in range(1, len(self.v)):

--- a/felupe/_field/__init__.py
+++ b/felupe/_field/__init__.py
@@ -1,4 +1,5 @@
 from ._base import Field
 from ._axi import FieldAxisymmetric
+from ._planestrain import FieldPlaneStrain
 from ._container import FieldContainer
 from ._fields import FieldsMixed

--- a/felupe/_field/_fields.py
+++ b/felupe/_field/_fields.py
@@ -26,6 +26,7 @@ along with Felupe.  If not, see <http://www.gnu.org/licenses/>.
 
 from ._base import Field
 from ._axi import FieldAxisymmetric
+from ._planestrain import FieldPlaneStrain
 from ._container import FieldContainer
 from ..region._templates import (
     RegionQuad,
@@ -53,6 +54,7 @@ class FieldsMixed(FieldContainer):
         n=3,
         values=(0, 0, 1, 0),
         axisymmetric=False,
+        planestrain=False,
         offset=0,
         npoints=None,
     ):
@@ -72,6 +74,8 @@ class FieldsMixed(FieldContainer):
             Initial field values.
         axisymmetric : bool, optional
             Flag to initiate a axisymmetric Field (default is False).
+        planestrain : bool, optional
+            Flag to initiate a plane strain Field (default is False).
         offset : int, optional
             Offset for cell connectivity (default is 0).
         npoints : int, optional
@@ -97,7 +101,13 @@ class FieldsMixed(FieldContainer):
 
         region_dual = regions[type(region)](region.mesh, **kwargs)
 
-        F = [Field, FieldAxisymmetric][axisymmetric]
+        if axisymmetric is False and planestrain is False:
+            F = Field
+        elif axisymmetric is True and planestrain is False:
+            F = FieldAxisymmetric
+        elif axisymmetric is False and planestrain is True:
+            F = FieldPlaneStrain
+
         fields = [F(region, dim=region.mesh.dim, values=values[0])]
 
         for a in range(1, n):

--- a/felupe/_field/_planestrain.py
+++ b/felupe/_field/_planestrain.py
@@ -1,0 +1,156 @@
+# -*- coding: utf-8 -*-
+"""
+ _______  _______  ___      __   __  _______  _______ 
+|       ||       ||   |    |  | |  ||       ||       |
+|    ___||    ___||   |    |  | |  ||    _  ||    ___|
+|   |___ |   |___ |   |    |  |_|  ||   |_| ||   |___ 
+|    ___||    ___||   |___ |       ||    ___||    ___|
+|   |    |   |___ |       ||       ||   |    |   |___ 
+|___|    |_______||_______||_______||___|    |_______|
+
+This file is part of felupe.
+
+Felupe is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Felupe is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Felupe.  If not, see <http://www.gnu.org/licenses/>.
+
+"""
+
+import numpy as np
+from ._base import Field
+from ..math import sym as symmetric
+
+
+class FieldPlaneStrain(Field):
+    r"""A plane strain Field on points of a two-dimensional
+    `region` with dimension `dim` (default is 2) and initial point
+    `values` (default is 0).
+
+    This is a modified :class:`Field` class in which the radial coordinates
+    are evaluated at the numeric integration points. The :meth:`grad`-method is
+    modified in such a way that it does not only contain the in-plane
+    2d-gradient but also the circumferential stretch as shown in Eq.(1).
+
+    ..  code-block::
+
+                            |  dudX(2d) :   0   |
+        dudX(planestrain) = | ..................|                  (1)
+                            |     0     :   0   |
+
+    Attributes
+    ----------
+    region : Region
+        The region on which the field will be created.
+    dim : int (default is 2)
+        The dimension of the field.
+    values : float (default is 0.0) or array
+        A single value for all components of the field or an array of
+        shape (region.mesh.npoints, dim)`.
+
+    """
+
+    def __init__(self, region, dim=2, values=0):
+        """A plane strain Field on points of a two-dimensional
+        `region` with dimension `dim` (default is 2) and initial point
+        `values` (default is 0).
+
+        Attributes
+        ----------
+        region : Region
+            The region on which the field will be created.
+        dim : int (default is 2)
+            The dimension of the field.
+        values : float (default is 0.0) or array
+            A single value for all components of the field or an array of
+            shape (region.mesh.npoints, dim)`.
+        """
+
+        # init base Field
+        super().__init__(region, dim=dim, values=values)
+
+    def _interpolate_2d(self):
+        """Interpolate 2D field values at points and evaluate them at the
+        integration points of all cells in the region."""
+
+        # interpolated field values "aI"
+        # evaluated at quadrature point "p"
+        # for cell "c"
+        return np.einsum(
+            "ca...,apc->...pc", self.values[self.region.mesh.cells], self.region.h
+        )
+
+    def interpolate(self):
+        # extend dimension of in-plane 2d-gradient
+        return np.pad(self._interpolate_2d(), ((0, 1), (0, 0), (0, 0)))
+
+    def _grad_2d(self, sym=False):
+        """In-plane 2D gradient as partial derivative of field values at points
+        w.r.t. the undeformed coordinates, evaluated at the integration points
+        of all cells in the region. Optionally, the symmetric part of the
+        gradient is returned.
+
+        Arguments
+        ---------
+        sym : bool, optional (default is False)
+            Calculate the symmetric part of the gradient.
+
+        Returns
+        -------
+        array
+            In-plane 2D-gradient as partial derivative of field values at points
+            w.r.t. undeformed coordinates, evaluated at the integration points
+            of all cells in the region.
+        """
+
+        # gradient as partial derivative of field component "I" at point "a"
+        # w.r.t. undeformed coordinate "J" evaluated at quadrature point "p"
+        # for each cell "e"
+        g = np.einsum(
+            "ca...,aJpc->...Jpc",
+            self.values[self.region.mesh.cells],
+            self.region.dhdX,
+        )
+
+        if sym:
+            return symmetric(g)
+        else:
+            return g
+
+    def grad(self, sym=False):
+        """3D-gradient as partial derivative of field values at points w.r.t.
+        the undeformed coordinates, evaluated at the integration points of all
+        cells in the region. Optionally, the symmetric part of the gradient is
+        returned.
+
+        ..  code-block::
+
+                                |  dudX(2d) :   0   |
+            dudX(planestrain) = | ..................|
+                                |     0     :   0   |
+
+        Arguments
+        ---------
+        sym : bool, optional (default is False)
+            Calculate the symmetric part of the gradient.
+
+        Returns
+        -------
+        array
+            Full 3D-gradient as partial derivative of field values at points
+            w.r.t. undeformed coordinates, evaluated at the integration points
+            of all cells in the region.
+        """
+
+        # extend dimension of in-plane 2d-gradient
+        g = np.pad(self._grad_2d(sym=sym), ((0, 1), (0, 1), (0, 0), (0, 0)))
+
+        return g

--- a/tests/test_planestrain.py
+++ b/tests/test_planestrain.py
@@ -29,6 +29,25 @@ import felupe as fem
 import pytest
 
 
+def test_axi():
+
+    m = fem.Rectangle(n=6)
+    r = fem.RegionQuad(m)
+    f = fem.FieldsMixed(r, n=1, axisymmetric=True)
+    u = fem.NeoHooke(mu=1, bulk=2)
+    b = fem.SolidBody(u, f)
+    loadcase = fem.dof.uniaxial(f, clamped=True)[-1]
+    res = fem.newtonrhapson(items=[b], **loadcase)
+    
+    u = f[0].interpolate()
+    strain = f[0].grad(sym=True)
+    
+    assert len(u) == 3
+    assert strain.shape[:-2] == (3, 3)
+
+    assert res.success
+
+
 def test_planestrain():
 
     m = fem.Rectangle(n=6)
@@ -38,6 +57,12 @@ def test_planestrain():
     b = fem.SolidBody(u, f)
     loadcase = fem.dof.uniaxial(f, clamped=True)[-1]
     res = fem.newtonrhapson(items=[b], **loadcase)
+    
+    u = f[0].interpolate()
+    strain = f[0].grad(sym=True)
+    
+    assert len(u) == 3
+    assert strain.shape[:-2] == (3, 3)
 
     assert res.success
 
@@ -51,10 +76,17 @@ def test_planestrain_mixed():
     b = fem.SolidBody(u, f)
     loadcase = fem.dof.uniaxial(f, clamped=True)[-1]
     res = fem.newtonrhapson(items=[b], **loadcase)
+    
+    u = f[0].interpolate()
+    strain = f[0].grad(sym=True)
+    
+    assert len(u) == 3
+    assert strain.shape[:-2] == (3, 3)
 
     assert res.success
 
 
 if __name__ == "__main__":
+    test_axi()
     test_planestrain()
     test_planestrain_mixed()

--- a/tests/test_planestrain.py
+++ b/tests/test_planestrain.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+"""
+ _______  _______  ___      __   __  _______  _______ 
+|       ||       ||   |    |  | |  ||       ||       |
+|    ___||    ___||   |    |  | |  ||    _  ||    ___|
+|   |___ |   |___ |   |    |  |_|  ||   |_| ||   |___ 
+|    ___||    ___||   |___ |       ||    ___||    ___|
+|   |    |   |___ |       ||       ||   |    |   |___ 
+|___|    |_______||_______||_______||___|    |_______|
+
+This file is part of felupe.
+
+Felupe is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Felupe is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Felupe.  If not, see <http://www.gnu.org/licenses/>.
+
+"""
+
+import felupe as fem
+import pytest
+
+
+def test_planestrain():
+
+    m = fem.Rectangle(n=6)
+    r = fem.RegionQuad(m)
+    f = fem.FieldsMixed(r, n=1, planestrain=True)
+    u = fem.NeoHooke(mu=1, bulk=2)
+    b = fem.SolidBody(u, f)
+    loadcase = fem.dof.uniaxial(f, clamped=True)[-1]
+    res = fem.newtonrhapson(items=[b], **loadcase)
+
+    assert res.success
+
+
+def test_planestrain_mixed():
+
+    m = fem.Rectangle(n=6)
+    r = fem.RegionQuad(m)
+    f = fem.FieldsMixed(r, n=3, planestrain=True)
+    u = fem.ThreeFieldVariation(fem.NeoHooke(mu=1, bulk=5000))
+    b = fem.SolidBody(u, f)
+    loadcase = fem.dof.uniaxial(f, clamped=True)[-1]
+    res = fem.newtonrhapson(items=[b], **loadcase)
+
+    assert res.success
+
+
+if __name__ == "__main__":
+    test_planestrain()
+    test_planestrain_mixed()


### PR DESCRIPTION
fixes #256 

Example usage:

```python
import felupe as fem

m = fem.Rectangle(n=6)
r = fem.RegionQuad(m)
f = fem.FieldsMixed(r, n=3, planestrain=True)
u = fem.ThreeFieldVariation(fem.NeoHooke(mu=1, bulk=5000))
b = fem.SolidBody(u, f)
loadcase = fem.dof.uniaxial(f, clamped=True)[-1]
res = fem.newtonrhapson(items=[b], **loadcase)
```