### PR TITLE
Enhance `Mesh`: Mesh tools as methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ All notable changes to this project will be documented in this file. The format 
 ### Changed
 - Change `einsumt` from an optional to a required dependency.
 - Vectorize implementations of `MultiPointConstraint` and `MultiPointContact` and re-implement both as `scipy.sparse.lil_matrix()`.
+- Rename old `Mesh` to `DiscreteGeometry` and rebase new `Mesh` on `DiscreteGeometry`. 
+- Simplify the usage of explicit mesh-related tools by adding them as methods to `Mesh`, i.e. `mesh.tools.expand(Rectangle())` is equivalent to `Rectangle().expand()`.
 
 ### Fixed
 - Fix `tools.project()` for higher-order quad- and hexahedron elements.

--- a/src/felupe/mesh/_convert.py
+++ b/src/felupe/mesh/_convert.py
@@ -27,8 +27,8 @@ along with Felupe.  If not, see <http://www.gnu.org/licenses/>.
 
 import numpy as np
 
+from ._discrete_geometry import DiscreteGeometry
 from ._helpers import mesh_or_data
-from ._mesh import Mesh
 
 
 @mesh_or_data

--- a/src/felupe/mesh/_discrete_geometry.py
+++ b/src/felupe/mesh/_discrete_geometry.py
@@ -25,8 +25,6 @@ along with Felupe.  If not, see <http://www.gnu.org/licenses/>.
 
 """
 
-from copy import deepcopy
-
 import numpy as np
 
 
@@ -102,60 +100,3 @@ class DiscreteGeometry:
         else:
             self.points_without_cells = np.array([], dtype=int)
             self.points_with_cells = np.arange(self.npoints)
-
-    def disconnect(self, points_per_cell=None, calc_points=True):
-        """Return a new instance of a Mesh with disconnected cells. Optionally, the
-        points-per-cell may be specified (must be lower or equal the number of points-
-        per-cell of the original Mesh). If the Mesh is to be used as a *dual* Mesh, then
-        the point-coordinates do not have to be re-created because they are not used."""
-
-        cells_trimmed = self.cells
-        cell_type = self.cell_type
-
-        if points_per_cell is not None:
-            cell_type = None
-            cells_trimmed = cells_trimmed[:, :points_per_cell]
-
-        if calc_points:
-            points = self.points[cells_trimmed].reshape(-1, self.dim)
-        else:
-            points = np.zeros(
-                (self.ncells * cells_trimmed.shape[1], self.dim), dtype=int
-            )
-
-        cells = np.arange(cells_trimmed.size).reshape(*cells_trimmed.shape)
-
-        return self(points, cells, cell_type=cell_type)
-
-    def as_meshio(self, **kwargs):
-        "Export the mesh as ``meshio.Mesh``."
-
-        import meshio
-
-        cells = {self.cell_type: self.cells}
-        return meshio.Mesh(self.points, cells, **kwargs)
-
-    def save(self, filename="mesh.vtk", **kwargs):
-        """Export the mesh as VTK file. For XDMF-export please ensure to have
-        ``h5py`` (as an optional dependancy of ``meshio``) installed.
-
-        Parameters
-        ----------
-        filename : str, optional
-            The filename of the mesh (default is ``mesh.vtk``).
-
-        """
-
-        self.as_meshio(**kwargs).write(filename)
-
-    def copy(self):
-        """Return a deepcopy of the mesh.
-
-        Returns
-        -------
-        Mesh
-            A deepcopy of the mesh.
-
-        """
-
-        return deepcopy(self)

--- a/src/felupe/mesh/_discrete_geometry.py
+++ b/src/felupe/mesh/_discrete_geometry.py
@@ -1,0 +1,161 @@
+# -*- coding: utf-8 -*-
+"""
+ _______  _______  ___      __   __  _______  _______ 
+|       ||       ||   |    |  | |  ||       ||       |
+|    ___||    ___||   |    |  | |  ||    _  ||    ___|
+|   |___ |   |___ |   |    |  |_|  ||   |_| ||   |___ 
+|    ___||    ___||   |___ |       ||    ___||    ___|
+|   |    |   |___ |       ||       ||   |    |   |___ 
+|___|    |_______||_______||_______||___|    |_______|
+
+This file is part of felupe.
+
+Felupe is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Felupe is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Felupe.  If not, see <http://www.gnu.org/licenses/>.
+
+"""
+
+from copy import deepcopy
+
+import numpy as np
+
+
+class DiscreteGeometry:
+    """A discrete geometry with points, cells and optional a specified cell type.
+
+    Parameters
+    ----------
+    points : ndarray
+        Point coordinates.
+    cells : ndarray
+        Point-connectivity of cells.
+    cell_type : str or None, optional
+        An optional string in VTK-convention that specifies the cell type (default is None). Necessary when a discrete geometry is saved to a file.
+
+    Attributes
+    ----------
+    points : ndarray
+        Point coordinates.
+    cells : ndarray
+        Point-connectivity of cells.
+    cell_type : str or None
+        A string in VTK-convention that specifies the cell type.
+    npoints : int
+        Amount of points.
+    dim : int
+        Dimension of mesh point coordinates.
+    ndof : int
+        Amount of degrees of freedom.
+    ncells : int
+        Amount of cells.
+    points_with_cells : array
+        Array with points connected to cells.
+    points_without_cells : array
+        Array with points not connected to cells.
+    cells_per_point : array
+        Array which counts connected cells per point. Used for averaging results.
+
+    """
+
+    def __init__(self, points, cells, cell_type=None):
+        self.points = np.array(points)
+        self.cells = np.array(cells)
+        self.cell_type = cell_type
+
+        self.update(self.cells)
+
+    def update(self, cells, cell_type=None):
+        "Update the cell and dimension attributes with a given cell array."
+        self.cells = cells
+
+        if cell_type is not None:
+            self.cell_type = cell_type
+
+        # obtain dimensions
+        self.npoints, self.dim = self.points.shape
+        self.ndof = self.points.size
+        self.ncells = self.cells.shape[0]
+
+        # get number of cells per point
+        points_in_cell, self.cells_per_point = np.unique(cells, return_counts=True)
+
+        # check if there are points without cells
+        if self.npoints != len(self.cells_per_point):
+            self.point_has_cell = np.isin(np.arange(self.npoints), points_in_cell)
+            # update "cells_per_point" ... cells per point
+            cells_per_point = -np.ones(self.npoints, dtype=int)
+            cells_per_point[points_in_cell] = self.cells_per_point
+            self.cells_per_point = cells_per_point
+
+            self.points_without_cells = np.arange(self.npoints)[~self.point_has_cell]
+            self.points_with_cells = np.arange(self.npoints)[self.point_has_cell]
+        else:
+            self.points_without_cells = np.array([], dtype=int)
+            self.points_with_cells = np.arange(self.npoints)
+
+    def disconnect(self, points_per_cell=None, calc_points=True):
+        """Return a new instance of a Mesh with disconnected cells. Optionally, the
+        points-per-cell may be specified (must be lower or equal the number of points-
+        per-cell of the original Mesh). If the Mesh is to be used as a *dual* Mesh, then
+        the point-coordinates do not have to be re-created because they are not used."""
+
+        cells_trimmed = self.cells
+        cell_type = self.cell_type
+
+        if points_per_cell is not None:
+            cell_type = None
+            cells_trimmed = cells_trimmed[:, :points_per_cell]
+
+        if calc_points:
+            points = self.points[cells_trimmed].reshape(-1, self.dim)
+        else:
+            points = np.zeros(
+                (self.ncells * cells_trimmed.shape[1], self.dim), dtype=int
+            )
+
+        cells = np.arange(cells_trimmed.size).reshape(*cells_trimmed.shape)
+
+        return self(points, cells, cell_type=cell_type)
+
+    def as_meshio(self, **kwargs):
+        "Export the mesh as ``meshio.Mesh``."
+
+        import meshio
+
+        cells = {self.cell_type: self.cells}
+        return meshio.Mesh(self.points, cells, **kwargs)
+
+    def save(self, filename="mesh.vtk", **kwargs):
+        """Export the mesh as VTK file. For XDMF-export please ensure to have
+        ``h5py`` (as an optional dependancy of ``meshio``) installed.
+
+        Parameters
+        ----------
+        filename : str, optional
+            The filename of the mesh (default is ``mesh.vtk``).
+
+        """
+
+        self.as_meshio(**kwargs).write(filename)
+
+    def copy(self):
+        """Return a deepcopy of the mesh.
+
+        Returns
+        -------
+        Mesh
+            A deepcopy of the mesh.
+
+        """
+
+        return deepcopy(self)

--- a/src/felupe/mesh/_helpers.py
+++ b/src/felupe/mesh/_helpers.py
@@ -27,12 +27,12 @@ along with Felupe.  If not, see <http://www.gnu.org/licenses/>.
 
 from functools import wraps
 
-from ._mesh import Mesh
+from ._discrete_geometry import DiscreteGeometry
 
 
 def mesh_or_data(meshfun):
-    """If a ``Mesh`` is passed to a mesh function, extract ``points`` and
-    ``cells`` arrays along with the ``cell_type`` and return a ``Mesh``
+    """If a ``DiscreteGeometry`` is passed to a mesh function, extract ``points`` and
+    ``cells`` arrays along with the ``cell_type`` and return a ``DiscreteGeometry``
     as a result."""
 
     @wraps(meshfun)
@@ -44,8 +44,8 @@ def mesh_or_data(meshfun):
         # check if unnamed args are passed
         if len(args) > 0:
 
-            # meshfun(Mesh)
-            if isinstance(args[0], Mesh):
+            # meshfun(DiscreteGeometry)
+            if isinstance(args[0], DiscreteGeometry):
 
                 # set mesh flag
                 is_mesh = True
@@ -104,9 +104,9 @@ def mesh_or_data(meshfun):
         # call mesh manipulation function
         points, cells, cell_type = meshfun(points, cells, cell_type, *args, **kwargs)
 
-        # return a Mesh if a Mesh was passed
+        # return a DiscreteGeometry if a DiscreteGeometry was passed
         if is_mesh:
-            return Mesh(points=points, cells=cells, cell_type=cell_type)
+            return DiscreteGeometry(points=points, cells=cells, cell_type=cell_type)
 
         else:
             # or (points, cells, cell_type) if arrays were given

--- a/src/felupe/mesh/_helpers.py
+++ b/src/felupe/mesh/_helpers.py
@@ -27,8 +27,6 @@ along with Felupe.  If not, see <http://www.gnu.org/licenses/>.
 
 from functools import wraps
 
-from ._discrete_geometry import DiscreteGeometry
-
 
 def mesh_or_data(meshfun):
     """If a ``DiscreteGeometry`` is passed to a mesh function, extract ``points`` and
@@ -45,7 +43,7 @@ def mesh_or_data(meshfun):
         if len(args) > 0:
 
             # meshfun(DiscreteGeometry)
-            if isinstance(args[0], DiscreteGeometry):
+            if hasattr(args[0], "__mesh__"):
 
                 # set mesh flag
                 is_mesh = True
@@ -54,6 +52,9 @@ def mesh_or_data(meshfun):
                 points = args[0].points
                 cells = args[0].cells
                 cell_type = args[0].cell_type
+
+                # get mesh class
+                Mesh = args[0].__mesh__
 
                 # remove Mesh from args
                 args = args[1:]
@@ -106,7 +107,7 @@ def mesh_or_data(meshfun):
 
         # return a DiscreteGeometry if a DiscreteGeometry was passed
         if is_mesh:
-            return DiscreteGeometry(points=points, cells=cells, cell_type=cell_type)
+            return Mesh(points=points, cells=cells, cell_type=cell_type)
 
         else:
             # or (points, cells, cell_type) if arrays were given

--- a/src/felupe/mesh/_mesh.py
+++ b/src/felupe/mesh/_mesh.py
@@ -154,7 +154,7 @@ class Mesh(DiscreteGeometry):
 
     @wraps(rotate)
     def rotate(self, angle_deg, axis, center=None):
-        return as_mesh(rotate(angle_deg=angle_deg, axis=axis, center=center))
+        return as_mesh(rotate(self, angle_deg=angle_deg, axis=axis, center=center))
 
     @wraps(revolve)
     def revolve(self, n=11, phi=180, axis=0):

--- a/src/felupe/mesh/_mesh.py
+++ b/src/felupe/mesh/_mesh.py
@@ -78,6 +78,8 @@ class Mesh(DiscreteGeometry):
 
         super().__init__(points=points, cells=cells, cell_type=cell_type)
 
+        self.__mesh__ = Mesh
+
     def __repr__(self):
         header = "<felupe mesh object>"
         points = f"  Number of points: {len(self.points)}"

--- a/src/felupe/mesh/_mesh.py
+++ b/src/felupe/mesh/_mesh.py
@@ -25,6 +25,7 @@ along with Felupe.  If not, see <http://www.gnu.org/licenses/>.
 
 """
 
+from copy import deepcopy
 from functools import wraps
 
 import numpy as np
@@ -87,6 +88,63 @@ class Mesh(DiscreteGeometry):
 
     def __str__(self):
         return self.__repr__()
+
+    def disconnect(self, points_per_cell=None, calc_points=True):
+        """Return a new instance of a Mesh with disconnected cells. Optionally, the
+        points-per-cell may be specified (must be lower or equal the number of points-
+        per-cell of the original Mesh). If the Mesh is to be used as a *dual* Mesh, then
+        the point-coordinates do not have to be re-created because they are not used."""
+
+        cells_trimmed = self.cells
+        cell_type = self.cell_type
+
+        if points_per_cell is not None:
+            cell_type = None
+            cells_trimmed = cells_trimmed[:, :points_per_cell]
+
+        if calc_points:
+            points = self.points[cells_trimmed].reshape(-1, self.dim)
+        else:
+            points = np.zeros(
+                (self.ncells * cells_trimmed.shape[1], self.dim), dtype=int
+            )
+
+        cells = np.arange(cells_trimmed.size).reshape(*cells_trimmed.shape)
+
+        return Mesh(points, cells, cell_type=cell_type)
+
+    def as_meshio(self, **kwargs):
+        "Export the mesh as ``meshio.Mesh``."
+
+        import meshio
+
+        cells = {self.cell_type: self.cells}
+        return meshio.Mesh(self.points, cells, **kwargs)
+
+    def save(self, filename="mesh.vtk", **kwargs):
+        """Export the mesh as VTK file. For XDMF-export please ensure to have
+        ``h5py`` (as an optional dependancy of ``meshio``) installed.
+
+        Parameters
+        ----------
+        filename : str, optional
+            The filename of the mesh (default is ``mesh.vtk``).
+
+        """
+
+        self.as_meshio(**kwargs).write(filename)
+
+    def copy(self):
+        """Return a deepcopy of the mesh.
+
+        Returns
+        -------
+        Mesh
+            A deepcopy of the mesh.
+
+        """
+
+        return deepcopy(self)
 
     @wraps(expand)
     def expand(self, n=11, z=1):

--- a/src/felupe/mesh/_tools.py
+++ b/src/felupe/mesh/_tools.py
@@ -331,7 +331,7 @@ def mirror(
 def concatenate(meshes):
     "Join a sequence of meshes with identical cell types."
 
-    Mesh = type(meshes[0])
+    Mesh = meshes[0].__mesh__
 
     points = np.vstack([mesh.points for mesh in meshes])
     offsets = np.cumsum(np.insert([mesh.npoints for mesh in meshes][:-1], 0, 0))

--- a/src/felupe/mesh/_tools.py
+++ b/src/felupe/mesh/_tools.py
@@ -29,7 +29,6 @@ import numpy as np
 
 from ..math import rotation_matrix
 from ._helpers import mesh_or_data
-from ._mesh import Mesh
 
 
 @mesh_or_data
@@ -331,6 +330,8 @@ def mirror(
 
 def concatenate(meshes):
     "Join a sequence of meshes with identical cell types."
+
+    Mesh = type(meshes[0])
 
     points = np.vstack([mesh.points for mesh in meshes])
     offsets = np.cumsum(np.insert([mesh.npoints for mesh in meshes][:-1], 0, 0))

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -52,6 +52,7 @@ def test_meshes():
     fe.mesh.convert(m, order=0, calc_points=True)
     fe.mesh.convert(m, order=2)
     fe.mesh.convert(m, order=2, calc_midfaces=True)
+    m.convert(order=2)
 
     m = fe.Mesh(
         points=np.array([[0, 0, 0], [1, 0, 0], [0, 1, 0], [0, 0, 1]]),
@@ -69,6 +70,7 @@ def test_meshes():
     assert m.cells.shape == (4, 2)
 
     mr = fe.mesh.revolve(m, n=11, phi=180, axis=2)
+    mr = m.revolve(n=11, phi=180, axis=2)
     assert mr.ncells == 4 * 10
 
     m = fe.Rectangle(a=(-1.2, -2), b=(2, 3.1), n=(4, 9))
@@ -105,6 +107,7 @@ def test_meshes():
     fe.mesh.expand(m.points, cells=m.cells, cell_type=m.cell_type)
     fe.mesh.expand(points=m.points, cells=m.cells, cell_type=m.cell_type)
     fe.mesh.expand(m)
+    m.expand()
 
     me1 = fe.mesh.expand(m, n=3, z=1)
     me2 = fe.mesh.expand(m, n=3, z=1.0)
@@ -130,6 +133,7 @@ def test_meshes():
     fe.mesh.rotate(m, angle_deg=10, axis=0, center=None)
     fe.mesh.rotate(m.points, m.cells, m.cell_type, angle_deg=10, axis=0, center=None)
     fe.mesh.rotate(m, angle_deg=10, axis=1, center=[0, 0, 0])
+    m.rotate(angle_deg=10, axis=0, center=None)
 
     fe.mesh.CubeArbitraryOrderHexahedron()
     fe.mesh.RectangleArbitraryOrderQuad()
@@ -150,6 +154,7 @@ def test_meshes():
 
     fe.mesh.sweep(m)
     fe.mesh.sweep(m.points, m.cells, m.cell_type, decimals=4)
+    m.sweep()
 
     m.as_meshio(point_data={"data": m.points}, cell_data={"cell_data": [m.cells[:, 0]]})
     m.save()
@@ -176,6 +181,7 @@ def test_mirror():
             m = fe.mesh.Line()
             r = fe.Region(m, fe.Line(), fe.GaussLegendre(1, 1))
             n = fe.mesh.mirror(m, **kwargs)
+            n = m.mirror(**kwargs)
             s = fe.Region(n, fe.Line(), fe.GaussLegendre(1, 1))
             assert np.isclose(r.dV.sum(), s.dV.sum())
 
@@ -222,6 +228,7 @@ def test_mirror():
 def test_triangulate():
     m = fe.Rectangle(n=3)
     n = fe.mesh.triangulate(m)
+    n = m.triangulate()
 
     rm = fe.RegionQuad(m)
     rn = fe.RegionTriangle(n)
@@ -244,6 +251,7 @@ def test_triangulate():
 def test_runouts():
     m = fe.Rectangle(n=3)
 
+    n = m.add_runouts(values=[0.0], axis=0, centerpoint=[0, 0])
     n = fe.mesh.runouts(m, values=[0.0], axis=0, centerpoint=[0, 0])
     assert n.points[:, 1].max() == m.points[:, 1].max()
 
@@ -346,6 +354,16 @@ def test_read_nocells(filename="tests/mesh_no-cells.bdf"):
     assert mesh[0].cells.shape == (0, 0)
 
 
+def test_mesh_methods():
+    mesh = fe.Cube()
+    mesh.collect_edges()
+    mesh.collect_faces()
+    mesh.collect_volumes()
+    mesh.add_midpoints_edges()
+    mesh.add_midpoints_faces()
+    mesh.add_midpoints_volumes()
+
+
 if __name__ == "__main__":
     test_meshes()
     test_mirror()
@@ -356,4 +374,5 @@ if __name__ == "__main__":
     test_grid_1d()
     test_container()
     test_read(filename="mesh.bdf")
+    test_mesh_methods()
     test_read_nocells(filename="mesh_no-cells.bdf")


### PR DESCRIPTION
# A more object-oriented `Mesh`

- [x] rename old `Mesh` to `DiscreteGeometry`
- [x] create `Mesh` on top of `DiscreteGeometry`
- [x] add all mesh-related tools as methods to the new `Mesh` class 

closes #424

This enables

```python
import felupe as fem

fem.Rectangle(n=5).expand(n=4, z=1)
```

in addition to the still useful but sometimes very lengthy code

```python
import felupe as fem

rect = fem.Rectangle(n=5)
cube = fem.mesh.expand(rect, n=4, z=1)
```