### PR TITLE
Enhance `linsteps` by supporting a list of substeps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file. The format 
 
 ### Changed
 - Enhance plotting with custom `x`- and `y`-data in `CharacteristicCurve.plot(x, y)` and allow a list of items for force evaluation in `CharacteristicCurve(items=[...])` to be passed.
+- Enhance `math.linsteps(points=[0, 5, 0], num=[5, 10])` by supporting a list of substeps.
 
 ## [6.0.0] - 2022-11-20
 

--- a/felupe/math/_math.py
+++ b/felupe/math/_math.py
@@ -30,7 +30,25 @@ import numpy as np
 
 def linsteps(points, num=10):
 
-    ls = np.linspace(points[:-1], points[1:], num=num, endpoint=False, axis=1).ravel()
-    ls_with_endpoint = np.append(ls, points[-1])
+    points = np.array(points).ravel()
+    start = points[:-1]
+    end = points[1:]
+    num = np.array([num]).ravel()
 
-    return ls_with_endpoint
+    if len(num) == 1:
+        num = np.tile(num, max(1, len(start)))
+
+    num = np.pad(num, (0, max(0, len(start) - len(num))), mode="edge")
+
+    steplist = [
+        np.linspace(a, b, n, endpoint=False) for a, b, n in zip(start, end, num)
+    ]
+    if len(steplist) > 0:
+        steps = np.concatenate(
+            [np.linspace(a, b, n, endpoint=False) for a, b, n in zip(start, end, num)]
+        )
+    else:
+        steps = np.array([])
+    steps_with_endpoint = np.append(steps, points[-1])
+
+    return steps_with_endpoint

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -140,6 +140,24 @@ def test_math():
     fe.math.trace(C)
 
 
+def test_math_linsteps():
+
+    steps = fe.math.linsteps([0, 1], num=10)
+    assert len(steps) == 11
+
+    steps = fe.math.linsteps([0, 1, 0], num=(10, 100))
+    assert len(steps) == 111
+
+    steps = fe.math.linsteps([1], num=0)
+    assert len(steps) == 1
+    assert steps[-1] == 1
+
+    steps = fe.math.linsteps([1], num=(0, 1))
+    assert len(steps) == 1
+    assert steps[-1] == 1
+
+
 if __name__ == "__main__":
     test_math()
     test_math_field()
+    test_math_linsteps()


### PR DESCRIPTION
add `linsteps(points=[0, 5, 0], num=[5, 10])`

fixes #351 