### PR TITLE
Enhance plotting in a characteristic-curve job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file. The format 
 ### Added
 - Add `ViewSolid`, which enables `view = ViewSolid(field, solid=None)` the view of cauchy stresses, e.g. `view.plot("Principal Values of Cauchy Stress").show()`.
 - Add constitutive models to top-level namespace, e.g. `yeoh()` from `constitution.yeoh()`. This makes typing hyperelastic material formulations shorter: `Hyperelastic(yeoh, C10=0.5, C20=-0.1, C30=0.02)`.
+- Add `CharacteristicCurve.plot(swapaxes=False)`.
 
 ### Changed
 - Add optional point- and cell-data args for `ViewMesh(mesh, point_data=None, cell_data=None)` like already implemented in `ViewField`.
@@ -15,6 +16,7 @@ All notable changes to this project will be documented in this file. The format 
 - Rename `UserMaterial` to `Material`, `UserMaterialStrain` to `MaterialStrain`, `UserMaterialHyperelastic` to `Hyperelastic` (keep old alias names until next major release).
 - Use consistent indices in `einsum()` for (elementwise operating) trailing axes: `q` for quadrature point and `c` for cell.
 - Rename internal `IntegralFormMixed` to `IntegralForm`, which is now consistent internally and in the top-level namespace. The previous internal base-class for a single-field `IntegralForm` is renamed to `WeakForm`.
+- Don't plot x- and y-labels in `CharacteristicCurve.plot(xlabel=None, ylabel=None)` if they are not specified.
 
 ### Fixed
 - Don't warp the mesh in `ViewMesh.plot()`.

--- a/src/felupe/mechanics/_curve.py
+++ b/src/felupe/mechanics/_curve.py
@@ -57,11 +57,12 @@ class CharacteristicCurve(Job):
         y=None,
         xaxis=0,
         yaxis=0,
-        xlabel="x",
-        ylabel="y",
+        xlabel=None,
+        ylabel=None,
         xscale=1,
         yscale=1,
         gradient=False,
+        swapaxes=False,
         fig=None,
         ax=None,
         items=None,
@@ -94,8 +95,17 @@ class CharacteristicCurve(Job):
         if fig is None or ax is None:
             fig, ax = plt.subplots()
 
+        if swapaxes:
+            x, y = y, x
+            xlabel, ylabel = ylabel, xlabel
+            xscale, yscale = yscale, xscale
+
         ax.plot(x[:, xaxis] * xscale, y[:, yaxis] * yscale, **kwargs)
-        ax.set_xlabel(xlabel)
-        ax.set_ylabel(ylabel)
+
+        if xlabel is not None:
+            ax.set_xlabel(xlabel)
+
+        if ylabel is not None:
+            ax.set_ylabel(ylabel)
 
         return fig, ax

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -112,7 +112,7 @@ def test_curve_custom_items():
         steps=[step], items=step.items, boundary=step.boundaries["move"]
     )
     curve.evaluate()
-    curve.plot(xaxis=0, yaxis=0, gradient=True)
+    curve.plot(xaxis=0, yaxis=0, gradient=True, swapaxes=True, xlabel="x", ylabel="y")
     curve.plot(x=np.zeros((10, 2)), y=np.ones((10, 2)), xaxis=0, yaxis=0)
 
     stretch = 1 + np.array(curve.x)[:, 0]


### PR DESCRIPTION
- Don't plot x- and y-labels if they are not specified.
- Add a transposed plot: Switch/Flip x- and y-axes in the plot.