### PR TITLE
Add `MeshContainer` and string-representation for `Mesh` objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file. The format 
 
 ### Added
 - Add optional pre-compression to shear-loadcase `dof.shear(compression=0.0)`.
+Add `MeshContainer` and string-representation for `Mesh` objects.
 
 ### Fixed
 - Fix missing `ArbitraryOrderLagrangeElement.points` attribute.

--- a/felupe/__init__.py
+++ b/felupe/__init__.py
@@ -80,6 +80,7 @@ from .quadrature import (
 )
 from .mesh import (
     Mesh,
+    MeshContainer,
     Rectangle,
     Cube,
     Grid,

--- a/felupe/mesh/__init__.py
+++ b/felupe/mesh/__init__.py
@@ -1,4 +1,5 @@
 from ._mesh import Mesh
+from ._container import MeshContainer
 from ._tools import (
     expand,
     rotate,

--- a/felupe/mesh/_container.py
+++ b/felupe/mesh/_container.py
@@ -1,0 +1,142 @@
+# -*- coding: utf-8 -*-
+"""
+ _______  _______  ___      __   __  _______  _______ 
+|       ||       ||   |    |  | |  ||       ||       |
+|    ___||    ___||   |    |  | |  ||    _  ||    ___|
+|   |___ |   |___ |   |    |  |_|  ||   |_| ||   |___ 
+|    ___||    ___||   |___ |       ||    ___||    ___|
+|   |    |   |___ |       ||       ||   |    |   |___ 
+|___|    |_______||_______||_______||___|    |_______|
+
+This file is part of felupe.
+
+Felupe is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Felupe is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Felupe.  If not, see <http://www.gnu.org/licenses/>.
+
+"""
+
+from copy import deepcopy
+import numpy as np
+
+from ._mesh import Mesh
+from ._tools import sweep
+
+
+class MeshContainer:
+    """A container which operates on a list of meshes with identical
+    dimensions.
+
+    Parameters
+    ----------
+    meshes : [felupe.Mesh, ...]
+        A list with meshes.
+
+    Attributes
+    ----------
+    dim : int
+        The (identical) dimension of all underlying meshes.
+    points : ndarray
+        Point coordinates.
+    meshes : [felupe.Mesh, ...]
+        A list with meshes.
+    """
+
+    def __init__(self, meshes, merge=False, decimals=None):
+        """A container which operates on a list of meshes with identical
+        dimensions."""
+
+        # obtain the dimension from the first mesh
+        self.dim = meshes[0].dim
+
+        # init points and list of meshes
+        self.points = np.zeros((0, self.dim))
+        self.meshes = []
+
+        # append all meshes
+        [self.append(mesh) for mesh in meshes]
+
+        if merge:
+            self.merge_duplicate_points(decimals=decimals)
+
+    def append(self, mesh):
+        "Append a Mesh to the list of meshes."
+
+        # number of points
+        points = np.vstack([self.points, mesh.points])
+        self.meshes.append(Mesh(points, mesh.cells + len(self.points), mesh.cell_type))
+
+        # ensure identical points-arrays
+        for i, m in enumerate(self.meshes):
+            self.meshes[i].points = self.points = points
+
+    def pop(self, index):
+        "Pop an item of the list of meshes."
+        item = self.meshes.pop(index)
+        return item
+
+    def cells(self):
+        "Return a list of tuples with cell-types and cell-connectivities."
+        return [(mesh.cell_type, mesh.cells) for mesh in self.meshes]
+
+    def merge_duplicate_points(self, decimals=None):
+        "Merge duplicate points and update meshes."
+
+        # sweep points
+        for i, mesh in enumerate(self.meshes):
+            self.meshes[i] = sweep(mesh, decimals=decimals)
+
+        # ensure identical points-arrays
+        points = self.meshes[0].points
+        for i, m in enumerate(self.meshes):
+            self.meshes[i].points = self.points = points
+
+    def as_meshio(self, **kwargs):
+        "Export a combined mesh object as ``meshio.Mesh``."
+
+        import meshio
+
+        cells = {}
+
+        # combine cell-blocks
+        for mesh in self.meshes:
+            if mesh.cell_type not in cells.keys():
+                cells[mesh.cell_type] = mesh.cells
+            else:
+                cells[mesh.cell_type] = np.vstack([cells[mesh.cell_type], mesh.cells])
+
+        return meshio.Mesh(self.points, cells, **kwargs)
+
+    def copy(self):
+        "Return a deepcopy of the mesh container."
+        return deepcopy(self)
+
+    def __iadd__(self, mesh):
+        self.append(mesh)
+        return self
+
+    def __getitem__(self, index):
+        return self.meshes[index]
+
+    def __repr__(self):
+        header = "<felupe mesh container object>"
+        points = f"  Number of points: {len(self.points)}"
+        cells_header = "  Number of cells:"
+        cells = []
+
+        for cells_type, cells_data in self.cells():
+            cells.append(f"    {cells_type}: {len(cells_data)}")
+
+        return "\n".join([header, points, cells_header, *cells])
+
+    def __str__(self):
+        return self.__repr__()

--- a/felupe/mesh/_mesh.py
+++ b/felupe/mesh/_mesh.py
@@ -108,14 +108,7 @@ class Mesh:
         return Mesh(points, cells, cell_type=self.cell_type)
 
     def as_meshio(self, **kwargs):
-        """Export the mesh as ``meshio.Mesh``.
-
-        Parameters
-        ----------
-        filename : str, optional
-            The filename of the mesh (default is ``mesh.vtk``).
-
-        """
+        "Export the mesh as ``meshio.Mesh``."
 
         import meshio
 
@@ -146,3 +139,14 @@ class Mesh:
         """
 
         return deepcopy(self)
+
+    def __repr__(self):
+        header = "<felupe mesh object>"
+        points = f"  Number of points: {len(self.points)}"
+        cells_header = "  Number of cells:"
+        cells = [f"    {self.cell_type}: {self.ncells}"]
+
+        return "\n".join([header, points, cells_header, *cells])
+
+    def __str__(self):
+        return self.__repr__()

--- a/felupe/region/_boundary.py
+++ b/felupe/region/_boundary.py
@@ -206,7 +206,7 @@ class RegionBoundary(Region):
 
         # get cell-faces and cells on boundary (unique cell-faces with one count)
         cells_on_boundary = cells[self._selection]
-        
+
         ## create mesh on boundary
         mesh_boundary = mesh.copy()
         mesh_boundary.update(cells_on_boundary)

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -317,6 +317,7 @@ def test_container():
     print(container.copy())
     
     container += mesh_1
+    container[2]
 
 
 if __name__ == "__main__":

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -315,6 +315,8 @@ def test_container():
     assert len(container.cells()) == 2
 
     print(container.copy())
+    
+    container += mesh_1
 
 
 if __name__ == "__main__":

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -289,6 +289,34 @@ def test_grid_1d():
     assert np.allclose(m.cells, n.cells)
 
 
+def test_container():
+
+    mesh_1 = fe.Rectangle()
+    mesh_2 = fe.Rectangle(a=(1, 0), b=(2, 1))
+    mesh_3 = fe.mesh.triangulate(fe.Rectangle(a=(2, 0), b=(3, 1)))
+
+    for merge in [False, True]:
+        container = fe.MeshContainer([mesh_1, mesh_2], merge=merge)
+
+    mesh_1
+    container
+
+    print(mesh_1)
+    print(container)
+
+    assert container.points.shape[1] == container.dim
+
+    container.append(mesh_3)
+    print(container.as_meshio())
+
+    m_1 = container.pop(0)
+
+    assert m_1.ncells == 1
+    assert len(container.cells()) == 2
+
+    print(container.copy())
+
+
 if __name__ == "__main__":
     test_meshes()
     test_mirror()
@@ -297,3 +325,4 @@ if __name__ == "__main__":
     test_concatenate()
     test_grid()
     test_grid_1d()
+    test_container()


### PR DESCRIPTION
Similar to a field container, but which operates on a list of meshes (with identical dimensions of the point arrays). This should simplify the definition of meshes/regions/fields with more than one solid body.

fixes #310

fixes #311