### PR TITLE
Add `job.evaluate(x0=field)`

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ All notable changes to this project will be documented in this file. The format 
 - Add `xscale` and `yscale` arguments to `CharacteristicCurve.plot()`.
 - Add `mesh.Grid(*xi)` as generalized line, rectangle or cube with custom linspaces.
 - Add `mesh.concatante(meshes)` to join a sequence of meshes with identical cell types.
+- Add `x0`-Argument to `Job.evaluate(x0=field)`.
 
 ## [5.1.0] - 2022-09-09
 

--- a/felupe/mechanics/_step.py
+++ b/felupe/mechanics/_step.py
@@ -48,7 +48,11 @@ class Step:
         "Generate all substeps."
 
         substeps = np.arange(self.nsubsteps)
-        field = self.items[0].field
+        
+        if not "x0" in kwargs.keys():
+            field = self.items[0].field
+        else:
+            field = kwargs["x0"]
 
         stop = False
         for substep in substeps:

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -38,20 +38,23 @@ def pre():
         boundaries=bounds,
     )
 
-    return step
+    return field, step
 
 
 def test_job():
 
-    step = pre()
-
+    field, step = pre()
     job = fem.Job(steps=[step])
     job.evaluate()
+    
+    field, step = pre()
+    job = fem.Job(steps=[step])
+    job.evaluate(x0=field)
 
 
 def test_curve():
 
-    step = pre()
+    field, step = pre()
 
     curve = fem.CharacteristicCurve(steps=[step], boundary=step.boundaries["move"])
     curve.plot(xaxis=0, yaxis=0)
@@ -65,7 +68,7 @@ def test_curve():
 
 def test_curve2():
 
-    step = pre()
+    field, step = pre()
 
     curve = fem.CharacteristicCurve(steps=[step], boundary=step.boundaries["move"])
     curve.evaluate()


### PR DESCRIPTION
For more than one solid body in `items=[body1, body2, ...]` it is necessary to use a global `field`, which must be passed as `job.evaluate(x0=field)`.

fixes #285 