### PR TITLE
Rename `tools._newton.Result` to `tools.NewtonResult`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be documented in this file. The format 
 - Change the return value on job-evaluation from `None = Job.evaluate()` to `job = Job.evaluate()`.
 - Change implementation of `LinearElasticLargeStrain` from `NeoHooke` to `NeoHookeCompressible`.
 - Do not invoke `pyvista.start_xvfb()` on a posix-os. If required, run it manually.
+- Rename `tools._newton.Result` to `tools._newton.NewtonResult` and add it to the public API as `tools.NewtonResult` because this class is returned as a result of Newton's method.
 
 ## [7.13.0] - 2023-12-22
 

--- a/docs/felupe/tools.rst
+++ b/docs/felupe/tools.rst
@@ -1,6 +1,8 @@
 Tools
 ~~~~~
 
+.. autoclass:: felupe.tools.NewtonResult
+
 .. autofunction:: felupe.newtonrhapson
 
 .. autofunction:: felupe.save

--- a/src/felupe/tools/__init__.py
+++ b/src/felupe/tools/__init__.py
@@ -1,4 +1,5 @@
 from ._misc import logo, runs_on
+from ._newton import NewtonResult
 from ._newton import fun_items as fun
 from ._newton import jac_items as jac
 from ._newton import newtonrhapson
@@ -21,6 +22,7 @@ __all__ = [
     "runs_on",
     "save",
     "solve",
+    "NewtonResult",
     "ViewMesh",
     "ViewField",
     "ViewXdmf",


### PR DESCRIPTION
closes #602 