### PR TITLE
Fix ignored surface mask for `cells_faces` of `RegionBoundary`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file. The format 
 
 ### Fixed
 - Fix missing `ArbitraryOrderLagrangeElement.points` attribute.
+- Fix ignored mask `only_surface=True` for `RegionBoundary().mesh.cells_faces`.
 
 ## [5.2.0] - 2022-10-08
 

--- a/felupe/region/_boundary.py
+++ b/felupe/region/_boundary.py
@@ -206,12 +206,12 @@ class RegionBoundary(Region):
 
         # get cell-faces and cells on boundary (unique cell-faces with one count)
         cells_on_boundary = cells[self._selection]
-
+        
         ## create mesh on boundary
         mesh_boundary = mesh.copy()
         mesh_boundary.update(cells_on_boundary)
         self.mesh = mesh_boundary
-        self.mesh.cells_faces = cells_faces
+        self.mesh.cells_faces = cells_faces[self._selection]
 
         # init region and faces
         super().__init__(mesh_boundary, element, quadrature, grad=grad)


### PR DESCRIPTION
fixes #306 