### PR TITLE
`FieldsMixed(region, **kwargs)`: Merge `kwargs` for the dual region

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file. The format 
 ### Changed
 - Change function signature and enhance `dof.biaxial(field, lefts=(None, None), rights=(None, None), moves=(0.2, 0.2), axes=(0, 1), clampes=(False, False), sym=True)`. Now with a full-featured docstring including an example.
 - Change function signature and enhance `dof.shear(field, bottom=None, top=None, moves=(0.2, 0.0, 0.0), axes=(0, 1), sym=True)`. Now with a full-featured docstring including an example. This is not backward compatible! However, due to the fact, that this was previously a non-documented function this won't enforce a new major version.
+- Merge keyword-arguments for the dual-regions with hard-coded arguments in `FieldsMixed(region, **kwargs)`.
 
 ### Fixed
 - Fix `FieldsMixed()` for regions with MINI-element formulations: Disable the disconnection of the dual mesh.

--- a/src/felupe/_field/_fields.py
+++ b/src/felupe/_field/_fields.py
@@ -128,7 +128,7 @@ class FieldsMixed(FieldContainer):
                 RegionLagrange: None,
             }
 
-            kwargs0 = {}
+            kwargs0 = {"quadrature": region.quadrature, "grad": False}
 
             if isinstance(region, RegionLagrange):
                 kwargs0["order"] = region.order - 1
@@ -147,8 +147,6 @@ class FieldsMixed(FieldContainer):
 
             region_dual = RegionDual(
                 mesh,
-                quadrature=region.quadrature,
-                grad=False,
                 **{**kwargs0, **kwargs},
             )
 


### PR DESCRIPTION
User-given keyword-arguments will overwrite the hardcoded values for `grad` and `quadrature`.