### PR TITLE
Add `Mesh.update(callback=None)`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file. The format 
 
 ### Added
 - Add optional output location for `FieldContainer.extract(out=None)`.
+- Add `Mesh.update(callback=None)`. This is especially useful if the points array of a mesh is changed and an already existing instance of a region has to be reloaded: `Mesh.update(points=new_points, callback=region.reload)`.
 
 ### Changed
 - Pass optional keyword-arguments in `math.dot(**kwargs)` to the underlying einsum-calls.

--- a/src/felupe/mesh/_discrete_geometry.py
+++ b/src/felupe/mesh/_discrete_geometry.py
@@ -76,7 +76,7 @@ class DiscreteGeometry:
 
         return out
 
-    def update(self, points=None, cells=None, cell_type=None):
+    def update(self, points=None, cells=None, cell_type=None, callback=None):
         "Update the cell and dimension attributes with a given cell array."
 
         if points is not None:
@@ -109,3 +109,6 @@ class DiscreteGeometry:
         else:
             self.points_without_cells = np.array([], dtype=int)
             self.points_with_cells = np.arange(self.npoints)
+
+        if callable(callback):
+            callback(self)

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -490,6 +490,25 @@ def test_view():
     # img = mesh.screenshot(transparent_background=True)
 
 
+def test_mesh_update():
+    import felupe as fem
+
+    mesh = fem.Cube(n=11)
+    region = fem.RegionHexahedron(mesh)
+    field = fem.FieldsMixed(region, n=1)
+
+    boundaries, loadcase = fem.dof.uniaxial(field, axis=0, sym=False, clamped=True)
+
+    new_points = mesh.rotate(angle_deg=-90, axis=2).points
+
+    # either update the mesh and the region via callback
+    mesh.update(points=new_points, callback=region.reload)
+
+    # or update the region separately
+    mesh.update(points=new_points)
+    region.reload(mesh)
+
+
 if __name__ == "__main__":
     test_meshes()
     test_mirror()
@@ -506,3 +525,4 @@ if __name__ == "__main__":
     test_circle()
     test_triangle()
     test_view()
+    test_mesh_update()


### PR DESCRIPTION
as suggested by @ZAARAOUI999 in https://github.com/adtzlr/felupe/issues/583#issuecomment-1869116553 in #583,

add a `callback`-argument to `Mesh.update()` in order to simplify the reload of an already existing instance of a region.

### Example
```python
import felupe as fem

mesh = fem.Cube(n=11)
region = fem.RegionHexahedron(mesh)
field = fem.FieldsMixed(region, n=1)

boundaries, loadcase = fem.dof.uniaxial(field, axis=0, sym=False, clamped=True)

new_points = mesh.rotate(angle_deg=-90, axis=2).points
mesh.update(points=new_points, callback=region.reload)
```