### PR TITLE
Fix `FieldsMixed()` for MINI-elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,15 @@ All notable changes to this project will be documented in this file. The format 
 
 ## [Unreleased]
 
+### Added
+- Add cell-type argument to `Mesh.add_midpoints_volumes(cell_type=None)` and its variants for edges and faces.
+
 ### Changed
 - Change function signature and enhance `dof.biaxial(field, lefts=(None, None), rights=(None, None), moves=(0.2, 0.2), axes=(0, 1), clampes=(False, False), sym=True)`. Now with a full-featured docstring including an example.
 - Change function signature and enhance `dof.shear(field, bottom=None, top=None, moves=(0.2, 0.0, 0.0), axes=(0, 1), sym=True)`. Now with a full-featured docstring including an example. This is not backward compatible! However, due to the fact, that this was previously a non-documented function this won't enforce a new major version.
+
+### Fixed
+- Fix `FieldsMixed()` for regions with MINI-element formulations: Disable the disconnection of the dual mesh.
 
 ### Removed
 - Remove `dof.planar()` because this is a special case of the biaxial load case `dof.biaxial(field, clampes=(True, False), moves=(0.2, 0), sym=False, axes=(0, 1))`.

--- a/src/felupe/_field/_fields.py
+++ b/src/felupe/_field/_fields.py
@@ -105,6 +105,19 @@ class FieldsMixed(FieldContainer):
                 RegionTriangleMINI: RegionTriangle,
                 RegionLagrange: RegionLagrange,
             }
+            mesh_kwargs = {
+                RegionHexahedron: {},
+                RegionQuad: {},
+                RegionQuadraticQuad: {},
+                RegionBiQuadraticQuad: {},
+                RegionQuadraticHexahedron: {},
+                RegionTriQuadraticHexahedron: {},
+                RegionQuadraticTetra: {},
+                RegionQuadraticTriangle: {},
+                RegionTetraMINI: {"disconnect": False},
+                RegionTriangleMINI: {"disconnect": False},
+                RegionLagrange: {},
+            }
             points_per_cell = {
                 RegionConstantHexahedron: 1,
                 RegionConstantQuad: 1,
@@ -129,6 +142,7 @@ class FieldsMixed(FieldContainer):
                     points_per_cell=points_per_cell[RegionDual],
                     offset=offset,
                     npoints=npoints,
+                    **mesh_kwargs[type(region)],
                 )
 
             region_dual = RegionDual(

--- a/src/felupe/mesh/_convert.py
+++ b/src/felupe/mesh/_convert.py
@@ -226,16 +226,9 @@ def collect_volumes(points, cells, cell_type):
 
 
 @mesh_or_data
-def add_midpoints_edges(points, cells, cell_type):
+def add_midpoints_edges(points, cells, cell_type, cell_type_new=None):
     """ "Add midpoints on edges for given points and cells
     and update cell_type accordingly."""
-
-    cell_types_new = {
-        "triangle": "triangle6",
-        "tetra": "tetra10",
-        "quad": "quad8",
-        "hexahedron": "hexahedron20",
-    }
 
     # collect edges
     points_edges, cells_edges, _ = collect_edges(
@@ -252,24 +245,21 @@ def add_midpoints_edges(points, cells, cell_type):
     points_new = np.vstack((points, points_edges))
     cells_new = np.hstack((cells, cells_edges))
 
-    return points_new, cells_new, cell_types_new[cell_type]
+    if cell_type_new is None:
+        cell_type_new = {
+            "triangle": "triangle6",
+            "tetra": "tetra10",
+            "quad": "quad8",
+            "hexahedron": "hexahedron20",
+        }[cell_type]
+
+    return points_new, cells_new, cell_type_new
 
 
 @mesh_or_data
-def add_midpoints_faces(points, cells, cell_type):
+def add_midpoints_faces(points, cells, cell_type, cell_type_new=None):
     """ "Add midpoints on faces for given points and cells
     and update cell_type accordingly."""
-
-    cell_types_new = {
-        None: None,
-        "triangle": None,
-        "triangle6": "triangle7",
-        "tetra10": "tetra14",
-        "quad": None,
-        "quad8": "quad9",
-        "hexahedron": None,
-        "hexahedron20": "hexahedron26",
-    }
 
     # collect faces
     points_faces, cells_faces, _ = collect_faces(
@@ -286,23 +276,25 @@ def add_midpoints_faces(points, cells, cell_type):
     points_new = np.vstack((points, points_faces))
     cells_new = np.hstack((cells, cells_faces))
 
-    return points_new, cells_new, cell_types_new[cell_type]
+    if cell_type_new is None:
+        cell_type_new = {
+            None: None,
+            "triangle": None,
+            "triangle6": "triangle7",
+            "tetra10": "tetra14",
+            "quad": None,
+            "quad8": "quad9",
+            "hexahedron": None,
+            "hexahedron20": "hexahedron26",
+        }[cell_type]
+
+    return points_new, cells_new, cell_type_new
 
 
 @mesh_or_data
-def add_midpoints_volumes(points, cells, cell_type):
+def add_midpoints_volumes(points, cells, cell_type, cell_type_new=None):
     """ "Add midpoints on volumes for given points and cells
     and update cell_type accordingly."""
-
-    cell_types_new = {
-        None: None,
-        "tetra": None,
-        "tetra10": None,
-        "tetra14": "tetra15",
-        "hexahedron": None,
-        "hexahedron20": None,
-        "hexahedron26": "hexahedron27",
-    }
 
     # collect volumes
     points_volumes, cells_volumes, _ = collect_volumes(
@@ -319,4 +311,15 @@ def add_midpoints_volumes(points, cells, cell_type):
     points_new = np.vstack((points, points_volumes))
     cells_new = np.hstack((cells, cells_volumes))
 
-    return points_new, cells_new, cell_types_new[cell_type]
+    if cell_type_new is None:
+        cell_type_new = {
+            None: None,
+            "tetra": None,
+            "tetra10": None,
+            "tetra14": "tetra15",
+            "hexahedron": None,
+            "hexahedron20": None,
+            "hexahedron26": "hexahedron27",
+        }[cell_type]
+
+    return points_new, cells_new, cell_type_new

--- a/src/felupe/mesh/_mesh.py
+++ b/src/felupe/mesh/_mesh.py
@@ -296,13 +296,13 @@ class Mesh(DiscreteGeometry):
         return collect_volumes(self)
 
     @wraps(add_midpoints_edges)
-    def add_midpoints_edges(self):
-        return add_midpoints_edges(self)
+    def add_midpoints_edges(self, cell_type=None):
+        return add_midpoints_edges(self, cell_type_new=cell_type)
 
     @wraps(add_midpoints_faces)
-    def add_midpoints_faces(self):
-        return add_midpoints_faces(self)
+    def add_midpoints_faces(self, cell_type=None):
+        return add_midpoints_faces(self, cell_type_new=cell_type)
 
     @wraps(add_midpoints_volumes)
-    def add_midpoints_volumes(self):
-        return add_midpoints_volumes(self)
+    def add_midpoints_volumes(self, cell_type=None):
+        return add_midpoints_volumes(self, cell_type_new=cell_type)


### PR DESCRIPTION
don't disconnect the dual mesh.

**Description**: *Fix nearly-incompressible hyperelasticity on (bubble-enriched MINI) triangle/tetrahedrons*.

Fixes #537 

```python
import felupe as fem
import pypardiso

mesh = fem.Cube(n=4).triangulate().add_midpoints_volumes(cell_type="tetra")
region = fem.RegionTetraMINI(mesh)
field = fem.FieldsMixed(region, n=3)

boundaries, loadcase = fem.dof.uniaxial(field, clamped=True)

umat = fem.ThreeFieldVariation(fem.NeoHooke(mu=1, bulk=5000))
solid = fem.SolidBody(umat, field)

move = fem.math.linsteps([0, 1], num=21)
step = fem.Step(items=[solid], ramp={boundaries["move"]: move}, boundaries=boundaries)

job = fem.CharacteristicCurve(steps=[step], boundary=boundaries["move"])
job.evaluate(tol=1e-3, solver=pypardiso.spsolve)
fig, ax = job.plot(
    xlabel="Displacement $u$ in mm $\longrightarrow$",
    ylabel="Normal Force $F$ in N $\longrightarrow$",
)

field.plot("Principal Values of Logarithmic Strain").show()
```

![image](https://github.com/adtzlr/felupe/assets/5793153/66d38ccc-c40d-4b80-ae6e-dfa074888302)

![image](https://github.com/adtzlr/felupe/assets/5793153/032f1cae-0852-416f-9676-da572008d144)
