### PR TITLE
VTK-wheels: Remove extra-index-url `https://wheels.vtk.org`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to this project will be documented in this file. The format 
 ### Removed
 - Don't import `Basis` to the global namespace (not necessary as it is used only internally by the weak-`Form` expression decorator).
 - Remove unused internal assemble-methods from `assembly.expression._linear.LinearForm` and `assembly.expression._bilinear.BilinearForm`.
+- Remove extra-index-url `https://wheels.vtk.org` as they are now available on PyPI for Python 3.12.
 
 ## [7.11.0] - 2023-10-22
 

--- a/README.md
+++ b/README.md
@@ -15,10 +15,10 @@ FElupe is a Python 3.8+ 🐍 finite element analysis package 📦 focussing on t
 Install Python, fire up 🔥 a terminal and run 🏃
 
 ```shell
-pip install --extra-index-url https://wheels.vtk.org felupe[all]
+pip install felupe[all]
 ```
 
-where the extra-index-url pulls VTK-wheels if they are not (yet) available on PyPI and `[all]` installs all optional dependencies. FElupe has minimal requirements, all available at PyPI supporting all platforms.
+where `[all]` installs all optional dependencies. FElupe has minimal requirements, all available at PyPI supporting all platforms.
 * `numpy` for array operations
 * `scipy` for sparse matrices
 * `tensortrax` for automatic differentiation

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -61,7 +61,7 @@ Install Python, open the terminal and run ``pip install felupe[all]``, where ``[
 
 .. code-block:: shell
 
-   pip install --extra-index-url https://wheels.vtk.org felupe[all]
+   pip install felupe[all]
 
 *optional:*
 

--- a/tox.ini
+++ b/tox.ini
@@ -3,8 +3,6 @@ envlist = py3
 isolated_build = True
 
 [testenv]
-setenv =
-    PIP_EXTRA_INDEX_URL=https://wheels.vtk.org
 deps =
     pytest
     pytest-cov


### PR DESCRIPTION
as they are now available on PyPI for Python 3.12