### PR TITLE
Enhance Mesh-Container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,10 @@ All notable changes to this project will be documented in this file. The format 
 
 ### Added
 - Add optional pre-compression to shear-loadcase `dof.shear(compression=0.0)`.
-Add `MeshContainer` and string-representation for `Mesh` objects.
+- Add `MeshContainer` and string-representation for `Mesh` objects.
+
+### Changed
+- Support an optional user-defined meshio-object in `Job().evaluate(mesh=None, filename="result.xdmf")`.
 
 ### Fixed
 - Fix missing `ArbitraryOrderLagrangeElement.points` attribute.

--- a/felupe/mechanics/_job.py
+++ b/felupe/mechanics/_job.py
@@ -85,6 +85,7 @@ class Job:
     def evaluate(
         self,
         filename=None,
+        mesh=None,
         point_data={"Displacement": displacement},
         cell_data={
             "Principal Values of Logarithmic Strain": log_strain_principal,
@@ -116,7 +117,9 @@ FElupe Version {version}
         if filename is not None:
             from meshio.xdmf import TimeSeriesWriter
 
-            mesh = self.steps[0].items[0].field.region.mesh.as_meshio()
+            if mesh is None:
+                mesh = self.steps[0].items[0].field.region.mesh.as_meshio()
+
             increment = 0
 
         else:  # fake a mesh and a TimeSeriesWriter

--- a/felupe/mesh/_container.py
+++ b/felupe/mesh/_container.py
@@ -100,19 +100,25 @@ class MeshContainer:
         for i, m in enumerate(self.meshes):
             self.meshes[i].points = self.points = points
 
-    def as_meshio(self, **kwargs):
-        "Export a combined mesh object as ``meshio.Mesh``."
+    def as_meshio(self, combined=True, **kwargs):
+        "Export a (combined) mesh object as ``meshio.Mesh``."
 
         import meshio
 
-        cells = {}
+        if not combined:
+            cells = [
+                meshio.CellBlock(cell_type, data) for cell_type, data in self.cells()
+            ]
 
-        # combine cell-blocks
-        for mesh in self.meshes:
-            if mesh.cell_type not in cells.keys():
-                cells[mesh.cell_type] = mesh.cells
-            else:
-                cells[mesh.cell_type] = np.vstack([cells[mesh.cell_type], mesh.cells])
+        else:
+            cells = {}
+            for mesh in self.meshes:
+                if mesh.cell_type not in cells.keys():
+                    cells[mesh.cell_type] = mesh.cells
+                else:
+                    cells[mesh.cell_type] = np.vstack(
+                        [cells[mesh.cell_type], mesh.cells]
+                    )
 
         return meshio.Mesh(self.points, cells, **kwargs)
 

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -315,9 +315,12 @@ def test_container():
     assert len(container.cells()) == 2
 
     print(container.copy())
-    
+
     container += mesh_1
     container[2]
+
+    for combined in [False, True]:
+        print(container.as_meshio(combined=combined))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This enables a new readme example:

```python
import felupe as fem

# create numeric regions on all meshes of a mesh-container (with two cubes)
mesh = fem.MeshContainer([
    fem.Cube(n=11), # elastic-block
    fem.Cube(a=(1, 0, 0), b=(1.1, 1, 1), n=(2, 11, 11)), # end-plate
], merge=True) # merge duplicate points
regions = [fem.RegionHexahedron(m) for m in mesh]

# add a mixed field container (with displacement, pressure and volume ratio)
block = fem.FieldsMixed(regions[0], n=3, values=(0, 0, 1))

# add another displacement field for the end-plate
plate = fem.FieldContainer([fem.Field(regions[1], dim=3)])

# apply a uniaxial elongation on the cube
boundaries = fem.dof.uniaxial(block, right=1.1, clamped=True)[0]

# define the constitutive material behaviour
neo_hooke = fem.ThreeFieldVariation(fem.NeoHooke(mu=1, bulk=5000))
linear_elastic = fem.LinearElastic(E=21000, nu=0.3)

# create solid bodies
rubber = fem.SolidBody(umat=neo_hooke, field=block)
steel = fem.SolidBody(umat=linear_elastic, field=plate)

# prepare a step with substeps
move = fem.math.linsteps([0, 1, -0.2, 0], num=10)
step = fem.Step(
    items=[rubber, steel], 
    ramp={boundaries["move"]: move}, 
    boundaries=boundaries
)

# add the step to a job, evaluate all substeps, create a plot and 
# export the mesh (only the mesh associated to the field of the first item)
job = fem.CharacteristicCurve(steps=[step], boundary=boundaries["move"])
job.evaluate(filename="result.xdmf")
fig, ax = job.plot(
    xlabel="Displacement $u$ in mm $\longrightarrow$",
    ylabel="Normal Force $F$ in N $\longrightarrow$",
)
```

Note that the XDMF-files only contains the mesh of the first field.

![grafik](https://user-images.githubusercontent.com/5793153/197637560-dafdd5af-3c02-413c-b87d-1c32934a95bb.png)
