### PR TITLE
`job.evaluate(x0=...)`: Take mesh from global field `x0` if present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file. The format 
 - Fix missing `ArbitraryOrderLagrangeElement.points` attribute.
 - Fix ignored mask `only_surface=True` for `RegionBoundary().mesh.cells_faces`.
 - Set default pressure to zero in `SolidBodyPressure()`.
+- Take the mesh from the global `x0`-field if `x0` is passed to `job.evaluate(x0=...)`.
 
 ## [5.2.0] - 2022-10-08
 

--- a/felupe/mechanics/_job.py
+++ b/felupe/mechanics/_job.py
@@ -118,7 +118,10 @@ FElupe Version {version}
             from meshio.xdmf import TimeSeriesWriter
 
             if mesh is None:
-                mesh = self.steps[0].items[0].field.region.mesh.as_meshio()
+                if "x0" in kwargs.keys():
+                    mesh = kwargs["x0"].region.mesh.as_meshio()
+                else:
+                    mesh = self.steps[0].items[0].field.region.mesh.as_meshio()
 
             increment = 0
 

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -60,7 +60,19 @@ def test_job_xdmf():
 
     field, step = pre()
     job = fem.Job(steps=[step])
+    job.evaluate(filename="result.xdmf")
+    
+
+def test_job_xdmf_global_field():
+
+    field, step = pre()
+    job = fem.Job(steps=[step])
+    job.evaluate()
+
+    field, step = pre()
+    job = fem.Job(steps=[step])
     job.evaluate(filename="result.xdmf", x0=field)
+
 
 
 def test_curve():
@@ -95,5 +107,6 @@ def test_curve2():
 if __name__ == "__main__":
     test_job()
     test_job_xdmf()
+    test_job_xdmf_global_field()
     test_curve()
     test_curve2()

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -61,7 +61,7 @@ def test_job_xdmf():
     field, step = pre()
     job = fem.Job(steps=[step])
     job.evaluate(filename="result.xdmf")
-    
+
 
 def test_job_xdmf_global_field():
 
@@ -72,7 +72,6 @@ def test_job_xdmf_global_field():
     field, step = pre()
     job = fem.Job(steps=[step])
     job.evaluate(filename="result.xdmf", x0=field)
-
 
 
 def test_curve():

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -49,7 +49,7 @@ def test_job():
 
     field, step = pre()
     job = fem.Job(steps=[step])
-    job.evaluate(x0=field)
+    job.evaluate()
 
 
 def test_job_xdmf():


### PR DESCRIPTION
fixes #319. Before, the cell connectivity is mixed up if a global field `x0` is given. Hence, displacement/strain output was wrong.