### PR TITLE
`Job.evaluate(verbose=True)`: Further reduce the output

### DIFF
--- a/docs/examples/platewithhole.ipynb
+++ b/docs/examples/platewithhole.ipynb
@@ -72,9 +72,7 @@
    "outputs": [],
    "source": [
     "mesh = fem.Mesh(\n",
-    "    points=mesh.points[:, :2], \n",
-    "    cells=mesh.cells[1].data, \n",
-    "    cell_type=mesh.cells[1].type\n",
+    "    points=mesh.points[:, :2], cells=mesh.cells[1].data, cell_type=mesh.cells[1].type\n",
     ")"
    ]
   },
@@ -176,15 +174,18 @@
    "outputs": [],
    "source": [
     "import numpy as np\n",
-    "    \n",
+    "\n",
+    "\n",
     "def von_mises(field, **kwargs):\n",
     "    \"Von Mises Stress projected to mesh points.\"\n",
     "\n",
     "    stress = solid.evaluate.gradient(field)[0]\n",
     "\n",
     "    vonmises = np.sqrt(\n",
-    "        stress[0, 0] ** 2 + stress[1, 1] ** 2 + 3 * stress[0, 1] ** 2 +\n",
-    "        stress[0, 0] * stress[1, 1]\n",
+    "        stress[0, 0] ** 2\n",
+    "        + stress[1, 1] ** 2\n",
+    "        + 3 * stress[0, 1] ** 2\n",
+    "        + stress[0, 0] * stress[1, 1]\n",
     "    )\n",
     "\n",
     "    return fem.project(vonmises, region)"
@@ -279,7 +280,7 @@
     "plt.plot(\n",
     "    fem.tools.project(solid.results.stress[0], region)[:, 0][left],\n",
     "    mesh.points[:, 1][left] / h,\n",
-    "    \"o-\"\n",
+    "    \"o-\",\n",
     ")\n",
     "\n",
     "plt.xlabel(r\"$\\sigma_{11}(x=0, y)$ in MPa $\\longrightarrow$\")\n",

--- a/src/felupe/__init__.py
+++ b/src/felupe/__init__.py
@@ -97,7 +97,7 @@ from .region import (
     RegionTriQuadraticHexahedron,
     RegionTriQuadraticHexahedronBoundary,
 )
-from .tools import View, ViewXdmf, newtonrhapson, project, save, topoints, runs_on
+from .tools import View, ViewXdmf, newtonrhapson, project, runs_on, save, topoints
 
 __all__ = [
     "__version__",

--- a/src/felupe/__init__.py
+++ b/src/felupe/__init__.py
@@ -97,7 +97,7 @@ from .region import (
     RegionTriQuadraticHexahedron,
     RegionTriQuadraticHexahedronBoundary,
 )
-from .tools import View, ViewXdmf, newtonrhapson, project, save, topoints
+from .tools import View, ViewXdmf, newtonrhapson, project, save, topoints, runs_on
 
 __all__ = [
     "__version__",
@@ -198,4 +198,5 @@ __all__ = [
     "topoints",
     "View",
     "ViewXdmf",
+    "runs_on",
 ]

--- a/src/felupe/mechanics/_job.py
+++ b/src/felupe/mechanics/_job.py
@@ -16,12 +16,10 @@ You should have received a copy of the GNU General Public License
 along with FElupe.  If not, see <http://www.gnu.org/licenses/>.
 """
 
-from platform import architecture, machine, platform
-
 import numpy as np
 
-from ..__about__ import __version__ as version
 from ..math import dot, eigh, eigvalsh, tovoigt, transpose
+from ..tools._misc import logo, runs_on
 
 
 def displacement(field, substep=None):
@@ -55,27 +53,8 @@ def log_strain(field, substep=None):
     return [tovoigt(strain.mean(-2), True).T]
 
 
-def header(verbose):
-    if verbose == 1:
-        return "\n".join([
-            f"FElupe Version {version}",
-            f"{platform(terse=True)} {machine()} {architecture()[0]}",
-            "",
-        ])
-    elif verbose > 1:
-        return f"""
- _______  _______  ___      __   __  _______  _______
-|       ||       ||   |    |  | |  ||       ||       |
-|    ___||    ___||   |    |  | |  ||    _  ||    ___|
-|   |___ |   |___ |   |    |  |_|  ||   |_| ||   |___
-|    ___||    ___||   |___ |       ||    ___||    ___|
-|   |    |   |___ |       ||       ||   |    |   |___
-|___|    |_______||_______||_______||___|    |_______|
-FElupe Version {version} ({platform(terse=True)} {machine()} {architecture()[0]})
-
-Run Job
-=======
-"""
+def print_header():
+    print("\n".join([logo(), runs_on(), "", "Run Job", "======="]))
 
 
 class Job:
@@ -118,8 +97,8 @@ class Job:
         except ModuleNotFoundError:
             verbose = 2
 
-        if verbose:
-            print(header(verbose))
+        if verbose == 2:
+            print_header()
 
         if parallel:
             if "kwargs" not in kwargs.keys():
@@ -171,7 +150,7 @@ class Job:
 
             if verbose == 1:
                 total = sum([step.nsubsteps for step in self.steps])
-                progress_bar = tqdm(total=total, unit=" substeps")
+                progress_bar = tqdm(total=total, unit="substep")
 
             for j, step in enumerate(self.steps):
 

--- a/src/felupe/tools/__init__.py
+++ b/src/felupe/tools/__init__.py
@@ -1,3 +1,4 @@
+from ._misc import logo, runs_on
 from ._newton import fun_items as fun
 from ._newton import jac_items as jac
 from ._newton import newtonrhapson
@@ -16,6 +17,8 @@ __all__ = [
     "moment",
     "project",
     "topoints",
+    "logo",
+    "runs_on",
     "save",
     "solve",
     "View",

--- a/src/felupe/tools/_misc.py
+++ b/src/felupe/tools/_misc.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+"""
+This file is part of FElupe.
+
+FElupe is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+FElupe is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with FElupe.  If not, see <http://www.gnu.org/licenses/>.
+"""
+
+from platform import architecture, machine, platform
+
+from ..__about__ import __version__ as version
+
+
+def logo():
+    return "\n".join(
+        [
+            " _______  _______  ___      __   __  _______  _______",
+            "|       ||       ||   |    |  | |  ||       ||       |",
+            "|    ___||    ___||   |    |  | |  ||    _  ||    ___|",
+            "|   |___ |   |___ |   |    |  |_|  ||   |_| ||   |___",
+            "|    ___||    ___||   |___ |       ||    ___||    ___|",
+            "|   |    |   |___ |       ||       ||   |    |   |___",
+            "|___|    |_______||_______||_______||___|    |_______|",
+        ]
+    )
+
+
+def runs_on():
+    return "\n".join(
+        [
+            f"FElupe Version {version}",
+            f"{platform(terse=True)} {machine()} {architecture()[0]}",
+        ]
+    )

--- a/src/felupe/tools/_plot.py
+++ b/src/felupe/tools/_plot.py
@@ -163,7 +163,7 @@ class Scene:
                     component_labels = component_labels_dict[dim]
 
                 component_label = component_labels[component]
-    
+
             else:
                 component_label = "Magnitude"
 


### PR DESCRIPTION
- [x] change hardcoded strings to `logo()` and `runs_on()` functions and move to `tools/`
- [x] don't print the version tag and the platform information on the default verbosity