### PR TITLE
Attempt to implement `SolidBodyNearlyIncompressibleX`

### DIFF
--- a/src/felupe/assembly/_integral.py
+++ b/src/felupe/assembly/_integral.py
@@ -21,6 +21,7 @@ from scipy.sparse import bmat, vstack
 
 from ..field._axi import FieldAxisymmetric
 from ..field._base import Field
+from ..field._dual import FieldDual
 from ..field._planestrain import FieldPlaneStrain
 from ._axi import IntegralFormAxisymmetric
 from ._cartesian import IntegralFormCartesian
@@ -207,6 +208,7 @@ class IntegralForm:
 
         IntForm = {
             Field: IntegralFormCartesian,
+            FieldDual: IntegralFormCartesian,
             FieldPlaneStrain: IntegralFormCartesian,
             FieldAxisymmetric: IntegralFormAxisymmetric,
         }[type(self.v[0])]

--- a/src/felupe/field/_dual.py
+++ b/src/felupe/field/_dual.py
@@ -56,6 +56,11 @@ class FieldDual(Field):
     mesh: Mesh or None, optional
         A mesh which is used for the dual region (default is None). If None, the mesh
         is taken from the region.
+    disconnect : bool, optional
+        A flag to disconnect the dual mesh (each cell has its own points). Default is
+        None. If None, a disconnected mesh is used except for regions with
+        quadratic-triangle and quadratic-tetra elements as well as for regions with the
+        MINI-elements.
     **kwargs : dict, optional
         Optional keyword arguments for the dual region.
 
@@ -92,6 +97,7 @@ class FieldDual(Field):
         offset=0,
         npoints=None,
         mesh=None,
+        disconnect=None,
         **kwargs,
     ):
         # create dual regions
@@ -120,7 +126,9 @@ class FieldDual(Field):
             RegionTetraMINI: {"disconnect": False},
             RegionTriangleMINI: {"disconnect": False},
             RegionLagrange: {},
-        }
+        }[type(region)]
+        if disconnect is not None:
+            mesh_kwargs["disconnect"] = disconnect
         points_per_cell = {
             RegionConstantHexahedron: 1,
             RegionConstantQuad: 1,
@@ -145,7 +153,7 @@ class FieldDual(Field):
                 points_per_cell=points_per_cell[RegionDual],
                 offset=offset,
                 npoints=npoints,
-                **mesh_kwargs[type(region)],
+                **mesh_kwargs,
             )
 
         region_dual = RegionDual(mesh, **{**kwargs0, **kwargs})

--- a/src/felupe/math/_tensor.py
+++ b/src/felupe/math/_tensor.py
@@ -223,28 +223,24 @@ def dot(A, B, mode=(2, 2), parallel=False, **kwargs):
 
     if mode == (2, 2):
         return einsum("ik...,kj...->ij...", A, B, **kwargs)
-
     elif mode == (1, 1):
         return einsum("i...,i...->...", A, B, **kwargs)
-
     elif mode == (4, 4):
         return einsum("ijkp...,plmn...->ijklmn...", A, B, **kwargs)
-
     elif mode == (2, 1):
         return einsum("ij...,j...->i...", A, B, **kwargs)
-
     elif mode == (1, 2):
         return einsum("i...,ij...->j...", A, B, **kwargs)
-
+    elif mode == (2, 3):
+        return einsum("im...,mjk...->ijk...", A, B, **kwargs)
+    elif mode == (3, 2):
+        return einsum("ijm...,mk...->ijk...", A, B, **kwargs)
     elif mode == (4, 1):
         return einsum("ijkl...,l...->ijk...", A, B, **kwargs)
-
     elif mode == (1, 4):
         return einsum("i...,ijkl...->jkl...", A, B, **kwargs)
-
     elif mode == (2, 4):
         return einsum("im...,mjkl...->ijkl...", A, B, **kwargs)
-
     elif mode == (4, 2):
         return einsum("ijkm...,ml...->ijkl...", A, B, **kwargs)
 
@@ -262,6 +258,10 @@ def ddot(A, B, mode=(2, 2), parallel=False, **kwargs):
 
     if mode == (2, 2):
         return einsum("ij...,ij...->...", A, B, **kwargs)
+    if mode == (2, 3):
+        return einsum("ij...,ijk...->k...", A, B, **kwargs)
+    if mode == (3, 2):
+        return einsum("ijk...,ij...->k...", A, B, **kwargs)
     elif mode == (2, 4):
         return einsum("ij...,ijkl...->kl...", A, B, **kwargs)
     elif mode == (4, 2):

--- a/src/felupe/mechanics/__init__.py
+++ b/src/felupe/mechanics/__init__.py
@@ -1,5 +1,5 @@
 from ._curve import CharacteristicCurve
-from ._helpers import StateNearlyIncompressible
+from ._helpers import StateNearlyIncompressible, StateNearlyIncompressibleX
 from ._item import FormItem
 from ._job import Job
 from ._multipoint import MultiPointConstraint, MultiPointContact
@@ -7,6 +7,7 @@ from ._pointload import PointLoad
 from ._solidbody import SolidBody
 from ._solidbody_gravity import SolidBodyGravity
 from ._solidbody_incompressible import SolidBodyNearlyIncompressible
+from ._solidbody_incompressible_x import SolidBodyNearlyIncompressibleX
 from ._solidbody_pressure import SolidBodyPressure
 from ._step import Step
 
@@ -19,6 +20,7 @@ __all__ = [
     "SolidBody",
     "SolidBodyGravity",
     "SolidBodyNearlyIncompressible",
+    "SolidBodyNearlyIncompressibleX",
     "SolidBodyPressure",
     "Step",
     "MultiPointConstraint",

--- a/src/felupe/mechanics/_helpers.py
+++ b/src/felupe/mechanics/_helpers.py
@@ -17,9 +17,9 @@ along with FElupe.  If not, see <http://www.gnu.org/licenses/>.
 """
 import numpy as np
 
-from ..assembly import IntegralForm
+from ..assembly import IntegralForm, IntegralFormCartesian
 from ..constitution import AreaChange
-from ..field import FieldAxisymmetric
+from ..field import FieldAxisymmetric, FieldDual
 from ..math import det
 
 
@@ -113,3 +113,96 @@ class StateNearlyIncompressible:
             dA = self.field.region.dV
             dV = 2 * np.pi * R * dA
         return (det(self.F[0]) * dV).sum(0)
+
+
+class StateNearlyIncompressibleX:
+    "A State with internal fields for (nearly) incompressible solid bodies."
+
+    def __init__(self, field, pressure=None, volume_ratio=None, **kwargs):
+        self.field = field
+        self.u = self.field[0].values
+
+        self.pressure = pressure
+        self.volume_ratio = volume_ratio
+
+        if self.pressure is None:
+            self.pressure = FieldDual(field.region, **kwargs)
+        if self.volume_ratio is None:
+            self.volume_ratio = FieldDual(field.region, values=1, **kwargs)
+
+        self.dJdF = AreaChange().function
+
+        # deformation gradient
+        self.F = field.extract()
+
+        # inverse of volume matrix
+        self.inv_V = np.linalg.inv(self.volume().T).T
+        self.h = self.integrate_shape_function_gradient()
+
+    def integrate_shape_function_gradient(self, parallel=False):
+        r"""Return the Integrated shape function gradient matrix w.r.t. the deformed
+        coordinates.
+
+        Notes
+        -----
+        ..  math::
+
+            h = \int_V \delta \boldsymbol{F} : \frac{\partial J}{\partial\boldsymbol{F}}
+                \ \Delta p ~ dV
+
+        """
+        self.h = IntegralForm(
+            fun=self.dJdF(self.F),
+            v=self.field,
+            u=self.pressure & None,
+            dV=self.field.region.dV,
+            grad_v=[True],
+            grad_u=[False],
+        ).integrate(parallel=parallel)[0]
+        return self.h
+
+    def volume(self, parallel=False):
+        r"""Return integrated differential (undeformed) volumes matrix with dual-trial
+        and dual-test fields.
+
+        Notes
+        -----
+        ..  math::
+
+            V = \int_V \delta p \Delta p ~ dV
+
+        """
+        return IntegralForm(
+            fun=[np.ones((1, 1))],
+            v=self.pressure & None,
+            dV=self.field.region.dV,
+            u=self.pressure & None,
+            grad_v=[False],
+            grad_u=[False],
+        ).integrate(parallel=parallel)[0]
+
+    def fp(self, parallel=False):
+        dV = self.field.region.dV
+        J = self.volume_ratio.interpolate()
+        v = self.pressure & None
+        return IntegralForm(
+            fun=[det(self.F[0]) - J], v=v, dV=dV, grad_v=[False]
+        ).integrate(parallel=parallel)[0]
+
+    def fJ(self, bulk, parallel=False):
+        dV = self.field.region.dV
+        p = self.pressure.interpolate()
+        J = self.volume_ratio.interpolate()
+        v = self.pressure & None
+        return IntegralForm(
+            fun=[bulk * (J - 1) - p], v=v, dV=dV, grad_v=[False]
+        ).integrate(parallel=parallel)[0]
+
+    def constraint(self, bulk, parallel=False):
+        dV = self.field.region.dV
+        p = self.pressure.interpolate()
+        detF = det(self.F[0])
+        v = self.pressure & None
+        return IntegralForm(
+            fun=[bulk * (detF - 1) - p], v=v, dV=dV, grad_v=[False]
+        ).integrate(parallel=parallel)[0]

--- a/src/felupe/mechanics/_helpers.py
+++ b/src/felupe/mechanics/_helpers.py
@@ -137,7 +137,6 @@ class StateNearlyIncompressibleX:
 
         # inverse of volume matrix
         self.inv_V = np.linalg.inv(self.volume().T).T
-        self.h = self.integrate_shape_function_gradient()
 
     def integrate_shape_function_gradient(self, parallel=False):
         r"""Return the Integrated shape function gradient matrix w.r.t. the deformed
@@ -151,7 +150,7 @@ class StateNearlyIncompressibleX:
                 \ \Delta p ~ dV
 
         """
-        self.h = IntegralForm(
+        return IntegralForm(
             fun=self.dJdF(self.F),
             v=self.field,
             u=self.pressure & None,
@@ -159,7 +158,6 @@ class StateNearlyIncompressibleX:
             grad_v=[True],
             grad_u=[False],
         ).integrate(parallel=parallel)[0]
-        return self.h
 
     def volume(self, parallel=False):
         r"""Return integrated differential (undeformed) volumes matrix with dual-trial

--- a/src/felupe/mechanics/_solidbody_incompressible.py
+++ b/src/felupe/mechanics/_solidbody_incompressible.py
@@ -281,7 +281,6 @@ class SolidBodyNearlyIncompressible(Solid):
         self.results.stress = self._gradient(
             field, parallel=parallel, args=args, kwargs=kwargs
         )
-
         form = self._form(
             fun=self.results.stress,
             v=self.field,
@@ -294,7 +293,7 @@ class SolidBodyNearlyIncompressible(Solid):
 
         values = form.integrate(parallel=parallel)
         np.add(values[0], h * (self.bulk * (v / self.V - 1) - p), out=values[0])
-
+        
         self.results.force = form.assemble(values=values)
 
         return self.results.force
@@ -333,7 +332,7 @@ class SolidBodyNearlyIncompressible(Solid):
         # change of state variables due to change of displacement field
         dJ = ddot(h, du, mode=(2, 2)) / self.V + (v / self.V - J)
         dp = self.bulk * (dJ + J - 1) - p
-
+        
         self.field = field
         self.results.kinematics = self.results.state.F = self.field.extract(
             out=self.results.kinematics
@@ -366,7 +365,7 @@ class SolidBodyNearlyIncompressible(Solid):
     def _hessian(self, field=None, parallel=False, args=(), kwargs={}):
         if field is not None:
             self.results.kinematics = self._extract(field, parallel=parallel)
-
+        
         d2JdF2 = self._area_change.gradient
         F = self.results.kinematics[0]
         statevars = self.results.statevars

--- a/src/felupe/mechanics/_solidbody_incompressible_x.py
+++ b/src/felupe/mechanics/_solidbody_incompressible_x.py
@@ -1,0 +1,204 @@
+# -*- coding: utf-8 -*-
+"""
+This file is part of FElupe.
+
+FElupe is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+FElupe is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with FElupe.  If not, see <http://www.gnu.org/licenses/>.
+"""
+
+import numpy as np
+
+from ..assembly import IntegralForm
+from ..constitution import AreaChange
+from ..field import FieldContainer
+from ..math import det, dot, transpose
+from ._helpers import Assemble, Evaluate, Results, StateNearlyIncompressibleX
+from ._solidbody import Solid
+
+
+class SolidBodyNearlyIncompressibleX(Solid):
+    def __init__(self, umat, field, bulk, state=None, statevars=None, **kwargs):
+        self.umat = umat
+        self.field = field
+        self.bulk = bulk
+        self._area_change = AreaChange()
+        self.results = Results(stress=True, elasticity=True)
+
+        if statevars is not None:
+            self.results.statevars = statevars
+        else:
+            statevars_shape = (0,)
+            if hasattr(umat, "x"):
+                statevars_shape = umat.x[-1].shape
+            self.results.statevars = np.zeros(
+                (
+                    *statevars_shape,
+                    field.region.quadrature.npoints,
+                    field.region.mesh.ncells,
+                )
+            )
+
+        self.results.state = state
+        if self.results.state is None:
+            self.results.state = StateNearlyIncompressibleX(field, **kwargs)
+
+        self.results.kinematics = self._extract(self.field)
+        self.assemble = Assemble(vector=self._vector, matrix=self._matrix)
+
+        self.evaluate = Evaluate(
+            gradient=self._gradient,
+            hessian=self._hessian,
+            cauchy_stress=self._cauchy_stress,
+            kirchhoff_stress=self._kirchhoff_stress,
+        )
+
+    def _vector(self, field=None, parallel=False, items=None, args=(), kwargs={}):
+        self.results.stress = self._gradient(
+            field, parallel=parallel, args=args, kwargs=kwargs
+        )
+        form = IntegralForm(
+            fun=self.results.stress,
+            v=self.field,
+            dV=self.field.region.dV,
+        )
+
+        h = self.results.state.h
+        inv_V = self.results.state.inv_V
+        constraint = self.results.state.constraint(bulk=self.bulk)
+
+        values = form.integrate(parallel=parallel)
+        np.add(
+            values[0],
+            np.einsum("aib...,bc...,cj...->ai...", h, inv_V, constraint),
+            out=values[0],
+        )
+
+        self.results.force = form.assemble(values=values)
+
+        return self.results.force
+
+    def _matrix(self, field=None, parallel=False, items=None, args=(), kwargs={}):
+        self.results.elasticity = self._hessian(
+            field, parallel=parallel, args=args, kwargs=kwargs
+        )
+
+        form = IntegralForm(
+            fun=self.results.elasticity,
+            v=self.field,
+            u=self.field,
+            dV=self.field.region.dV,
+        )
+
+        h = self.results.state.h
+        inv_V = self.results.state.inv_V
+
+        values = form.integrate(parallel=parallel, out=self.results.stiffness_values)
+        np.add(
+            values[0],
+            np.einsum("aic...,bjd...,cd...->aibj...", h, h, inv_V, optimize=True)
+            * self.bulk,
+            out=values[0],
+        )
+
+        self.results.stiffness = form.assemble(values=values)
+
+        return self.results.stiffness
+
+    def _extract(self, field, parallel=False):
+        mesh = self.field.region.mesh
+
+        u = field[0].values
+        u0 = self.results.state.u
+
+        mesh_dual = self.results.state.volume_ratio.region.mesh
+        p = self.results.state.pressure.values[mesh_dual.cells].transpose([1, 2, 0])
+        J = self.results.state.volume_ratio.values[mesh_dual.cells].transpose([1, 2, 0])
+
+        h = self.results.state.integrate_shape_function_gradient()
+        inv_V = self.results.state.inv_V
+
+        # change of internal field values due to change of displacement field
+        du = (u - u0)[mesh.cells].transpose([1, 2, 0])
+        dJ = np.einsum(
+            "ai...,aib...,bc...,j->cj...", du, h, inv_V, np.ones(1), optimize=True
+        )
+        dJ = np.add(dJ, dot(inv_V, self.results.state.fp()), out=dJ)
+        dp = self.bulk * (dJ + J - 1) - p
+
+        self.field = field
+        self.results.kinematics = self.results.state.F = self.field.extract(
+            out=self.results.kinematics
+        )
+
+        form = IntegralForm(
+            fun=[np.ones(1)],
+            v=FieldContainer([self.results.state.pressure]),
+            dV=self.field.region.dV,
+            grad_v=[False],
+        )
+        assemble = lambda values: form.assemble([np.asarray(values)]).toarray()
+
+        # update state variables
+        self.results.state.u = u
+        self.results.state.pressure.values[:] += assemble(dp)
+        self.results.state.volume_ratio.values[:] += assemble(dJ)
+
+        return self.results.kinematics
+
+    def _gradient(self, field=None, parallel=False, args=(), kwargs={}):
+        if field is not None:
+            self.results.kinematics = self._extract(field, parallel=parallel)
+
+        F = self.results.kinematics[0]
+        p = self.results.state.pressure.interpolate()
+        statevars = self.results.statevars
+
+        gradient = self.umat.gradient([F, statevars], *args, **kwargs)
+
+        dJdF = self._area_change.function
+        self.results.stress = [gradient[0] + p * dJdF([F])[0]]
+        self.results._statevars = gradient[-1]
+
+        return self.results.stress
+
+    def _hessian(self, field=None, parallel=False, args=(), kwargs={}):
+        if field is not None:
+            self.results.kinematics = self._extract(field, parallel=parallel)
+
+        F = self.results.kinematics[0]
+        p = self.results.state.pressure.interpolate()
+        statevars = self.results.statevars
+
+        d2JdF2 = self._area_change.gradient
+        self.results.elasticity = [
+            self.umat.hessian([F, statevars], *args, **kwargs)[0] + p * d2JdF2([F])[0]
+        ]
+
+        return self.results.elasticity
+
+    def _kirchhoff_stress(self, field=None):
+        self._gradient(field)
+
+        P = self.results.stress[0]
+        F = self.results.kinematics[0]
+
+        return dot(P, transpose(F))
+
+    def _cauchy_stress(self, field=None):
+        self._gradient(field)
+
+        P = self.results.stress[0]
+        F = self.results.kinematics[0]
+        J = det(F)
+
+        return dot(P, transpose(F)) / J

--- a/src/felupe/mechanics/_solidbody_incompressible_x.py
+++ b/src/felupe/mechanics/_solidbody_incompressible_x.py
@@ -72,7 +72,7 @@ class SolidBodyNearlyIncompressibleX(Solid):
             dV=self.field.region.dV,
         )
 
-        h = self.results.state.h
+        h = self.results.state.integrate_shape_function_gradient()
         inv_V = self.results.state.inv_V
         constraint = self.results.state.constraint(bulk=self.bulk)
 
@@ -99,7 +99,7 @@ class SolidBodyNearlyIncompressibleX(Solid):
             dV=self.field.region.dV,
         )
 
-        h = self.results.state.h
+        h = self.results.state.integrate_shape_function_gradient()
         inv_V = self.results.state.inv_V
 
         values = form.integrate(parallel=parallel, out=self.results.stiffness_values)

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -85,9 +85,8 @@ def test_math():
     with pytest.raises(ValueError):
         fem.math.transpose(F, mode=3)
 
-    with pytest.raises(TypeError):
-        fem.math.dot(C, B, mode=(2, 3))
-        fem.math.dot(B, C, mode=(3, 2))
+    fem.math.dot(C, B, mode=(2, 3))
+    fem.math.dot(B, C, mode=(3, 2))
 
     assert fem.math.dot(C, a, mode=(2, 1)).shape == (3, 8, 200)
     assert fem.math.dot(a, C, mode=(1, 2)).shape == (3, 8, 200)
@@ -106,7 +105,9 @@ def test_math():
     with pytest.raises(TypeError):
         fem.math.ddot(A, B, mode=(4, 3))
         fem.math.ddot(B, B, mode=(3, 3))
-        fem.math.ddot(C, B, mode=(2, 3))
+
+    fem.math.ddot(C, B, mode=(2, 3))
+    fem.math.ddot(B, C, mode=(3, 2))
 
     detC = fem.math.det(C)
     fem.math.det(C[:2, :2])


### PR DESCRIPTION
- [x] this works for disconnected dual meshes
- [ ] ~but not for connected dual meshes~

I guess it's because the volume-matrices are not invertible for connected meshes.

I'm not sure if it's worth the effort for disconnected meshes only...