### PR TITLE
Add `project(mean=True)`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file. The format 
 
 ## [Unreleased]
 
+### Added
+- Add `project(mean=True)` to project cell mean-values to mesh-points. Now `project()` supports Triangles and Tetrahedrons.
+
 ## [5.3.1] - 2022-11-03
 
 ### Fixed

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -93,6 +93,9 @@ def test_solve_check():
 
     cauchy = fe.tools.project(fe.math.tovoigt(s), region=r, average=False)
     assert cauchy.shape == (r.mesh.cells.size, 6)
+    
+    cauchy = fe.tools.project(fe.math.tovoigt(s), region=r, mean=True)
+    assert cauchy.shape == (r.mesh.npoints, 6)
 
 
 def test_solve_mixed_check():


### PR DESCRIPTION
This enables support for triangles and tetrahedrons in `project()`.

fixes #328 as discussed in #322, derived by the idea of @ZAARAOUI999

# Idea
Project the cell mean-values to mesh-points.

## Notes
Computes the weighted average by using the quadrature weights.