### PR TITLE
Add `FormItem(bilinearform, linearform=None)`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,14 @@ All notable changes to this project will be documented in this file. The format 
 
 ### Added
 - Add plot- and screenshot-methods to `Region` and `Scheme` (base class for quadratures).
+- Add `item = FormItem(bilinearform, linearform=None)` to be used as an item in a `Step(items=[item])`.
 
 ### Changed
 - Refactor the assembly-submodule. Move the weak-form expression-related classes to the `assembly.expression` submodule.
 - Move `Basis` to the new `assembly.expression` submodule.
 - Make the `field`-submodule public.
 - Always `import felupe as fem` in docs and tests.
+- Change default optional (keyword) arguments of a weak-form expression decorator from `Form(args=(), kwargs={})` to `Form(args=None, kwargs=None)`.
 
 ### Removed
 - Don't import `Basis` to the global namespace (not necessary as it is used only internally by the weak-`Form` expression decorator).

--- a/docs/felupe/assembly.rst
+++ b/docs/felupe/assembly.rst
@@ -26,6 +26,12 @@ Define weak-form expressions on-the-fly for flexible and general form expression
 
    Form
 
+Create an item out of bilinear and linear weak-form expressions for a Step.
+
+.. autosummary::
+
+   FormItem
+
 **Detailed API Reference**
 
 .. autoclass:: felupe.IntegralForm
@@ -34,3 +40,8 @@ Define weak-form expressions on-the-fly for flexible and general form expression
    :inherited-members:
 
 .. autofunction:: felupe.Form
+
+.. autoclass:: felupe.FormItem
+   :members:
+   :undoc-members:
+   :inherited-members:

--- a/src/felupe/__init__.py
+++ b/src/felupe/__init__.py
@@ -71,6 +71,7 @@ from .field import (
 )
 from .mechanics import (
     CharacteristicCurve,
+    FormItem,
     Job,
     MultiPointConstraint,
     MultiPointContact,
@@ -133,6 +134,7 @@ __all__ = [
     "solve",
     "tools",
     "Form",
+    "FormItem",
     "IntegralForm",
     "Basis",
     "Field",

--- a/src/felupe/assembly/expression/_decorator.py
+++ b/src/felupe/assembly/expression/_decorator.py
@@ -20,7 +20,7 @@ from ._expression import FormExpression
 
 
 def FormExpressionDecorator(
-    v, u=None, grad_v=None, grad_u=None, dx=None, args=(), kwargs={}, parallel=False
+    v, u=None, grad_v=None, grad_u=None, dx=None, args=None, kwargs=None, parallel=False
 ):
     r"""A linear or bilinear form object as function decorator on a weak-form
     with methods for integration and assembly of vectors or sparse matrices.
@@ -37,12 +37,12 @@ def FormExpressionDecorator(
         Flag to use the gradient of ``u`` (default is None).
     dx : ndarray or None, optional
         Array with (numerical) differential volumes  (default is None).
-    args : tuple, optional
+    args : tuple or None, optional
         Tuple with initial optional weakform-arguments. May be updated during
-        integration / assembly  (default is ()).
-    kwargs : dict, optional
+        integration / assembly (default is None).
+    kwargs : dict or None, optional
         Dictionary with initial optional weakform-keyword-arguments. May be
-        updated during integration / assembly  (default is {}).
+        updated during integration / assembly (default is None).
 
     Returns
     -------
@@ -120,7 +120,7 @@ def FormExpressionDecorator(
 
     >>> from felupe.math import ddot, trace, sym
 
-    >>> @fe.Form(
+    >>> @fem.Form(
     >>>     v=field, u=field, grad_v=[True], grad_u=[True], kwargs={"μ": 1.0, "λ": 2.0}
     >>> )
     >>> def bilinearform():

--- a/src/felupe/assembly/expression/_expression.py
+++ b/src/felupe/assembly/expression/_expression.py
@@ -44,20 +44,20 @@ class FormExpression:
     u : Field or FieldMixed
         An object with interpolation or gradients of a field. May be
         updated during integration / assembly.
-    grad_v : bool, optional (default is False)
-        Flag to use the gradient of ``v``.
-    grad_u : bool, optional (default is False)
-        Flag to use the gradient of ``u``.
-    dx : ndarray or None, optional (default is None)
-        Array with (numerical) differential volumes.
-    args : tuple, optional (default is ())
+    grad_v : bool, optional
+        Flag to use the gradient of ``v`` (default is False).
+    grad_u : bool, optional
+        Flag to use the gradient of ``u`` (default is False).
+    dx : ndarray or None, optional
+        Array with (numerical) differential volumes (default is None).
+    args : tuple or None, optional
         Tuple with initial optional weakform-arguments. May be updated during
-        integration / assembly.
-    kwargs : dict, optional (default is {})
+        integration / assembly (default is None).
+    kwargs : dict or None, optional
         Dictionary with initial optional weakform-keyword-arguments. May be updated
-        during integration / assembly.
-    parallel : bool, optional (default is False)
-        Flag to activate parallel (threaded) basis evaluation.
+        during integration / assembly (default is None).
+    parallel : bool, optional
+        Flag to activate parallel (threaded) basis evaluation (default is False).
 
     """
 
@@ -69,8 +69,8 @@ class FormExpression:
         grad_v=False,
         grad_u=False,
         dx=None,
-        args=(),
-        kwargs={},
+        args=None,
+        kwargs=None,
         parallel=False,
     ):
         # set attributes
@@ -80,23 +80,29 @@ class FormExpression:
         self.dx = dx
         self.weakform = weakform
 
+        if args is not None:
+            self.args = args
+        else:
+            self.args = ()
+
+        if kwargs is not None:
+            self.kwargs = kwargs
+        else:
+            self.kwargs = {}
+
         # init underlying linear or bilinear (mixed) form
         self._init_or_update_forms(v, u, args, kwargs, parallel)
 
     def _init_or_update_forms(self, v, u, args, kwargs, parallel):
         "Init or update the underlying form object."
 
-        # update args and kwargs for weakform
-        if args is not None or kwargs is not None:
-            if args is not None:
-                self.args = args
-            else:
-                self.args = ()
+        # update args for weakform
+        if args is not None:
+            self.args = args
 
-            if kwargs is not None:
-                self.kwargs = kwargs
-            else:
-                self.kwargs = {}
+        # update kwargs for weakform
+        if kwargs is not None:
+            self.kwargs = kwargs
 
         # get current form type
         if self.form is not None:

--- a/src/felupe/mechanics/__init__.py
+++ b/src/felupe/mechanics/__init__.py
@@ -1,5 +1,6 @@
 from ._curve import CharacteristicCurve
 from ._helpers import StateNearlyIncompressible
+from ._item import FormItem
 from ._job import Job
 from ._multipoint import MultiPointConstraint, MultiPointContact
 from ._pointload import PointLoad
@@ -11,6 +12,7 @@ from ._step import Step
 
 __all__ = [
     "CharacteristicCurve",
+    "FormItem",
     "StateNearlyIncompressible",
     "Job",
     "PointLoad",

--- a/src/felupe/mechanics/_item.py
+++ b/src/felupe/mechanics/_item.py
@@ -1,0 +1,67 @@
+# -*- coding: utf-8 -*-
+"""
+This file is part of FElupe.
+
+FElupe is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+FElupe is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with FElupe.  If not, see <http://www.gnu.org/licenses/>.
+"""
+
+from ._helpers import Assemble, Results
+
+
+class FormItem:
+    def __init__(
+        self, bilinearform, linearform=None, sym=False, args=None, kwargs=None
+    ):
+        self.bilinearform = bilinearform
+        self.linearform = linearform
+
+        self.sym = sym
+        self.args = args
+        self.kwargs = kwargs
+
+        self.results = Results(stress=False, elasticity=False)
+        self.assemble = Assemble(vector=self._vector, matrix=self._matrix)
+
+        self.field = self.bilinearform.form.v.field
+
+    def _vector(self, field=None, parallel=False):
+        if field is not None:
+            self.field = field
+
+        if self.linearform is not None:
+            self.results.force = self.linearform.assemble(
+                v=self.field, parallel=parallel, args=self.args, kwargs=self.kwargs
+            )
+
+        else:
+            from scipy.sparse import csr_matrix
+
+            self.results.force = csr_matrix(self.field.fields[0].values.shape)
+
+        return self.results.force
+
+    def _matrix(self, field=None, parallel=False):
+        if field is not None:
+            self.field = field
+
+        self.results.stiffness = self.bilinearform.assemble(
+            v=self.field,
+            u=self.field,
+            parallel=parallel,
+            sym=self.sym,
+            args=self.args,
+            kwargs=self.kwargs,
+        )
+
+        return self.results.stiffness


### PR DESCRIPTION
closes #563 

The readme example with a form expression for linear elasticity:

```python
mesh = fem.Cube(n=11)
region = fem.RegionHexahedron(mesh)
field = fem.FieldContainer([fem.Field(region, dim=3)])
boundaries, loadcase = fem.dof.uniaxial(field, clamped=True)

from felupe.math import ddot, sym, trace

@fem.Form(v=field, u=field, grad_v=[True], grad_u=[True])
def bilinearform():
    def a(gradv, gradu, μ=1.0, λ=2.0):
        δε, ε = sym(gradv), sym(gradu)
        return 2 * μ * ddot(δε, ε) + λ * trace(δε) * trace(ε)

    return [a]

@fem.Form(v=field, grad_v=[True])
def linearform():
    def L(gradv, μ=1.0, λ=2.0):
        δε = sym(gradv)
        ε = field.extract(grad=True, sym=True, add_identity=False)[0]
        return 2 * μ * ddot(δε, ε) + λ * trace(δε) * trace(ε)

    return [L]

item = fem.FormItem(bilinearform, linearform, sym=True)
step = fem.Step(items=[item], boundaries=boundaries)
fem.Job(steps=[step]).evaluate()
```