### PR TITLE
Add `tools.NewtonResult(xnorms=None, fnorms=None)`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file. The format 
 - Add `ax = Mesh.imshow()` which acts as a wrapper on top of the `img = Mesh.screenshot(filename=None)` method. The image data is passed to a matplotlib figure and the `ax` object is returned.
 - Add view-methods for `SolidBody` and `SolidBodyNearlyIncompressible` (same as already implemented for mesh and fields).
 - Add lists with norms of values and norms of the objective function in `tools.NewtonResult(xnorms=None, fnorms=None)`.
+- Add lists of norms of the objective function as attribute to `Job.fnorms`.
 
 ### Changed
 - Pass optional keyword-arguments in `math.dot(**kwargs)` to the underlying einsum-calls.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file. The format 
 - Add `ax = FieldContainer.imshow()` which acts as a wrapper on top of the `img = FieldContainer.screenshot(filename=None)` method. The image data is passed to a matplotlib figure and the `ax` object is returned.
 - Add `ax = Mesh.imshow()` which acts as a wrapper on top of the `img = Mesh.screenshot(filename=None)` method. The image data is passed to a matplotlib figure and the `ax` object is returned.
 - Add view-methods for `SolidBody` and `SolidBodyNearlyIncompressible` (same as already implemented for mesh and fields).
+- Add lists with norms of values and norms of the objective function in `tools.NewtonResult(xnorms=None, fnorms=None)`.
 
 ### Changed
 - Pass optional keyword-arguments in `math.dot(**kwargs)` to the underlying einsum-calls.

--- a/src/felupe/mechanics/_job.py
+++ b/src/felupe/mechanics/_job.py
@@ -70,6 +70,7 @@ class Job:
         self.nsteps = len(steps)
         self.callback = callback
         self.timetrack = []
+        self.fnorms = []
 
     def _write(self, writer, time, substep, point_data, cell_data):
         field = substep.x
@@ -159,6 +160,7 @@ class Job:
 
                 substeps = step.generate(verbose=newton_verbose, **kwargs)
                 for i, substep in enumerate(substeps):
+                    self.fnorms.append(substep.fnorms)
                     if verbose == 2:
                         _substep = f"Substep {i + 1}/{step.nsubsteps}"
                         _step = f"Step {j + 1}/{self.nsteps}"


### PR DESCRIPTION
this enables to view the convergence graph:

![image](https://github.com/adtzlr/felupe/assets/5793153/57a18420-4e5f-484f-8dfa-b7a1f21c0c4d)

for

```python
import felupe as fem
import matplotlib.pyplot as plt

mesh = fem.Cube(n=6)
region = fem.RegionHexahedron(mesh)
field = fem.FieldContainer([fem.Field(region, dim=3)])
boundaries, loadcase = fem.dof.uniaxial(field, clamped=True, move=-0.3)

umat = fem.NeoHooke(mu=1)
solid = fem.SolidBodyNearlyIncompressible(umat, field, bulk=5000)

res = fem.newtonrhapson(items=[solid], **loadcase)

plt.semilogy(res.fnorms, "o-")
plt.xlabel(r"Iteration # $\rightarrow$")
plt.ylabel(r"Norm of function $|f_1| / (\varepsilon + |f_0|)$")
```

norms of the objective function are also saved as `Job.fnorms` (this is a list of lists, one list for each substep).