### PR TITLE
Create `FieldContainer` by all logical-and combinations of `Field` and `FieldContainer`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file. The format 
 - Add a mesh for a single vertex point `vertex = Point(a=0)`.
 - Add expansion of a vertex point to a line mesh `vertex.expand(n=11, z=1)`.
 - Add revolution of a vertex point to a line mesh `vertex.revolve(n=11, phi=180)`.
+- Create a `FieldContainer` by logical-and operations between fields and field containers, i.e. `field = displacement & pressure`, where `displacement = Field(region, dim=2)` and `pressure = Field(region)`. This also works for `field & pressure` as well as `pressure & field`.
 
 ### Changed
 - Assume that no state variables are used in an `umat` if it has no attribute `umat.x`. Set the shape of the state variables by default to `(0, q, c)` in `SolidBody` and `SolidBodyNearlyIncompressible`.

--- a/src/felupe/field/_base.py
+++ b/src/felupe/field/_base.py
@@ -23,6 +23,7 @@ import numpy as np
 from ..math import identity
 from ..math import sym as symmetric
 from ._indices import Indices
+from ._container import FieldContainer
 
 
 class Field:
@@ -340,3 +341,11 @@ class Field:
         a list of degrees of freedom `dof`."""
 
         return self.values.ravel()[dof]
+    
+    def __and__(self, field):
+        
+        fields = [field]
+        if isinstance(field, FieldContainer):
+            fields = field.fields
+            
+        return FieldContainer([self, *fields])

--- a/src/felupe/field/_container.py
+++ b/src/felupe/field/_container.py
@@ -32,10 +32,54 @@ class FieldContainer:
     fields : list or tuple of Field, FieldAxisymmetric or FieldPlaneStrain
         List with fields. The region is linked to the first field.
 
+    Examples
+    --------
+    >>> import felupe as fem
+    >>>
+    >>> mesh = fem.Cube(n=3)
+    >>> region = fem.RegionHexahedron(mesh)
+    >>> region_dual = fem.RegionConstantHexahedron(mesh.dual(points_per_cell=1))
+    >>> displacement = fem.Field(region, dim=3)
+    >>> pressure = fem.Field(region_dual)
+    >>> field = fem.FieldContainer([displacement, pressure])
+    >>> field
+    <felupe FieldContainer object>
+      Number of fields: 2
+      Dimension of fields:
+        Field: 3
+        Field: 1
+
+    A new :class:`~felupe.FieldContainer` is also created by one of the logical-and
+    combinations of a :class:`~felupe.Field`, :class:`~felupe.FieldAxisymmetric`,
+    :class:`~felupe.FieldPlanestrain` or :class:`~felupe.FieldContainer`.
+
+    >>> displacement & pressure
+    <felupe FieldContainer object>
+      Number of fields: 2
+      Dimension of fields:
+        Field: 3
+        Field: 1
+
+    >>> volume_ratio = fem.Field(region_dual)
+    >>> field & volume_ratio  # displacement & pressure & volume_ratio
+    <felupe FieldContainer object>
+      Number of fields: 3
+      Dimension of fields:
+        Field: 2
+        Field: 1
+        Field: 1
+
     See Also
     --------
     felupe.Field : Field on points of a :class:`~felupe.Region` with dimension ``dim``
-       and initial point ``values``.
+        and initial point ``values``.
+    felupe.FieldAxisymmetric : An axisymmetric :class:`~felupe.Field` on points of a
+        two-dimensional :class:`~felupe.Region` with dimension ``dim`` (default is 2) and
+        initial point ``values`` (default is 0).
+    felupe.FieldPlaneStrain : A plane strain :class:`~felupe.Field` on points of a
+        two-dimensional :class:`~felupe.Region` with dimension ``dim`` (default is 2)
+        and initial point ``values`` (default is 0).
+
     """
 
     def __init__(self, fields):
@@ -261,3 +305,10 @@ class FieldContainer:
         "Number of fields inside the container."
 
         return len(self.fields)
+
+    def __and__(self, field):
+        fields = [field]
+        if isinstance(field, FieldContainer):
+            fields = field.fields
+
+        return FieldContainer([*self.fields, *fields])

--- a/tests/test_field.py
+++ b/tests/test_field.py
@@ -71,9 +71,11 @@ def pre_mixed():
     f2 = u & p & J
     f3 = (u & p) & J
     f4 = u & (p & J)
+    f5 = fem.FieldContainer([u]) & (p & J)
     assert [np.allclose(fi, f2i) for fi, f2i in zip(f.extract(), f2.extract())]
     assert [np.allclose(fi, f3i) for fi, f3i in zip(f.extract(), f3.extract())]
     assert [np.allclose(fi, f4i) for fi, f4i in zip(f.extract(), f4.extract())]
+    assert [np.allclose(fi, f5i) for fi, f5i in zip(f.extract(), f5.extract())]
 
     print(m), print(r), print(f)
 

--- a/tests/test_field.py
+++ b/tests/test_field.py
@@ -66,8 +66,14 @@ def pre_mixed():
     p = fem.Field(r)
     J = fem.Field(r, values=1)
 
-    f = fem.FieldContainer((u, p, J))
+    f = fem.FieldContainer([u, p, J])
     g = fem.FieldsMixed(fem.RegionHexahedron(m), n=3)
+    f2 = u & p & J
+    f3 = (u & p) & J
+    f4 = u & (p & J)
+    assert [np.allclose(fi, f2i) for fi, f2i in zip(f.extract(), f2.extract())]
+    assert [np.allclose(fi, f3i) for fi, f3i in zip(f.extract(), f3.extract())]
+    assert [np.allclose(fi, f4i) for fi, f4i in zip(f.extract(), f4.extract())]
 
     print(m), print(r), print(f)
 


### PR DESCRIPTION
### Example

```python
import felupe as fem

mesh = fem.Cube(n=3)

region = fem.RegionHexahedron(mesh)
region_dual = fem.RegionConstantHexahedron(mesh.dual(points_per_cell=1))

displacement = fem.Field(region, dim=3)
pressure = fem.Field(region_dual)

field = fem.FieldContainer([displacement, pressure])
field = displacement & pressure

volume_ratio = fem.Field(region_dual)

field_new = field & volume_ratio
field_new_2 = volume_ratio & field
```