### PR TITLE
Add support for Python 3.12

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     steps:
     - uses: actions/setup-python@v4
       with:
@@ -26,4 +26,4 @@ jobs:
         tox -- --cov felupe --cov-report xml --cov-report term
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v3
-      if: ${{ matrix.python-version == '3.11' }}
+      if: ${{ matrix.python-version == '3.12' }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ All notable changes to this project will be documented in this file. The format 
 ### Fixed
 - Fix `FieldsMixed()` for regions with MINI-element formulations: Disable the disconnection of the dual mesh.
 - Fix `dof.shear(sym=True)` which was previously ignored due to a wrong setup of the symmetry boundaries.
-- Fix the install command on Python 3.12 by adding an extra-index-url for VTK wheels (provided by Kitware).
+- Fix the install command on Python 3.12 by adding an extra-index-url for VTK wheels if they are not yet available on PyPI (the extra index is provided by Kitware).
+- Fix a warning because the timings of the Newton-Rhapson solver are printed from a one-dimensional array. Take the first item of the runtime-array to resolve this warning.
 
 ### Removed
 - Remove `dof.planar()` because this is a special case of the biaxial load case `dof.biaxial(field, clampes=(True, False), moves=(0.2, 0), sym=False, axes=(0, 1))`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,12 @@ All notable changes to this project will be documented in this file. The format 
 - Change function signature and enhance `dof.biaxial(field, lefts=(None, None), rights=(None, None), moves=(0.2, 0.2), axes=(0, 1), clampes=(False, False), sym=True)`. Now with a full-featured docstring including an example.
 - Change function signature and enhance `dof.shear(field, bottom=None, top=None, moves=(0.2, 0.0, 0.0), axes=(0, 1), sym=True)`. Now with a full-featured docstring including an example. This is not backward compatible! However, due to the fact, that this was previously a non-documented function this won't enforce a new major version.
 - Merge keyword-arguments for the dual-regions with hard-coded arguments in `FieldsMixed(region, **kwargs)`.
+- Replace `np.product()` (will be removed in NumPy 2.0) with the equivalent `np.prod()`.
 
 ### Fixed
 - Fix `FieldsMixed()` for regions with MINI-element formulations: Disable the disconnection of the dual mesh.
 - Fix `dof.shear(sym=True)` which was previously ignored due to a wrong setup of the symmetry boundaries.
+- Fix the install command on Python 3.12 by adding an extra-index-url for VTK wheels (provided by Kitware).
 
 ### Removed
 - Remove `dof.planar()` because this is a special case of the biaxial load case `dof.biaxial(field, clampes=(True, False), moves=(0.2, 0), sym=False, axes=(0, 1))`.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ FElupe is a Python 3.8+ 🐍 finite element analysis package 📦 focussing on t
 Install Python, fire up 🔥 a terminal and run 🏃
 
 ```shell
-pip install felupe[all] --extra-index-url https://wheels.vtk.org
+pip install --extra-index-url https://wheels.vtk.org felupe[all]
 ```
 
 where the extra-index-url pulls VTK-wheels if they are not (yet) available on PyPI and `[all]` installs all optional dependencies. FElupe has minimal requirements, all available at PyPI supporting all platforms.

--- a/README.md
+++ b/README.md
@@ -15,10 +15,10 @@ FElupe is a Python 3.8+ 🐍 finite element analysis package 📦 focussing on t
 Install Python, fire up 🔥 a terminal and run 🏃
 
 ```shell
-pip install felupe[all]
+pip install felupe[all] --extra-index-url https://wheels.vtk.org
 ```
 
-where `[all]` installs all optional dependencies. FElupe has minimal requirements, all available at PyPI supporting all platforms.
+where the extra-index-url pulls VTK-wheels if they are not (yet) available on PyPI and `[all]` installs all optional dependencies. FElupe has minimal requirements, all available at PyPI supporting all platforms.
 * `numpy` for array operations
 * `scipy` for sparse matrices
 * `tensortrax` for automatic differentiation

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -61,7 +61,7 @@ Install Python, open the terminal and run ``pip install felupe[all]``, where ``[
 
 .. code-block:: shell
 
-   pip install felupe[all]
+   pip install felupe[all] --extra-index-url https://wheels.vtk.org
 
 *optional:*
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -61,7 +61,7 @@ Install Python, open the terminal and run ``pip install felupe[all]``, where ``[
 
 .. code-block:: shell
 
-   pip install felupe[all] --extra-index-url https://wheels.vtk.org
+   pip install --extra-index-url https://wheels.vtk.org felupe[all]
 
 *optional:*
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ classifiers = [
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
   "Topic :: Scientific/Engineering",
   "Topic :: Scientific/Engineering :: Mathematics",
   "Topic :: Utilities"

--- a/src/felupe/__about__.py
+++ b/src/felupe/__about__.py
@@ -1,1 +1,1 @@
-__version__ = "7.11.0-dev"
+__version__ = "8.0.0-dev"

--- a/src/felupe/constitution/_user_materials.py
+++ b/src/felupe/constitution/_user_materials.py
@@ -135,7 +135,7 @@ class MaterialStrain:
     def __init__(self, material, dim=3, statevars=(0,), **kwargs):
         self.material = material
         self.statevars_shape = statevars
-        self.statevars_size = [np.product(shape) for shape in statevars]
+        self.statevars_size = [np.prod(shape) for shape in statevars]
         self.statevars_offsets = np.cumsum(self.statevars_size)
         self.nstatevars = sum(self.statevars_size)
 

--- a/src/felupe/math/_tensor.py
+++ b/src/felupe/math/_tensor.py
@@ -293,4 +293,4 @@ def reshape(A, shape, trailing_axes=2):
 
 def ravel(A, trailing_axes=2):
     ij, shape = np.split(A.shape, [-trailing_axes])
-    return reshape(A, shape=np.product(ij))
+    return reshape(A, shape=np.prod(ij))

--- a/src/felupe/tools/_newton.py
+++ b/src/felupe/tools/_newton.py
@@ -285,7 +285,7 @@ def newtonrhapson(
 
     if verbose:
         runtimes.append(perf_counter())
-        runtime = np.diff(runtimes)
+        runtime = np.diff(runtimes)[0]
         soltime = np.diff(soltimes).sum()
         print(
             "\nConverged in %d iterations (Assembly: %1.4g s, Solve: %1.4g s).\n"

--- a/src/felupe/tools/_project.py
+++ b/src/felupe/tools/_project.py
@@ -76,7 +76,7 @@ def project(values, region, average=True, mean=False):
     """
 
     dim = values.shape[:-2]
-    size = int(np.product(dim))
+    size = int(np.prod(dim))
     weights = region.quadrature.weights
 
     # transpose values

--- a/tox.ini
+++ b/tox.ini
@@ -8,8 +8,6 @@ setenv =
 deps =
     pytest
     pytest-cov
-    matplotlib
-    vtk
 extras = all
 commands =
     pytest {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@ deps =
     pytest
     pytest-cov
     matplotlib
+    vtk
 extras = all
 commands =
     pytest {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,8 @@ envlist = py3
 isolated_build = True
 
 [testenv]
+setenv =
+    PIP_EXTRA_INDEX_URL=https://wheels.vtk.org
 deps =
     pytest
     pytest-cov


### PR DESCRIPTION
Test on Python 3.12

- [x] ~`h5py` not compatible.~ **Update 2023-10-15**: 3.12 wheels have been released!
- [x] ~`pyvista` still not supported.~ **Update 2023-10-19**: VTK wheels are pulled from [wheels.vtk.org](https://wheels.vtk.org) (extra index url) in tox.ini. Since an extra-index-url is not possible in `pyproject.toml`, this has to be noted somewhere. see https://discourse.vtk.org/t/status-update-vtk-python-wheels/11212

### Compatibility with NumPy 2.0
- [x] fixes #546
- [x] fixes #547 