### PR TITLE
Add `FieldDual(disconnect=None)`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file. The format 
 - Add a quadrature scheme for integrating the surface of a unit hemisphere `BazantOh(n=21)`.
 - Add `NearlyIncompressible` as a simplified version of `ThreeFieldVariation`. A constitutive material formulation on the distortional part of a strain energy function in terms of the deformation gradient has to be provided, e.g. by `umat = NearlyIncompressible(NeoHooke(mu=1), bulk=5000)`.
 - Add optional kwargs to job-callback `Job(callback=lambda stepnumber, substepnumber, substep, **kwargs: None, **kwargs)` and `CharacteristicCurve(callback=lambda stepnumber, substepnumber, substep, **kwargs: None, **kwargs)`.
+- Add `FieldDual(disconnect=None)` for an optional disconnected mesh on the dual field. This also enables `FieldsMixed(disconnect=True)`.
 
 ### Changed
 - Rename `Mesh.save()` to `Mesh.write()` and add `Mesh.save()` as an alias to `Mesh.write()`.
@@ -15,7 +16,8 @@ All notable changes to this project will be documented in this file. The format 
 # Fixed
 - Fix missing support for third-order- and second-order tensor combinations to `math.dot(A, B, mode=(2,3))` and `math.ddot(A, B, mode=(2,3))`.
 - Fix error if `FieldDual` is in the fields of a `FieldContainer` for `IntegralForm`.
-- Fix `math.inv(A)` for arrays with shape ``A.shape = (1, 1, ...)``. Also raise an error if ``shape[:2]`` not in ``[(3, 3), (2, 2), (1, 1)]``.
+- Fix `math.inv(A)` for arrays with shape `A.shape = (1, 1, ...)`. Also raise an error if `shape[:2]` not in `[(3, 3), (2, 2), (1, 1)]`.
+- Raise an error in `math.det(A)` if `A.shape[:2]` not in `[(3, 3), (2, 2), (1, 1)]`.
 
 ## [7.18.0] - 2024-02-16
 

--- a/src/felupe/field/_dual.py
+++ b/src/felupe/field/_dual.py
@@ -56,6 +56,10 @@ class FieldDual(Field):
     mesh: Mesh or None, optional
         A mesh which is used for the dual region (default is None). If None, the mesh
         is taken from the region.
+    disconnect : bool or None, optional
+        A flag to disconnect the dual mesh (default is None). If None, a disconnected
+        mesh is used except for regions with quadratic-triangle or -tetra or MINI
+        element formulations.
     **kwargs : dict, optional
         Optional keyword arguments for the dual region.
 
@@ -92,6 +96,7 @@ class FieldDual(Field):
         offset=0,
         npoints=None,
         mesh=None,
+        disconnect=None,
         **kwargs,
     ):
         # create dual regions
@@ -108,6 +113,7 @@ class FieldDual(Field):
             RegionTriangleMINI: RegionTriangle,
             RegionLagrange: RegionLagrange,
         }
+
         mesh_kwargs = {
             RegionHexahedron: {},
             RegionQuad: {},
@@ -120,7 +126,11 @@ class FieldDual(Field):
             RegionTetraMINI: {"disconnect": False},
             RegionTriangleMINI: {"disconnect": False},
             RegionLagrange: {},
-        }
+        }[type(region)]
+
+        if disconnect is not None:
+            mesh_kwargs["disconnect"] = disconnect
+
         points_per_cell = {
             RegionConstantHexahedron: 1,
             RegionConstantQuad: 1,
@@ -145,7 +155,7 @@ class FieldDual(Field):
                 points_per_cell=points_per_cell[RegionDual],
                 offset=offset,
                 npoints=npoints,
-                **mesh_kwargs[type(region)],
+                **mesh_kwargs,
             )
 
         region_dual = RegionDual(mesh, **{**kwargs0, **kwargs})

--- a/tests/test_field.py
+++ b/tests/test_field.py
@@ -67,7 +67,7 @@ def pre_mixed():
     J = fem.Field(r, values=1)
 
     f = fem.FieldContainer([u, p, J])
-    g = fem.FieldsMixed(fem.RegionHexahedron(m), n=3)
+    g = fem.FieldsMixed(fem.RegionHexahedron(m), n=3, disconnect=True)
     f2 = u & p & J
     f3 = (u & p) & J
     f4 = u & (p & J)


### PR DESCRIPTION
closes #645 

With a connected mesh, the last block of the assembled hessians of `ThreeFieldVariation` is not invertible.

```python
import felupe as fem

mesh = fem.Cube(n=3).convert(2, 0, 1, 1)
region = fem.RegionTriQuadraticHexahedron(mesh)
field = fem.FieldsMixed(region, n=3, disconnect=False)
boundaries, loadcase = fem.dof.uniaxial(field, clamped=True)
umat = fem.ThreeFieldVariation(fem.NeoHooke(mu=1, bulk=5000))

form = fem.IntegralForm(umat.hessian([*field.extract(), None]), field, region.dV, field)
blocks = form.assemble(block=False)

from scipy.sparse.linalg import inv

res = inv(blocks[-1].T)
```

With a disconnected mesh, this is possible (inverses on cell-level).

```python
import felupe as fem

mesh = fem.Cube(n=3).convert(2, 0, 1, 1)
region = fem.RegionTriQuadraticHexahedron(mesh)
field = fem.FieldsMixed(region, n=3, disconnect=True)
boundaries, loadcase = fem.dof.uniaxial(field, clamped=True)
umat = fem.ThreeFieldVariation(fem.NeoHooke(mu=1, bulk=5000))

form = fem.IntegralForm(umat.hessian([*field.extract(), None]), field, region.dV, field)
blocks = form.assemble(block=False)

from scipy.sparse.linalg import inv

res = inv(blocks[-1].T)
```

see also #627 