### PR TITLE
Fix scalar-checks in `mesh.expand()` and `mesh.revolve()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ All notable changes to this project will be documented in this file. The format 
 - Change `einsumt` from an optional to a required dependency.
 - Vectorize implementations of `MultiPointConstraint` and `MultiPointContact` and re-implement both as `scipy.sparse.lil_matrix()`.
 
+### Fixed
+- Fix `tools.project()` for higher-order quad- and hexahedron elements.
+- Fix transposed output of `tools.project()`.
+- Fix failed scalar-value checks by using `np.isscalar()` in `mesh.expand(z=1)` and `mesh.revolve(phi=180)` where `z` or `phi` are of type `np.int32`.
+
 ### Removed
 - Remove `jit`-compilation of forms (`parallel` is the preferred method).
 - Remove unused `tools.check()`.

--- a/src/felupe/mesh/_tools.py
+++ b/src/felupe/mesh/_tools.py
@@ -81,7 +81,7 @@ def expand(points, cells, cell_type, n=11, z=1):
     p = np.pad(points, ((0, 0), (0, 1)))
 
     # generate new points array for every thickness expansion ``h``
-    if isinstance(z, int) or isinstance(z, float):
+    if np.isscalar(z):
         points_z = np.linspace(0, z, n)
     else:
         points_z = z
@@ -182,7 +182,7 @@ def revolve(points, cells, cell_type, n=11, phi=180, axis=0):
         "quad": ("hexahedron", slice(None, None, None)),
     }[cell_type]
 
-    if isinstance(phi, int) or isinstance(phi, float):
+    if np.isscalar(phi):
         points_phi = np.linspace(0, phi, n)
     else:
         points_phi = phi


### PR DESCRIPTION
for `z` and `phi`. They failed if they were of type `np.int32`. The check is changed and now uses `np.isscalar()`.

fixes #420 