### PR TITLE
Warp the mesh for `View.plot(name=None)`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,11 @@ All notable changes to this project will be documented in this file. The format 
 - Add optional point- and cell-data args for `ViewMesh(mesh, point_data=None, cell_data=None)` like already implemented in `ViewField`.
 - Enforce contiguous arrays in `UserMaterialHyperelastic` (enhance performance).
 - `View`: Switch from `ViewField` to `ViewSolid`.
+- `View`: Always plot the undeformed mesh with `opacity=0.2` and `show_edges=False`.
 
 ### Fixed
 - Don't warp the mesh in `ViewMesh.plot()`.
+- Warp the mesh in case no name is passed in `View.plot(name=None)`.
 
 ## [7.4.1] - 2023-05-02
 

--- a/src/felupe/tools/_plot.py
+++ b/src/felupe/tools/_plot.py
@@ -174,34 +174,28 @@ class Scene:
             show_edges_undeformed = False
             opacity_undeformed = 0.2
 
-            if name is None:
-                show_edges_undeformed = show_edges
-                opacity_undeformed = None
-
             plotter.add_mesh(
                 self.mesh, show_edges=show_edges_undeformed, opacity=opacity_undeformed
             )
 
-        if name is not None:
+        mesh = self.mesh
+        if "Displacement" in self.mesh.point_data.keys():
+            mesh = mesh.warp_by_vector("Displacement", factor=factor)
 
-            mesh = self.mesh
-            if "Displacement" in self.mesh.point_data.keys():
-                mesh = mesh.warp_by_vector("Displacement", factor=factor)
-
-            plotter.add_mesh(
-                mesh=mesh,
-                scalars=name,
-                component=component,
-                show_edges=show_edges,
-                cmap=cmap,
-                scalar_bar_args={
-                    "title": label,
-                    "interactive": True,
-                    "vertical": scalar_bar_vertical,
-                    **scalar_bar_args,
-                },
-                **kwargs,
-            )
+        plotter.add_mesh(
+            mesh=mesh,
+            scalars=name,
+            component=component,
+            show_edges=show_edges,
+            cmap=cmap,
+            scalar_bar_args={
+                "title": label,
+                "interactive": True,
+                "vertical": scalar_bar_vertical,
+                **scalar_bar_args,
+            },
+            **kwargs,
+        )
 
         if view == "default":
 


### PR DESCRIPTION
and always show a transparent undeformed mesh. In `ViewMesh`, this results in two identical mesh plots. If it makes problems, change that in the future.

closes #480 