### PR TITLE
Only add `off_screen` and `notebook` keyword-arguments to `pyvista.Plotter(**kwargs)` if they are `True`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to this project will be documented in this file. The format 
 - Enhance the performance of `math.inv(out=None)` and `math.det(out=None)`.
 - Use only the offical API of `tensortrax`. A workaround is used to ensure compatibility with `tensortrax` <= v0.17.1.
 - Pass optional keyword-arguments in the plot-methods `ViewMaterial.plot(**kwargs)` and `ViewMaterialIncompressible.plot(**kwargs)` to the matplotlib axes object `ax.plot(**kwargs)`.
+- Only add `off_screen` and `notebook` keyword-arguments to `pyvista.Plotter(**kwargs)` if they are `True`. This is needed for not ignoring a global variable like `pyvista.OFF_SCREEN = True`.
 
 # Fixed
 - Fix missing support for third-order- and second-order tensor combinations to `math.dot(A, B, mode=(2,3))` and `math.ddot(A, B, mode=(2,3))`.

--- a/src/felupe/tools/_plot.py
+++ b/src/felupe/tools/_plot.py
@@ -118,7 +118,7 @@ class Scene:
                 plotter_kwargs["off_screen"] = off_screen
             if notebook:
                 plotter_kwargs["notebook"] = notebook
-            plotter = pv.Plotter(**kwargs)
+            plotter = pv.Plotter(**plotter_kwargs)
 
         if scalar_bar_args is None:
             scalar_bar_args = {}

--- a/src/felupe/tools/_plot.py
+++ b/src/felupe/tools/_plot.py
@@ -113,7 +113,12 @@ class Scene:
             pv.set_plot_theme(theme)
 
         if plotter is None:
-            plotter = pv.Plotter(off_screen=off_screen, notebook=notebook)
+            plotter_kwargs = dict()
+            if off_screen:
+                plotter_kwargs["off_screen"] = off_screen
+            if notebook:
+                plotter_kwargs["notebook"] = notebook
+            plotter = pv.Plotter(**kwargs)
 
         if scalar_bar_args is None:
             scalar_bar_args = {}


### PR DESCRIPTION
fixes #669 