### PR TITLE
Add models for isotropic hyperelasticity `UserMaterialHyperelastic()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file. The format 
 
 ### Added
 - Add Total-Lagrange `UserMaterialHyperelastic(fun, parallel=False, **kwargs)` based on optional `tensortrax`. Only available if `tensortrax` is installed.
+- Add constitutive isotropic hyperelastic model formulations to be used with `UserMaterialHyperelastic()` (`constitution.ogden(C, mu, alpha)`, etc.).
 
 ## [6.1.0] - 2022-12-10
 

--- a/felupe/constitution/__init__.py
+++ b/felupe/constitution/__init__.py
@@ -4,6 +4,7 @@ from ._models_hyperelasticity import (
 
 try:
     from ._models_hyperelasticity_ad import (
+        isochoric_volumetric_split,
         neo_hooke,
         yeoh,
         third_order_deformation,

--- a/felupe/constitution/__init__.py
+++ b/felupe/constitution/__init__.py
@@ -2,6 +2,13 @@ from ._models_hyperelasticity import (
     NeoHooke,
 )
 
+from ._models_hyperelasticity_ad import (
+    neo_hooke,
+    yeoh,
+    third_order_deformation,
+    ogden,
+)
+
 from ._models_linear_elasticity import (
     LinearElastic,
     LinearElasticTensorNotation,

--- a/felupe/constitution/__init__.py
+++ b/felupe/constitution/__init__.py
@@ -2,12 +2,15 @@ from ._models_hyperelasticity import (
     NeoHooke,
 )
 
-from ._models_hyperelasticity_ad import (
-    neo_hooke,
-    yeoh,
-    third_order_deformation,
-    ogden,
-)
+try:
+    from ._models_hyperelasticity_ad import (
+        neo_hooke,
+        yeoh,
+        third_order_deformation,
+        ogden,
+    )
+except:
+    pass
 
 from ._models_linear_elasticity import (
     LinearElastic,

--- a/felupe/constitution/_models_hyperelasticity_ad.py
+++ b/felupe/constitution/_models_hyperelasticity_ad.py
@@ -1,0 +1,75 @@
+# -*- coding: utf-8 -*-
+"""
+ _______  _______  ___      __   __  _______  _______ 
+|       ||       ||   |    |  | |  ||       ||       |
+|    ___||    ___||   |    |  | |  ||    _  ||    ___|
+|   |___ |   |___ |   |    |  |_|  ||   |_| ||   |___ 
+|    ___||    ___||   |___ |       ||    ___||    ___|
+|   |    |   |___ |       ||       ||   |    |   |___ 
+|___|    |_______||_______||_______||___|    |_______|
+
+This file is part of felupe.
+
+Felupe is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Felupe is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Felupe.  If not, see <http://www.gnu.org/licenses/>.
+
+"""
+
+from functools import wraps
+
+from tensortrax.math._linalg import det, eigvalsh
+from tensortrax.math import trace, sum as sum1
+
+
+def isochoric_volumetric_split(fun):
+    """Apply the material formulation only on the isochoric part of the
+    multiplicative split of the deformation gradient."""
+
+    @wraps(fun)
+    def apply_iso(C, *args, **kwargs):
+        return fun(det(C) ** (-1 / 3) * C, *args, **kwargs)
+
+    return apply_iso
+
+
+@isochoric_volumetric_split
+def neo_hooke(C, mu):
+    "Strain energy function of the Neo-Hookean material formulation."
+    return mu / 2 * (trace(C) - 3)
+
+
+@isochoric_volumetric_split
+def yeoh(C, C10, C20, C30):
+    I1 = trace(C)
+    return C10 * (I1 - 3) + C20 * (I1 - 3) ** 2 + C30 * (I1 - 3) ** 3
+
+
+@isochoric_volumetric_split
+def third_order_deformation(C, C10, C01, C11, C20, C30):
+    "Strain energy function of the Third-Order-Deformation material formulation."
+    I1 = trace(C)
+    I2 = (I1**2 - trace(C @ C)) / 2
+    return (
+        C10 * (I1 - 3)
+        + C01 * (I2 - 3)
+        + C11 * (I1 - 3) * (I2 - 3)
+        + C20 * (I1 - 3) ** 2
+        + C30 * (I1 - 3) ** 3
+    )
+
+
+@isochoric_volumetric_split
+def ogden(C, mu, alpha):
+    "Strain energy function of the Ogden material formulation."
+    wC = eigvalsh(C)
+    return sum1([2 * m / a**2 * (sum1(wC ** (a / 2)) - 3) for m, a in zip(mu, alpha)])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "felupe"
-version = "6.1.0"
+version = "6.2.0"
 description = "Finite Element Analysis"
 readme = "README.md"
 requires-python = ">=3.7"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = felupe
-version = 6.1.0
+version = 6.2.0
 author = Andreas Dutzler
 author_email = a.dutzler@gmail.com
 description = Finite Element Analysis

--- a/tests/test_constitution.py
+++ b/tests/test_constitution.py
@@ -296,10 +296,21 @@ def test_umat_hyperelastic():
     def neo_hooke(C, mu=1):
         return mu / 2 * (tm.linalg.det(C) ** (-1 / 3) * tm.trace(C) - 3)
 
-    umat = fe.UserMaterialHyperelastic(neo_hooke, mu=1)
+    for model, kwargs in [
+        (neo_hooke, {"mu": 1}),
+        (fe.constitution.neo_hooke, {"mu": 1}),
+        (fe.constitution.yeoh, {"C10": 0.5, "C20": -0.1, "C30": 0.02}),
+        (
+            fe.constitution.third_order_deformation,
+            {"C10": 0.5, "C01": 0.1, "C11": 0.01, "C20": -0.1, "C30": 0.02},
+        ),
+        (fe.constitution.ogden, {"mu": [1], "alpha": [1.7]}),
+    ]:
 
-    s, statevars_new = umat.gradient([F, None])
-    dsde = umat.hessian([F, None])
+        umat = fe.UserMaterialHyperelastic(model, **kwargs)
+
+        s, statevars_new = umat.gradient([F, None])
+        dsde = umat.hessian([F, None])
 
 
 def test_umat_strain():


### PR DESCRIPTION
- [x] Neo-Hooke `felupe.constitution.neo_hooke(C, mu)`
- [x] Yeoh `felupe.constitution.yeoh(C, C10, C20, C30)`
- [x] Third-Order-Deformation `felupe.constitution.third_order_deformation(C, C10, C01, C11, C20, C30)`
- [x] Ogden `felupe.constitution.ogden(C, mu, alpha)`

all based on the isochoric-volumetric split of the deformation gradient.