### PR TITLE
Add a minimalistic boundary-based quad- or hex-mesher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file. The format 
 ### Added
 - Add optional normalization of mesh runouts (which are then indents) by `mesh.runouts(normalize=False)`.
 - Add `LinearElasticLargeStrain(E=None, nu=None, parallel=False)`, suitable for large-rotation analyses. This is based on `NeoHooke()` with converted Lamé-constants.
+- Add a simple boundary-based quad- or hex mesher: A mesh tool for filling the face or volume between two line- or quad-meshes `mesh.fill_between(mesh, other_mesh, n=11)`.
 
 ### Removed
 - Remove tests on Python 3.7 (end of life).

--- a/src/felupe/mesh/__init__.py
+++ b/src/felupe/mesh/__init__.py
@@ -25,6 +25,7 @@ from ._read import read
 from ._tools import (
     concatenate,
     expand,
+    fill_between,
     flip,
     mirror,
     revolve,

--- a/src/felupe/mesh/_geometry.py
+++ b/src/felupe/mesh/_geometry.py
@@ -17,7 +17,9 @@ along with FElupe.  If not, see <http://www.gnu.org/licenses/>.
 """
 
 import numpy as np
+from scipy.interpolate import griddata
 
+from ..math import transpose
 from ._line_rectangle_cube import cube_hexa, line_line, rectangle_quad
 from ._mesh import Mesh
 

--- a/src/felupe/mesh/_mesh.py
+++ b/src/felupe/mesh/_mesh.py
@@ -34,6 +34,7 @@ from ._discrete_geometry import DiscreteGeometry
 from ._dual import dual
 from ._tools import (
     expand,
+    fill_between,
     flip,
     mirror,
     revolve,
@@ -177,6 +178,10 @@ class Mesh(DiscreteGeometry):
     @wraps(sweep)
     def sweep(self, decimals=None):
         return as_mesh(sweep(self, decimals=decimals))
+
+    @wraps(fill_between)
+    def fill_between(self, other_mesh, n=11):
+        return as_mesh(fill_between(self, other_mesh=other_mesh, n=n))
 
     @wraps(flip)
     def flip(self, mask=None):

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -397,6 +397,38 @@ def test_mesh_methods():
     assert isinstance(m, fe.Mesh)
 
 
+def test_mesh_fill_between():
+    # 2d
+    phi = np.linspace(1, 0.5, 11) * np.pi / 2
+
+    line = fe.mesh.Line(n=11)
+    bottom = line.copy()
+    top = line.copy()
+
+    bottom.points = 0.5 * np.vstack([np.cos(phi), np.sin(phi)]).T
+    top.points = np.vstack([np.linspace(0, 1, 11), np.linspace(1, 1, 11)]).T
+
+    face1 = bottom.fill_between(top, n=5)
+    face2 = fe.mesh.fill_between(bottom, top, n=5)
+
+    assert np.allclose(face1.points, face2.points)
+
+    # 3d
+    face = fe.Rectangle(n=(6, 7))
+
+    bottom = face.copy()
+    top = face.copy()
+
+    bottom.points = np.hstack([face.points, np.zeros((face.npoints, 1))])
+    top.points = np.hstack([face.points, np.ones((face.npoints, 1))])
+    top.points[:, 2] += np.random.rand(top.npoints) / 10
+
+    solid1 = bottom.fill_between(top, n=5)
+    solid2 = fe.mesh.fill_between(bottom, top, n=5)
+
+    assert np.allclose(solid1.points, solid2.points)
+
+
 if __name__ == "__main__":
     test_meshes()
     test_mirror()
@@ -409,3 +441,4 @@ if __name__ == "__main__":
     test_read(filename="mesh.bdf")
     test_mesh_methods()
     test_read_nocells(filename="mesh_no-cells.bdf")
+    test_mesh_fill_between()


### PR DESCRIPTION
```python
import numpy as np
import felupe as fem

phi = np.linspace(1, 0.5, 11) * np.pi / 2

# add a line-mesh object
line = fem.mesh.Line(n=11)
bottom = line.copy()
top = line.copy()

# replace points array for the bottom and top line
bottom.points = 0.5 * np.vstack([np.cos(phi), np.sin(phi)]).T
top.points = np.vstack([np.linspace(0, 1, 11), np.linspace(1, 1, 11)]).T

# fill the face with quads, mirror and concatenate both meshes
face = bottom.fill_between(top, n=5)
mesh = fem.mesh.concatenate([face, mesh.mirror(normal=(-1, 1, 0))])

fem.ViewMesh(mesh).plot().show()
```

![image](https://github.com/adtzlr/felupe/assets/5793153/ab738528-9734-454c-92e6-ec675a2cf32d)
