### PR TITLE
Do not broadcast linear-elastic elasticity tensor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file. The format 
 
 ### Changed
 - Unify material definition with methods for the stress `P, statevars_new = umat.gradient([F, statevars])` and the elasticity tensor `A = umat.hessian([F, statevars])`. This breaks support for materials defined by matadi<=0.1.10.
+- Do not broadcast the (constant) elasticity tensor for linear-elastic materials as `einsumt>=0.9.3` supports broadcasting along the parallel-executed dimension.
 
 ### Removed
 - Remove unused `SolidBodyTensor()` and `SolidBodyTensorNearlyIncompressible()`.

--- a/docs/tutorial/beam.rst
+++ b/docs/tutorial/beam.rst
@@ -70,7 +70,7 @@ The weak form of linear elasticity is assembled into the stiffness matrix, where
 ..  code-block:: python
     
     stiffness = fe.IntegralForm(
-        fun=umat.elasticity(region=region), 
+        fun=umat.elasticity(), 
         v=field, 
         dV=region.dV, 
         u=field, 

--- a/felupe/constitution/_models_linear_elasticity.py
+++ b/felupe/constitution/_models_linear_elasticity.py
@@ -144,7 +144,7 @@ class LinearElastic:
 
         return [E / (1 + nu) / (1 - 2 * nu) * stress, statevars]
 
-    def hessian(self, x=None, E=None, nu=None, shape=(1, 1), region=None):
+    def hessian(self, x=None, E=None, nu=None, shape=(1, 1)):
         """Evaluate the elasticity tensor. The Deformation gradient is only
         used for the shape of the trailing axes.
 
@@ -157,10 +157,8 @@ class LinearElastic:
             Young's modulus (default is None)
         nu : float, optional
             Poisson ratio (default is None)
-        shape : (int, int), optional (default is (1, 1))
-            Tuple with shape of the trailing axes (default is None)
-        region : Region, optional
-            A numeric region for shape of the trailing axes (default is None)
+        shape : (int, ...), optional
+            Tuple with shape of the trailing axes (default is (1, 1))
 
         Returns
         -------
@@ -175,7 +173,7 @@ class LinearElastic:
         if nu is None:
             nu = self.nu
 
-        elast = np.zeros((3, 3, 3, 3, 1, 1))
+        elast = np.zeros((3, 3, 3, 3, *shape))
 
         # diagonal normal components
         for i in range(3):
@@ -274,7 +272,7 @@ class LinearElasticTensorNotation:
 
         return [2 * mu * strain + gamma * trace(strain) * identity(strain), statevars]
 
-    def hessian(self, x=None, E=None, nu=None, shape=(1, 1), region=None):
+    def hessian(self, x=None, E=None, nu=None, shape=(1, 1)):
         """Evaluate the elasticity tensor. The Deformation gradient is only
         used for the shape of the trailing axes.
 
@@ -287,10 +285,8 @@ class LinearElasticTensorNotation:
             Young's modulus (default is None)
         nu : float, optional
             Poisson ratio (default is None)
-        shape : (int, int), optional (default is (1, 1))
-            Tuple with shape of the trailing axes (default is None)
-        region : Region, optional
-            A numeric region for shape of the trailing axes (default is None)
+        shape : (int, ...), optional 
+            Tuple with shape of the trailing axes (default is (1, 1))
 
         Returns
         -------
@@ -305,7 +301,7 @@ class LinearElasticTensorNotation:
         if nu is None:
             nu = self.nu
 
-        I = identity(dim=3, shape=[1, 1])
+        I = identity(dim=3, shape=shape)
 
         # convert to lame constants
         mu, gamma = self._lame_converter(E, nu)
@@ -576,7 +572,7 @@ class LinearElasticPlaneStress:
 
         return [stress, statevars]
 
-    def hessian(self, x=None, E=None, nu=None, shape=(1, 1), region=None):
+    def hessian(self, x=None, E=None, nu=None, shape=(1, 1)):
         """Evaluate the elasticity tensor from the deformation gradient.
 
         Arguments
@@ -588,10 +584,8 @@ class LinearElasticPlaneStress:
             Young's  modulus (default is None)
         nu : float, optional
             Poisson ratio (default is None)
-        shape : (int, int), optional (default is (1, 1))
-            Tuple with shape of the trailing axes (default is None)
-        region : Region, optional
-            A numeric region for shape of the trailing axes (default is None)
+        shape : (int, ...), optional 
+            Tuple with shape of the trailing axes (default is (1, 1))
 
         Returns
         -------
@@ -606,7 +600,7 @@ class LinearElasticPlaneStress:
         if nu is None:
             nu = self.nu
 
-        elast = np.zeros((2, 2, 2, 2, 1, 1))
+        elast = np.zeros((2, 2, 2, 2, *shape))
 
         for a in range(2):
             elast[a, a, a, a] = E / (1 - nu**2)

--- a/felupe/constitution/_models_linear_elasticity.py
+++ b/felupe/constitution/_models_linear_elasticity.py
@@ -169,20 +169,13 @@ class LinearElastic:
 
         """
 
-        if x is None:
-            if region is not None:
-                shape = (len(region.quadrature.points), region.mesh.ncells)
-        else:
-            F = x[0]
-            shape = F.shape[-2:]
-
         if E is None:
             E = self.E
 
         if nu is None:
             nu = self.nu
 
-        elast = np.zeros((3, 3, 3, 3, *shape))
+        elast = np.zeros((3, 3, 3, 3, 1, 1))
 
         # diagonal normal components
         for i in range(3):
@@ -312,13 +305,7 @@ class LinearElasticTensorNotation:
         if nu is None:
             nu = self.nu
 
-        if x is None:
-            if region is not None:
-                shape = (len(region.quadrature.points), region.mesh.ncells)
-            I = identity(dim=3, shape=shape)
-        else:
-            F = x[0]
-            I = identity(F)
+        I = identity(dim=3, shape=[1, 1])
 
         # convert to lame constants
         mu, gamma = self._lame_converter(E, nu)
@@ -619,14 +606,7 @@ class LinearElasticPlaneStress:
         if nu is None:
             nu = self.nu
 
-        if x is None:
-            if region is not None:
-                shape = (len(region.quadrature.points), region.mesh.ncells)
-        else:
-            F = x[0]
-            shape = F.shape[-2:]
-
-        elast = np.zeros((2, 2, 2, 2, *shape))
+        elast = np.zeros((2, 2, 2, 2, 1, 1))
 
         for a in range(2):
             elast[a, a, a, a] = E / (1 - nu**2)

--- a/tests/test_constitution.py
+++ b/tests/test_constitution.py
@@ -116,14 +116,13 @@ def test_linear():
         stress = le.gradient(F)[:-1]
         dsde = le.hessian(F)
         dsde2 = le.hessian(shape=F[0].shape[-2:])
-        dsde3 = le.hessian(region=r)
 
         assert le.elasticity()[0].shape[-2:] == (1, 1)
 
         check_stress.append(stress)
-        check_dsde.append([dsde, dsde2, dsde3])
+        check_dsde.append([dsde[0][..., 0, 0], dsde2[0][..., 0, 0]])
 
-        assert dsde[0].shape == dsde2[0].shape
+        assert dsde[0].shape[:-2] == dsde2[0].shape[:-2]
 
         le = LinearElastic(E=None, nu=0.3, **kwargs)
         stress = le.gradient(F, E=2.0)[:-1]
@@ -132,7 +131,7 @@ def test_linear():
         dsde = le.hessian(F, E=3.0)
 
         assert stress[0].shape == (3, 3, *F[0].shape[-2:])
-        assert dsde[0].shape == (3, 3, 3, 3, *F[0].shape[-2:])
+        assert dsde[0].shape == (3, 3, 3, 3, 1, 1)
 
         assert np.allclose(stress, 0)
 
@@ -150,11 +149,10 @@ def test_linear_planestress():
     dsde = le.hessian(F)
     dsde = le.hessian(F)
     dsde2 = le.hessian(shape=F[0].shape[-2:])
-    dsde3 = le.hessian(region=r)
 
     assert le.elasticity()[0].shape[-2:] == (1, 1)
 
-    check_dsde = [dsde, dsde2, dsde3]
+    check_dsde = [dsde[0][..., 0, 0], dsde2[0][..., 0, 0]]
 
     assert np.allclose(*check_dsde)
 
@@ -171,7 +169,7 @@ def test_linear_planestress():
     dsde = le.hessian(F, E=3.0)
 
     assert stress[0].shape == (2, 2, *F[0].shape[-2:])
-    assert dsde[0].shape == (2, 2, 2, 2, *F[0].shape[-2:])
+    assert dsde[0].shape == (2, 2, 2, 2, 1, 1)
 
     assert np.allclose(stress, 0)
 
@@ -200,7 +198,7 @@ def test_linear_planestrain():
     dsde = le.hessian(F, E=3.0)
 
     assert stress[0].shape == (2, 2, *F[0].shape[-2:])
-    assert dsde[0].shape == (2, 2, 2, 2, *F[0].shape[-2:])
+    assert dsde[0].shape == (2, 2, 2, 2, 1, 1)
 
     assert np.allclose(stress, 0)
 

--- a/tests/test_mechanics.py
+++ b/tests/test_mechanics.py
@@ -55,7 +55,7 @@ def test_simple():
     assert P[0].shape == (3, 3, 8, 8)
     assert s.shape == (3, 3, 8, 8)
     assert t.shape == (3, 3, 8, 8)
-    assert C[0].shape == (3, 3, 3, 3, 8, 8)
+    assert C[0].shape == (3, 3, 3, 3, 1, 1)
 
 
 def test_pressure():
@@ -92,7 +92,7 @@ def test_pressure():
     assert r.shape == (81, 1)
     assert F[0].shape == (3, 3, 8, 8)
     assert s[0].shape == (3, 3, 8, 8)
-    assert C[0].shape == (3, 3, 3, 3, 8, 8)
+    assert C[0].shape == (3, 3, 3, 3, 1, 1)
 
     r = c.assemble.vector()
     K = c.assemble.matrix()


### PR DESCRIPTION
because `einsumt>=0.9.3` supports broadcasting, see https://github.com/mrkwjc/einsumt/pull/2.

This saves both
a) memory and
b) computation time.