### PR TITLE
Fix `Mesh.imshow(ax=None)`, `FieldContainer.imshow(ax=None)` and `SolidBody.imshow(ax=None)`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ All notable changes to this project will be documented in this file. The format 
 - Add `Mesh.merge_duplicate_points(decimals=None)` and make `Mesh.sweep(decimals=None)` an alias of it.
 - Add `Mesh.merge_duplicate_cells()`.
 
+### Fixed
+- Fix `Mesh.imshow(ax=None)`, `FieldContainer.imshow(ax=None)` and `SolidBody.imshow(ax=None)` from v7.15.
+
 ## [7.15.0] - 2024-02-11
 
 ### Added

--- a/src/felupe/field/_container.py
+++ b/src/felupe/field/_container.py
@@ -169,7 +169,7 @@ class FieldContainer:
             scale=scale,
         )
 
-    def imshow(self, ax=None, *args, **kwargs):
+    def imshow(self, *args, ax=None, **kwargs):
         """Take a screenshot of the first field of the container, show the image data in
         a figure and return the ax.
         """

--- a/src/felupe/mechanics/_solidbody.py
+++ b/src/felupe/mechanics/_solidbody.py
@@ -89,7 +89,7 @@ class Solid:
             scale=scale,
         )
 
-    def imshow(self, ax=None, *args, **kwargs):
+    def imshow(self, *args, ax=None, **kwargs):
         """Take a screenshot of the solid body, show the image data in a figure and
         return the ax.
         """

--- a/src/felupe/mesh/_mesh.py
+++ b/src/felupe/mesh/_mesh.py
@@ -194,7 +194,7 @@ class Mesh(DiscreteGeometry):
             scale=scale,
         )
 
-    def imshow(self, ax=None, *args, **kwargs):
+    def imshow(self, *args, ax=None, **kwargs):
         """Take a screenshot of the mesh, show the image data in a figure and return the
         ax.
         """


### PR DESCRIPTION
because the newly `ax=None`-argument from v7.14 was inserted before `*args`.

fixes #614 