### PR TITLE
Fix `Mesh.flip(mask=None)`: Take care of the mask

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ All notable changes to this project will be documented in this file. The format 
 ### Changed
 - Don't disconnect the dual mesh by default for regions `RegionQuadraticTriangle` and `RegionQuadraticTetra` in `FieldsMixed`.
 
+### Fixed
+- Fix `Mesh.flip(mask=None)`: Take care of the mask (it wasn't applied to the cells-array of the mesh).
+
 ## [7.17.0] - 2024-02-15
 
 ### Added

--- a/src/felupe/mesh/_tools.py
+++ b/src/felupe/mesh/_tools.py
@@ -705,7 +705,7 @@ def flip(points, cells, cell_type, mask=None):
     cells_new = cells.copy()
 
     for face in faces_to_flip:
-        cells_new[:, face] = cells[:, face[::-1]]
+        cells_new[mask, face] = cells[mask, face[::-1]]
 
     return points, cells_new, cell_type
 


### PR DESCRIPTION
fixes #624 (as mentioned in https://github.com/adtzlr/felupe/discussions/622)

### Example
```python
from skfem import MeshTet

mesh_skfem = MeshTet().refined(2)
mesh_skfem.save("trialMesh.xdmf")

from meshio import xdmf
import felupe as fem
import numpy as np

meshio_mesh = xdmf.read("trialMesh.xdmf")
mesh = fem.Mesh(
    points=meshio_mesh.points,
    cells=meshio_mesh.get_cells_type("tetra"),
    cell_type=meshio_mesh.cells[0].type,
)

# ensure positive cell volumes (before adding midpoints on edges!)
region = fem.RegionTetra(mesh)
mesh = mesh.flip(np.any(region.dV < 0, axis=0))
region.reload(mesh)
assert np.all(region.dV > 0)

region_u = fem.RegionQuadraticTetra(mesh.add_midpoints_edges())
region_p = fem.RegionTetra(
    mesh=fem.mesh.dual(mesh, disconnect=False),
    quadrature=region_u.quadrature,
    grad=False,
)
```