### PR TITLE
Add view-methods for solid bodies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file. The format 
 - Add `Mesh.update(callback=None)`. This is especially useful if the points array of a mesh is changed and an already existing instance of a region has to be reloaded: `Mesh.update(points=new_points, callback=region.reload)`.
 - Add `ax = FieldContainer.imshow()` which acts as a wrapper on top of the `img = FieldContainer.screenshot(filename=None)` method. The image data is passed to a matplotlib figure and the `ax` object is returned.
 - Add `ax = Mesh.imshow()` which acts as a wrapper on top of the `img = Mesh.screenshot(filename=None)` method. The image data is passed to a matplotlib figure and the `ax` object is returned.
+- Add view-methods for `SolidBody` and `SolidBodyNearlyIncompressible` (same as already implemented for mesh and fields).
 
 ### Changed
 - Pass optional keyword-arguments in `math.dot(**kwargs)` to the underlying einsum-calls.

--- a/README.md
+++ b/README.md
@@ -66,12 +66,12 @@ fig, ax = job.plot(
     ylabel="Normal Force $F$ in N $\longrightarrow$",
 )
 
-field.plot("Principal Values of Logarithmic Strain").show()
+ax2 = solid.imshow("Principal Values of Cauchy Stress", theme="paraview")
 ```
 
 ![curve](https://user-images.githubusercontent.com/5793153/234382805-d9a56108-9dd7-4f57-a029-571a5a2486a4.svg)
 
-![cube](https://user-images.githubusercontent.com/5793153/234405093-2f5201c1-3bba-46ee-bd91-af87813609d9.png)
+![solidbody](https://github.com/adtzlr/felupe/assets/5793153/2a236f27-53a5-42aa-a45e-85628ecddf72)
 
 # Documentation
 The documentation is located [here](https://felupe.readthedocs.io/en/latest/?badge=latest).

--- a/src/felupe/mechanics/_job.py
+++ b/src/felupe/mechanics/_job.py
@@ -188,5 +188,5 @@ class Job:
 
             if verbose == 1:
                 progress_bar.close()
-        
+
         return self

--- a/src/felupe/mechanics/_solidbody.py
+++ b/src/felupe/mechanics/_solidbody.py
@@ -21,10 +21,89 @@ import numpy as np
 from ..assembly import IntegralForm
 from ..constitution import AreaChange
 from ..math import det, dot, transpose
+from ..tools._plot import ViewSolid
 from ._helpers import Assemble, Evaluate, Results
 
 
-class SolidBody:
+class Solid:
+    "Base class for solid bodies which provides methods for visualisations."
+
+    def view(self, point_data=None, cell_data=None, cell_type=None):
+        """View the solid with optional given dicts of point- and cell-data items.
+
+        Parameters
+        ----------
+        point_data : dict or None, optional
+            Additional point-data dict (default is None).
+        cell_data : dict or None, optional
+            Additional cell-data dict (default is None).
+        cell_type : pyvista.CellType or None, optional
+            Cell-type of PyVista (default is None).
+
+        Returns
+        -------
+        felupe.ViewSolid
+            An object which provides visualization methods for solid bodies,
+            e.g. :class:`felupe.SolidBody`.
+
+        See Also
+        --------
+        felupe.ViewSolid : Visualization methods for :class:`felupe.SolidBody`.
+        """
+
+        return ViewSolid(
+            self.field,
+            solid=self,
+            point_data=point_data,
+            cell_data=cell_data,
+            cell_type=cell_type,
+        )
+
+    def plot(self, *args, **kwargs):
+        """Plot the solid body.
+
+        See Also
+        --------
+        felupe.Scene.plot: Plot method of a scene.
+        """
+        return self.view().plot(*args, **kwargs)
+
+    def screenshot(
+        self,
+        *args,
+        filename="solidbody.png",
+        transparent_background=None,
+        scale=None,
+        **kwargs,
+    ):
+        """Take a screenshot of the solid body.
+
+        See Also
+        --------
+        pyvista.Plotter.screenshot: Take a screenshot of a PyVista plotter.
+        """
+
+        return self.plot(*args, off_screen=True, **kwargs).screenshot(
+            filename=filename,
+            transparent_background=transparent_background,
+            scale=scale,
+        )
+
+    def imshow(self, *args, **kwargs):
+        """Take a screenshot of the solid body, show the image data in a figure and
+        return the ax.
+        """
+
+        import matplotlib.pyplot as plt
+
+        fig, ax = plt.subplots()
+        ax.imshow(self.screenshot(*args, filename=None, **kwargs))
+        ax.set_axis_off()
+
+        return ax
+
+
+class SolidBody(Solid):
     "A SolidBody with methods for the assembly of sparse vectors/matrices."
 
     def __init__(self, umat, field, statevars=None):

--- a/src/felupe/mechanics/_solidbody_incompressible.py
+++ b/src/felupe/mechanics/_solidbody_incompressible.py
@@ -23,9 +23,10 @@ from ..constitution import AreaChange
 from ..field import FieldAxisymmetric
 from ..math import ddot, det, dot, dya, transpose
 from ._helpers import Assemble, Evaluate, Results, StateNearlyIncompressible
+from ._solidbody import Solid
 
 
-class SolidBodyNearlyIncompressible:
+class SolidBodyNearlyIncompressible(Solid):
     r"""A (nearly) incompressible SolidBody with methods for the assembly of sparse
     vectors/matrices for a material with optional state variables.
 

--- a/src/felupe/tools/_plot.py
+++ b/src/felupe/tools/_plot.py
@@ -16,8 +16,6 @@ You should have received a copy of the GNU General Public License
 along with FElupe.  If not, see <http://www.gnu.org/licenses/>.
 """
 
-import os
-
 import numpy as np
 
 from ..math import eigvalsh, tovoigt

--- a/tests/test_mechanics.py
+++ b/tests/test_mechanics.py
@@ -492,6 +492,17 @@ def test_load():
         assert res.success
 
 
+def test_view():
+    mesh = fem.Rectangle(n=6)
+    region = fem.RegionQuad(mesh)
+    field = fem.FieldContainer([fem.FieldPlaneStrain(region, dim=2)])
+    umat = fem.NeoHooke(mu=1, bulk=2)
+    solid = fem.SolidBody(umat, field)
+    plotter = solid.plot(off_screen=True)
+    # img = solid.screenshot(transparent_background=True)
+    # ax = solid.imshow()
+
+
 if __name__ == "__main__":
     test_simple()
     test_solidbody()
@@ -502,3 +513,4 @@ if __name__ == "__main__":
     test_solidbody_mixed()
     test_pressure()
     test_load()
+    test_view()


### PR DESCRIPTION
Add view-methods for `SolidBody` and `SolidBodyNearlyIncompressible` (same as already implemented for mesh and fields).