### PR TITLE
Rename internal `IntegralFormMixed` to `IntegralForm`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file. The format 
 - `View`: Always plot the undeformed mesh with `opacity=0.2` and `show_edges=False`.
 - Rename `UserMaterial` to `Material`, `UserMaterialStrain` to `MaterialStrain`, `UserMaterialHyperelastic` to `Hyperelastic` (keep old alias names until next major release).
 - Use consistent indices in `einsum()` for (elementwise operating) trailing axes: `q` for quadrature point and `c` for cell.
+- Rename internal `IntegralFormMixed` to `IntegralForm`, which is now consistent internally and in the top-level namespace. The previous internal base-class for a single-field `IntegralForm` is renamed to `WeakForm`.
 
 ### Fixed
 - Don't warp the mesh in `ViewMesh.plot()`.

--- a/docs/howto/axi.rst
+++ b/docs/howto/axi.rst
@@ -25,7 +25,7 @@ For simplicity, let's assume a (built-in) Neo-Hookean material.
     umat = fem.NeoHooke(mu=1, bulk=5)
 
 
-FElupe provides an adopted :class:`felupe.IntegralFormAxisymmetric` class for the integration and the sparse matrix assemblage of axisymmetric problems under hood. It uses the additional information (e.g. radial coordinates at integration points) stored in :class:`felupe.FieldAxisymmetric` to provide a consistent interface in comparison to default IntegralForms.
+Internally, FElupe provides an adopted :class:`felupe.IntegralFormAxisymmetric` class for the integration and the sparse matrix assemblage of axisymmetric problems. It uses the additional information (e.g. radial coordinates at integration points) stored in :class:`felupe.FieldAxisymmetric` to provide a consistent interface in comparison to default IntegralForms.
 
 ..  code-block:: python
 

--- a/src/felupe/__init__.py
+++ b/src/felupe/__init__.py
@@ -11,8 +11,7 @@ from . import (
     tools,
 )
 from .__about__ import __version__
-from ._assembly import Form
-from ._assembly import IntegralFormMixed as IntegralForm
+from ._assembly import Form, IntegralForm
 from ._basis import BasisMixed as Basis
 from ._field import (
     Field,

--- a/src/felupe/_assembly/__init__.py
+++ b/src/felupe/_assembly/__init__.py
@@ -1,23 +1,15 @@
 from ._axi import IntegralFormAxisymmetric
-from ._base import IntegralForm
-from ._form import (
-    BaseForm,
-    BilinearForm,
-    BilinearFormMixed,
-    Form,
-    LinearForm,
-    LinearFormMixed,
-)
-from ._mixed import IntegralFormMixed
+from ._form import BilinearForm, BilinearFormMixed, Form, LinearForm, LinearFormMixed
+from ._integral import IntegralForm
+from ._weak import WeakForm
 
 __all__ = [
+    "WeakForm",
     "IntegralFormAxisymmetric",
     "IntegralForm",
-    "BaseForm",
     "BilinearForm",
     "BilinearFormMixed",
     "Form",
     "LinearForm",
     "LinearFormMixed",
-    "IntegralFormMixed",
 ]

--- a/src/felupe/_assembly/_axi.py
+++ b/src/felupe/_assembly/_axi.py
@@ -20,10 +20,10 @@ import numpy as np
 
 from .._field._axi import FieldAxisymmetric
 from .._field._base import Field
-from ._base import IntegralForm
+from ._weak import WeakForm
 
 
-class IntegralFormAxisymmetric(IntegralForm):
+class IntegralFormAxisymmetric(WeakForm):
     def __init__(self, fun, v, dV, u=None, grad_v=True, grad_u=True):
         R = v.radius
         self.dV = 2 * np.pi * R * dV
@@ -39,15 +39,15 @@ class IntegralFormAxisymmetric(IntegralForm):
                     fun_2d = fun[:-1]
                     fun_zz = fun[-1].reshape(1, *fun[-1].shape) / R
 
-                form_a = IntegralForm(fun_2d, v, self.dV, grad_v=grad_v)
-                form_b = IntegralForm(fun_zz, v.scalar, self.dV)
+                form_a = WeakForm(fun_2d, v, self.dV, grad_v=grad_v)
+                form_b = WeakForm(fun_zz, v.scalar, self.dV)
 
                 self.forms = [form_a, form_b]
 
             else:
                 self.mode = 10
 
-                form_a = IntegralForm(fun, v, self.dV, grad_v=False)
+                form_a = WeakForm(fun, v, self.dV, grad_v=False)
                 self.forms = [
                     form_a,
                 ]
@@ -57,10 +57,10 @@ class IntegralFormAxisymmetric(IntegralForm):
                 self.mode = 2
 
                 if grad_v and grad_u:
-                    form_aa = IntegralForm(
+                    form_aa = WeakForm(
                         fun[:-1, :-1, :-1, :-1], v, self.dV, u, True, True
                     )
-                    form_bb = IntegralForm(
+                    form_bb = WeakForm(
                         fun[-1, -1, -1, -1] / R**2,
                         v.scalar,
                         self.dV,
@@ -68,18 +68,16 @@ class IntegralFormAxisymmetric(IntegralForm):
                         False,
                         False,
                     )
-                    form_ba = IntegralForm(
+                    form_ba = WeakForm(
                         fun[-1, -1, :-1, :-1] / R, v.scalar, self.dV, u, False, True
                     )
-                    form_ab = IntegralForm(
+                    form_ab = WeakForm(
                         fun[:-1, :-1, -1, -1] / R, v, self.dV, u.scalar, True, False
                     )
 
                 if not grad_v and grad_u:
-                    form_aa = IntegralForm(
-                        fun[:-1, :-1, :-1], v, self.dV, u, False, True
-                    )
-                    form_bb = IntegralForm(
+                    form_aa = WeakForm(fun[:-1, :-1, :-1], v, self.dV, u, False, True)
+                    form_bb = WeakForm(
                         fun[-1, -1, -1] / R**2,
                         v.scalar,
                         self.dV,
@@ -87,10 +85,10 @@ class IntegralFormAxisymmetric(IntegralForm):
                         False,
                         False,
                     )
-                    form_ba = IntegralForm(
+                    form_ba = WeakForm(
                         fun[-1, :-1, :-1] / R, v.scalar, self.dV, u, False, True
                     )
-                    form_ab = IntegralForm(
+                    form_ab = WeakForm(
                         fun[:-1, -1, -1] / R, v, self.dV, u.scalar, False, False
                     )
 
@@ -99,17 +97,15 @@ class IntegralFormAxisymmetric(IntegralForm):
             elif isinstance(v, FieldAxisymmetric) and isinstance(u, Field):
                 self.mode = 30
 
-                form_a = IntegralForm(fun[:-1, :-1], v, self.dV, u, True, False)
-                form_b = IntegralForm(
-                    fun[-1, -1] / R, v.scalar, self.dV, u, False, False
-                )
+                form_a = WeakForm(fun[:-1, :-1], v, self.dV, u, True, False)
+                form_b = WeakForm(fun[-1, -1] / R, v.scalar, self.dV, u, False, False)
 
                 self.forms = [form_a, form_b]
 
             elif isinstance(v, Field) and isinstance(u, Field):
                 self.mode = 40
 
-                form_a = IntegralForm(fun, v, self.dV, u, False, False)
+                form_a = WeakForm(fun, v, self.dV, u, False, False)
 
                 self.forms = [
                     form_a,

--- a/src/felupe/_assembly/_form.py
+++ b/src/felupe/_assembly/_form.py
@@ -21,8 +21,8 @@ from threading import Thread
 import numpy as np
 
 from .._basis import BasisMixed
-from ._base import IntegralForm
-from ._mixed import IntegralFormMixed
+from ._integral import IntegralForm
+from ._weak import WeakForm
 
 
 class LinearForm:
@@ -51,7 +51,7 @@ class LinearForm:
         else:
             self.dx = dx
 
-        self._form = IntegralForm(fun=None, v=v.field, dV=self.dx, grad_v=grad_v)
+        self._form = WeakForm(fun=None, v=v.field, dV=self.dx, grad_v=grad_v)
 
     def integrate(self, weakform, args=(), kwargs={}, parallel=False):
         r"""Return evaluated (but not assembled) integrals.
@@ -161,7 +161,7 @@ class BilinearForm:
         else:
             self.dx = dx
 
-        self._form = IntegralForm(None, v.field, self.dx, u.field, grad_v, grad_u)
+        self._form = WeakForm(None, v.field, self.dx, u.field, grad_v, grad_u)
 
     def integrate(self, weakform, args=(), kwargs={}, parallel=False, sym=False):
         r"""Return evaluated (but not assembled) integrals.
@@ -303,7 +303,7 @@ class LinearFormMixed:
     def __init__(self, v, grad_v=None):
         self.v = v
         self.dx = self.v.field[0].region.dV
-        self._form = IntegralFormMixed(
+        self._form = IntegralForm(
             np.zeros(len(v.field.fields)), self.v.field, self.dx, grad_v=grad_v
         )
 
@@ -406,7 +406,7 @@ class BilinearFormMixed:
         self.grad_v = _set_first_grad_true(grad_v, self.v.field.fields)
         self.grad_u = _set_first_grad_true(grad_u, self.u.field.fields)
 
-        self._form = IntegralFormMixed(
+        self._form = IntegralForm(
             fun=np.zeros(len(self.i)),
             v=self.v.field,
             dV=self.dx,

--- a/src/felupe/_assembly/_integral.py
+++ b/src/felupe/_assembly/_integral.py
@@ -23,10 +23,10 @@ from .._field._axi import FieldAxisymmetric
 from .._field._base import Field
 from .._field._planestrain import FieldPlaneStrain
 from ._axi import IntegralFormAxisymmetric
-from ._base import IntegralForm
+from ._weak import WeakForm
 
 
-class IntegralFormMixed:
+class IntegralForm:
     def __init__(self, fun, v, dV, u=None, grad_v=None, grad_u=None):
         self.fun = fun
         self.v = v.fields
@@ -41,8 +41,8 @@ class IntegralFormMixed:
             self.nu = None
 
         IntForm = {
-            Field: IntegralForm,
-            FieldPlaneStrain: IntegralForm,
+            Field: WeakForm,
+            FieldPlaneStrain: WeakForm,
             FieldAxisymmetric: IntegralFormAxisymmetric,
         }[type(self.v[0])]
 

--- a/src/felupe/_assembly/_weak.py
+++ b/src/felupe/_assembly/_weak.py
@@ -26,8 +26,8 @@ except ModuleNotFoundError:
 from scipy.sparse import csr_matrix as sparsematrix
 
 
-class IntegralForm:
-    r"""Integral Form constructed by a function result ``fun``,
+class WeakForm:
+    r"""Single-Field Integral-Form constructed by a function result ``fun``,
     a virtual field ``v``, differential volumes ``dV`` and optionally a
     field ``u``. For both fields ``v`` and ``u`` gradients may be passed by
     setting ``grad_v`` and ``grad_u`` to True (default is False for both).

--- a/src/felupe/mechanics/_helpers.py
+++ b/src/felupe/mechanics/_helpers.py
@@ -17,7 +17,7 @@ along with FElupe.  If not, see <http://www.gnu.org/licenses/>.
 """
 import numpy as np
 
-from .._assembly import IntegralFormMixed
+from .._assembly import IntegralForm
 from .._field import FieldAxisymmetric
 from ..constitution import AreaChange
 from ..math import det
@@ -85,7 +85,7 @@ class StateNearlyIncompressible:
     def h(self, parallel=False):
         "Integrated shape-function gradient w.r.t. the deformed coordinates `x`."
 
-        return IntegralFormMixed(
+        return IntegralForm(
             fun=self.dJdF(self.F), v=self.field, dV=self.field.region.dV
         ).integrate(parallel=parallel)[0]
 

--- a/src/felupe/mechanics/_solidbody.py
+++ b/src/felupe/mechanics/_solidbody.py
@@ -18,7 +18,7 @@ along with FElupe.  If not, see <http://www.gnu.org/licenses/>.
 
 import numpy as np
 
-from .._assembly import IntegralFormMixed
+from .._assembly import IntegralForm
 from ..constitution import AreaChange
 from ..math import det, dot, transpose
 from ._helpers import Assemble, Evaluate, Results
@@ -56,7 +56,7 @@ class SolidBody:
 
         self._area_change = AreaChange()
 
-        self._form = IntegralFormMixed
+        self._form = IntegralForm
 
     def _vector(self, field=None, parallel=False, items=None, args=(), kwargs={}):
         if field is not None:

--- a/src/felupe/mechanics/_solidbody_gravity.py
+++ b/src/felupe/mechanics/_solidbody_gravity.py
@@ -19,7 +19,7 @@ along with FElupe.  If not, see <http://www.gnu.org/licenses/>.
 import numpy as np
 from scipy.sparse import csr_matrix
 
-from .._assembly import IntegralFormMixed
+from .._assembly import IntegralForm
 from ._helpers import Assemble, Results
 
 
@@ -30,7 +30,7 @@ class SolidBodyGravity:
         self.field = field
         self.results = Results(stress=False, elasticity=False)
         self.assemble = Assemble(vector=self._vector, matrix=self._matrix)
-        self._form = IntegralFormMixed
+        self._form = IntegralForm
 
         self.results.gravity = np.array(gravity)
         self.results.density = density

--- a/src/felupe/mechanics/_solidbody_incompressible.py
+++ b/src/felupe/mechanics/_solidbody_incompressible.py
@@ -18,7 +18,7 @@ along with FElupe.  If not, see <http://www.gnu.org/licenses/>.
 
 import numpy as np
 
-from .._assembly import IntegralFormMixed
+from .._assembly import IntegralForm
 from .._field import FieldAxisymmetric
 from ..constitution import AreaChange
 from ..math import ddot, det, dot, dya, transpose
@@ -62,7 +62,7 @@ class SolidBodyNearlyIncompressible:
         self.bulk = bulk
 
         self._area_change = AreaChange()
-        self._form = IntegralFormMixed
+        self._form = IntegralForm
 
         # volume of undeformed configuration
         if isinstance(self.field[0], FieldAxisymmetric):

--- a/src/felupe/mechanics/_solidbody_pressure.py
+++ b/src/felupe/mechanics/_solidbody_pressure.py
@@ -16,7 +16,7 @@ You should have received a copy of the GNU General Public License
 along with FElupe.  If not, see <http://www.gnu.org/licenses/>.
 """
 
-from .._assembly import IntegralFormMixed
+from .._assembly import IntegralForm
 from ..constitution import AreaChange
 from ._helpers import Assemble, Results
 
@@ -64,7 +64,7 @@ class SolidBodyPressure:
 
         fun[0] *= self.results.pressure
 
-        self.results.force = IntegralFormMixed(
+        self.results.force = IntegralForm(
             fun=fun, v=self.field, dV=self.field.region.dV, grad_v=[False]
         ).assemble(parallel=parallel)
 
@@ -89,7 +89,7 @@ class SolidBodyPressure:
 
         fun[0] *= self.results.pressure
 
-        self.results.stiffness = IntegralFormMixed(
+        self.results.stiffness = IntegralForm(
             fun=fun,
             v=self.field,
             u=self.field,

--- a/src/felupe/tools/_newton.py
+++ b/src/felupe/tools/_newton.py
@@ -24,7 +24,7 @@ from scipy.sparse import csr_matrix
 from scipy.sparse.linalg import spsolve
 
 from .. import solve as fesolve
-from .._assembly import IntegralFormMixed
+from .._assembly import IntegralForm
 from ..math import norm
 
 
@@ -93,7 +93,7 @@ def fun(x, umat, parallel=False, grad=True, add_identity=True, sym=False):
     "Force residuals from assembly of equilibrium (weak form)."
 
     return (
-        IntegralFormMixed(
+        IntegralForm(
             fun=umat.gradient(x.extract(grad=grad, add_identity=add_identity, sym=sym))[
                 :-1
             ],
@@ -108,7 +108,7 @@ def fun(x, umat, parallel=False, grad=True, add_identity=True, sym=False):
 def jac(x, umat, parallel=False, grad=True, add_identity=True, sym=False):
     "Tangent stiffness matrix from assembly of linearized equilibrium."
 
-    return IntegralFormMixed(
+    return IntegralForm(
         fun=umat.hessian(x.extract(grad=grad, add_identity=add_identity, sym=sym)),
         v=x,
         dV=x.region.dV,


### PR DESCRIPTION
Rename internal `IntegralFormMixed` to `IntegralForm`, which is now consistent internally and in the top-level namespace. The previous internal base-class for a single-field `IntegralForm` is renamed to `WeakForm`.