### PR TITLE
Add `SolidBodyNearlyIncompressible(umat, field, bulk)`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,11 @@ All notable changes to this project will be documented in this file. The format 
 - Add optional pre-compression to shear-loadcase `dof.shear(compression=0.0)`.
 - Add `MeshContainer` and string-representation for `Mesh` objects.
 - Add a mesh-reader using meshio `mesh.read(filename, ...)`.
+- Add `SolidBodyNearlyIncompressible(umat, field, bulk)` for (nearly) incompressible solids and a given (distortional-part only) constitutive material formulation. This is a pure displacement-based alternative to the three-field-formulation technique.
 
 ### Changed
 - Support an optional user-defined meshio-object in `Job().evaluate(mesh=None, filename="result.xdmf")`.
+- Support a distortional-part only Neo-Hookean material formulation with no bulk modulus defined `NeoHooke(mu=1.0)`.
 
 ### Fixed
 - Fix missing `ArbitraryOrderLagrangeElement.points` attribute.

--- a/felupe/__init__.py
+++ b/felupe/__init__.py
@@ -103,7 +103,7 @@ from .tools import (
 )
 from .mechanics import (
     SolidBody,
-    SolidBodyIncompressible,
+    SolidBodyNearlyIncompressible,
     SolidBodyPressure,
     SolidBodyTensor,
     SolidBodyGravity,

--- a/felupe/__init__.py
+++ b/felupe/__init__.py
@@ -104,6 +104,7 @@ from .tools import (
 from .mechanics import (
     SolidBody,
     SolidBodyNearlyIncompressible,
+    StateNearlyIncompressible,
     SolidBodyPressure,
     SolidBodyTensor,
     SolidBodyGravity,

--- a/felupe/__init__.py
+++ b/felupe/__init__.py
@@ -103,6 +103,7 @@ from .tools import (
 )
 from .mechanics import (
     SolidBody,
+    SolidBodyIncompressible,
     SolidBodyPressure,
     SolidBodyTensor,
     SolidBodyGravity,

--- a/felupe/mechanics/__init__.py
+++ b/felupe/mechanics/__init__.py
@@ -1,4 +1,5 @@
 from ._solidbody import SolidBody
+from ._solidbody_incompressible import SolidBodyIncompressible
 from ._solidbody_pressure import SolidBodyPressure
 from ._solidbody_tensor import SolidBodyTensor
 from ._solidbody_gravity import SolidBodyGravity

--- a/felupe/mechanics/__init__.py
+++ b/felupe/mechanics/__init__.py
@@ -1,5 +1,5 @@
 from ._solidbody import SolidBody
-from ._solidbody_incompressible import SolidBodyIncompressible
+from ._solidbody_incompressible import SolidBodyNearlyIncompressible
 from ._solidbody_pressure import SolidBodyPressure
 from ._solidbody_tensor import SolidBodyTensor
 from ._solidbody_gravity import SolidBodyGravity

--- a/felupe/mechanics/__init__.py
+++ b/felupe/mechanics/__init__.py
@@ -1,5 +1,8 @@
 from ._solidbody import SolidBody
-from ._solidbody_incompressible import SolidBodyNearlyIncompressible
+from ._solidbody_incompressible import (
+    SolidBodyNearlyIncompressible,
+    StateNearlyIncompressible,
+)
 from ._solidbody_pressure import SolidBodyPressure
 from ._solidbody_tensor import SolidBodyTensor
 from ._solidbody_gravity import SolidBodyGravity

--- a/felupe/mechanics/_solidbody_incompressible.py
+++ b/felupe/mechanics/_solidbody_incompressible.py
@@ -33,7 +33,7 @@ from ..math import dot, transpose, det, dya, ddot
 from ._helpers import Assemble, Evaluate, Results
 
 
-class State:
+class StateNearlyIncompressible:
     "A State with internal fields for (nearly) incompressible solid bodies."
 
     def __init__(self, field):
@@ -82,7 +82,8 @@ class SolidBodyNearlyIncompressible:
         self.results = Results(stress=True, elasticity=True)
 
         if state is None:
-            self.results.state = State(field)  # init state of internal fields
+            # init state of internal fields
+            self.results.state = StateNearlyIncompressible(field)
         else:
             self.results.state = state
 

--- a/felupe/mechanics/_solidbody_incompressible.py
+++ b/felupe/mechanics/_solidbody_incompressible.py
@@ -1,0 +1,205 @@
+# -*- coding: utf-8 -*-
+"""
+ _______  _______  ___      __   __  _______  _______ 
+|       ||       ||   |    |  | |  ||       ||       |
+|    ___||    ___||   |    |  | |  ||    _  ||    ___|
+|   |___ |   |___ |   |    |  |_|  ||   |_| ||   |___ 
+|    ___||    ___||   |___ |       ||    ___||    ___|
+|   |    |   |___ |       ||       ||   |    |   |___ 
+|___|    |_______||_______||_______||___|    |_______|
+
+This file is part of felupe.
+
+Felupe is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Felupe is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Felupe.  If not, see <http://www.gnu.org/licenses/>.
+
+"""
+
+import numpy as np
+
+from .._field import Field
+from .._assembly import IntegralFormMixed
+from ..constitution import VolumeChange
+from ..math import dot, transpose, det, dya, ddot, identity
+from ._helpers import Assemble, Evaluate, Results
+
+
+class SolidBodyIncompressible:
+    """A (nearly) incompressible SolidBody with methods for the assembly of 
+    sparse vectors/matrices."""
+
+    def __init__(self, umat, field, bulk):
+
+        self.umat = umat
+        self.field = field
+        self.bulk = bulk
+        
+        self._volume_change = VolumeChange()
+        self._form = IntegralFormMixed
+        
+        # internal state variables
+        self.p = np.zeros(self.field.region.mesh.ncells)
+        self.J = np.ones(self.field.region.mesh.ncells)
+        self.dp = np.zeros_like(self.p)
+        self.dJ = np.zeros_like(self.J)
+        
+        # volume of undeformed configuration
+        self.V = self.field.region.dV.sum(0)
+        
+        self.results = Results(stress=True, elasticity=True)
+        self.results.kinematics = self._extract(self.field)
+
+        self.assemble = Assemble(vector=self._vector, matrix=self._matrix)
+
+        self.evaluate = Evaluate(
+            gradient=self._gradient,
+            hessian=self._hessian,
+            cauchy_stress=self._cauchy_stress,
+            kirchhoff_stress=self._kirchhoff_stress,
+        )
+
+    def _vector(
+        self, field=None, parallel=False, jit=False, items=None, args=(), kwargs={}
+    ):
+
+        if field is not None:
+            self.field = field
+
+        self.results.stress = self._gradient(field, args=args, kwargs=kwargs)
+        
+        form = self._form(
+            fun=self.results.stress,
+            v=self.field,
+            dV=self.field.region.dV,
+        )
+        
+        r = [
+            form.integrate(parallel=parallel, jit=jit)[0] + self.H * self.p
+            + self.H * self.bulk * (self.J - self.v / self.V)
+            + self.H * (self.p - self.bulk * (self.J - 1))
+        ]
+    
+        self.results.force = form.assemble(values=r, parallel=parallel, jit=jit)
+        
+        return self.results.force
+
+    def _matrix(
+        self, field=None, parallel=False, jit=False, items=None, args=(), kwargs={}
+    ):
+
+        if field is not None:
+            self.field = field
+
+        self.results.elasticity = self._hessian(field, args=args, kwargs=kwargs)
+
+        fun = [
+            self.results.elasticity[0] 
+            + self.p * self._volume_change.hessian(self.results.kinematics)[0]
+        ]
+        
+        form = self._form(
+            fun=fun,
+            v=self.field,
+            u=self.field,
+            dV=self.field.region.dV,
+        )
+        
+        K = [
+            form.integrate(parallel=parallel, jit=jit)[0]
+            + self.bulk / self.V * dya(self.H, self.H)
+        ]
+    
+        self.results.stiffness = form.assemble(values=K, parallel=parallel, jit=jit)
+
+        return self.results.stiffness
+
+    def _extract(self, field, parallel=False, jit=False):
+        
+        # change of displacement field
+        self.du = Field(
+            region=self.field.region,
+            dim=self.field[0].dim,
+            values=field[0].values - self.field[0].values,
+        ).extract(grad=False).transpose([1, 0, 2])
+        
+        self.field = field
+        self.results.kinematics = self.field.extract()
+        
+        self.H = self._form(
+            fun=self._volume_change.gradient(self.results.kinematics),
+            v=self.field,
+            dV=self.field.region.dV,
+        ).integrate(parallel=parallel, jit=jit)[0]
+
+        # volume of deformed configuration
+        mesh = self.field.region.mesh.copy()
+        mesh.points += self.field[0].values
+        self.v = type(self.field.region)(mesh).dV.sum(0)
+        
+        # change of state variables due to change of displacement field
+        self.dJ = (
+            ddot(self.H, self.du, n=1) / self.V
+            + self.v / self.V - self.J
+        )
+        self.dp = (
+            self.bulk * self.dJ 
+            + self.bulk * (self.J - 1) - self.p
+        )
+                
+        # update state variables
+        self.J += self.dJ
+        self.p += self.dp
+        
+        return self.results.kinematics
+
+    def _gradient(self, field=None, args=(), kwargs={}):
+
+        if field is not None:
+            self.results.kinematics = self._extract(field)
+
+        self.results.stress = self.umat.gradient(
+            self.results.kinematics, *args, **kwargs
+        )
+
+        return self.results.stress
+
+    def _hessian(self, field=None, args=(), kwargs={}):
+
+        if field is not None:
+            self.results.kinematics = self._extract(field)
+
+        self.results.elasticity = self.umat.hessian(
+            self.results.kinematics, *args, **kwargs
+        )
+
+        return self.results.elasticity
+
+    def _kirchhoff_stress(self, field=None):
+
+        self._gradient(field)
+
+        P = self.results.stress[0]
+        F = self.results.kinematics[0]
+        J = det(F)
+
+        return dot(P, transpose(F)) + identity(dim=3) * self.p * J
+
+    def _cauchy_stress(self, field=None):
+
+        self._gradient(field)
+
+        P = self.results.stress[0]
+        F = self.results.kinematics[0]
+        J = det(F)
+
+        return dot(P, transpose(F)) / J + identity(dim=3) * self.p

--- a/tests/test_constitution.py
+++ b/tests/test_constitution.py
@@ -86,6 +86,16 @@ def test_nh():
 
         assert np.allclose(P, 0)
 
+        nh = fe.constitution.NeoHooke(mu=1.0, parallel=parallel)
+
+        W = nh.function(F)
+        P = nh.gradient(F)
+        A = nh.hessian(F)
+
+        assert W[0].shape == F[0].shape[-2:]
+        assert P[0].shape == (3, 3, *F[0].shape[-2:])
+        assert A[0].shape == (3, 3, 3, 3, *F[0].shape[-2:])
+
 
 def test_linear():
     r, F = pre(sym=False, add_identity=True)

--- a/tests/test_mechanics.py
+++ b/tests/test_mechanics.py
@@ -215,6 +215,9 @@ def test_solidbody_incompressible():
 
     umat, u = pre(dim=3, bulk=None)
     b = fe.SolidBodyNearlyIncompressible(umat=umat, field=u, bulk=5000)
+    b = fe.SolidBodyNearlyIncompressible(
+        umat=umat, field=u, bulk=5000, state=fe.StateNearlyIncompressible(u)
+    )
 
     for parallel in [False, True]:
         for jit in [False, True]:

--- a/tests/test_mechanics.py
+++ b/tests/test_mechanics.py
@@ -210,6 +210,7 @@ def test_solidbody():
             t2 = b.evaluate.kirchhoff_stress(u)
             assert np.allclose(t1, t2)
 
+
 def test_solidbody_incompressible():
 
     umat, u = pre(dim=3, bulk=None)
@@ -259,6 +260,7 @@ def test_solidbody_incompressible():
             t1 = b.evaluate.kirchhoff_stress()
             t2 = b.evaluate.kirchhoff_stress(u)
             assert np.allclose(t1, t2)
+
 
 def test_solidbody_axi():
 

--- a/tests/test_mechanics.py
+++ b/tests/test_mechanics.py
@@ -116,9 +116,9 @@ def test_pressure():
     assert np.allclose(w[0].values, v[0].values)
 
 
-def pre(dim):
+def pre(dim, bulk=2):
 
-    umat = fe.NeoHooke(mu=1, bulk=2)
+    umat = fe.NeoHooke(mu=1, bulk=bulk)
 
     m = fe.Cube(n=3)
     r = fe.RegionHexahedron(m)
@@ -210,6 +210,55 @@ def test_solidbody():
             t2 = b.evaluate.kirchhoff_stress(u)
             assert np.allclose(t1, t2)
 
+def test_solidbody_incompressible():
+
+    umat, u = pre(dim=3, bulk=None)
+    b = fe.SolidBodyNearlyIncompressible(umat=umat, field=u, bulk=5000)
+
+    for parallel in [False, True]:
+        for jit in [False, True]:
+
+            kwargs = {"parallel": parallel, "jit": jit}
+
+            r1 = b.assemble.vector(u, **kwargs)
+            assert r1.shape == (81, 1)
+
+            r1b = b.results.force
+            assert np.allclose(r1.toarray(), r1b.toarray())
+
+            r2 = b.assemble.vector(**kwargs)
+            assert np.allclose(r1.toarray(), r2.toarray())
+
+            K1 = b.assemble.matrix(u, **kwargs)
+            assert K1.shape == (81, 81)
+
+            K1b = b.results.stiffness
+            assert np.allclose(K1.toarray(), K1b.toarray())
+
+            K2 = b.assemble.matrix(**kwargs)
+            assert np.allclose(K1.toarray(), K2.toarray())
+
+            P1 = b.results.stress
+            P2 = b.evaluate.gradient()
+            P2 = b.evaluate.gradient(u)
+            assert np.allclose(P1, P2)
+
+            A1 = b.results.elasticity
+            A2 = b.evaluate.hessian()
+            A2 = b.evaluate.hessian(u)
+            assert np.allclose(A1, A2)
+
+            F1 = b.results.kinematics
+            F2 = b._extract(u)
+            assert np.allclose(F1, F2)
+
+            s1 = b.evaluate.cauchy_stress()
+            s2 = b.evaluate.cauchy_stress(u)
+            assert np.allclose(s1, s2)
+
+            t1 = b.evaluate.kirchhoff_stress()
+            t2 = b.evaluate.kirchhoff_stress(u)
+            assert np.allclose(t1, t2)
 
 def test_solidbody_axi():
 
@@ -352,6 +401,7 @@ def test_load():
 if __name__ == "__main__":
     test_simple()
     test_solidbody()
+    test_solidbody_incompressible()
     test_solidbody_axi()
     test_solidbody_mixed()
     test_pressure()


### PR DESCRIPTION
The basic idea evolved out of #296 in combination with the **Mean-Dilatation** technique, see e.g. [Bonet & Wood](https://www.cambridge.org/core/books/nonlinear-continuum-mechanics-for-finite-element-analysis/67AD6DBAAB77E755C09E7FB82565DA0B). Due to a static-condensation of the internal (secondary) fields, this is not as general but considerably (more than 3x) faster than the three-field formulation on global mixed-fields. Usage will be basically

```python
# create a hexahedron-region on a cube
mesh = fem.Cube(n=6)
region = fem.RegionHexahedron(mesh)

# add a field container (with a displacement field)
field = fem.FieldsMixed(region, n=1)

# define the constitutive material behaviour (distortional part only!)
# and create a solid body (define the bulk modulus here)
umat = fem.NeoHooke(mu=1)
solid = fem.SolidBodyNearlyIncompressible(umat, field, bulk=5000)

# apply a uniaxial elongation on the cube
boundaries, lc = fem.dof.uniaxial(field, move=-0.1, clamped=True)
res = fem.newtonrhapson(items=[solid], **lc)
```

and is equal to

```python
# create a hexahedron-region on a cube
mesh = fem.Cube(n=6)
region = fem.RegionHexahedron(mesh)

# add a field container (with a displacement, pressure and volume-ratio fields)
field = fem.FieldsMixed(region, n=3)

# define the constitutive material behaviour and create a solid body
umat = fem.ThreeFieldVariation(fem.NeoHooke(mu=1, bulk=5000))
solid = fem.SolidBody(umat, field)

# apply a uniaxial elongation on the cube
boundaries, lc = fem.dof.uniaxial(field, move=-0.1, clamped=True)
res = fem.newtonrhapson(items=[solid], **lc)
```

This fixes #317.