### PR TITLE
Fix `mesh.concatenate()` for a list of length one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ All notable changes to this project will be documented in this file. The format 
 ### Changed
 - Change `mesh.Circle(n=6)` to the minimum `mesh.Circle(n=2)`.
 
+### Fixed
+- Fix `mesh.concatenate([mesh])` for a list of length one by enforcing the dtype of the offset as integer.
+
 ## [7.7.0] - 2023-08-31
 
 ### Added

--- a/src/felupe/mesh/_tools.py
+++ b/src/felupe/mesh/_tools.py
@@ -434,7 +434,9 @@ def concatenate(meshes):
 
     points = np.vstack([mesh.points for mesh in meshes])
     offsets = np.cumsum(np.insert([mesh.npoints for mesh in meshes][:-1], 0, 0))
-    cells = np.vstack([offset + mesh.cells for offset, mesh in zip(offsets, meshes)])
+    cells = np.vstack(
+        [int(offset) + mesh.cells for offset, mesh in zip(offsets, meshes)]
+    )
     mesh = Mesh(points=points, cells=cells, cell_type=meshes[0].cell_type)
 
     return mesh


### PR DESCRIPTION
fixes #527 