### PR TITLE
Fix error during assembly in `Form` for different mesh- and field-dimensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ All notable changes to this project will be documented in this file. The format 
 - Fix `math.inv(A)` for arrays with shape `A.shape = (1, 1, ...)`. Also raise an error if `shape[:2]` not in `[(3, 3), (2, 2), (1, 1)]`.
 - Raise an error in `math.det(A)` if `A.shape[:2]` not in `[(3, 3), (2, 2), (1, 1)]`.
 - Fix mutable keyword-arguments in `SolidBody._vector(kwargs={})` by `SolidBody._vector(kwargs=None)`. Also for `._matrix()` and for `SolidBodyNearlyIncompressible`.
+- Fix wrong shape and the resulting error during assembly in `fem.assembly.expression.Form` for the integration of a linear form with different mesh- and field-dimensions.
 
 ## [7.18.0] - 2024-02-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ All notable changes to this project will be documented in this file. The format 
 - Pass optional keyword-arguments in the plot-methods `ViewMaterial.plot(**kwargs)` and `ViewMaterialIncompressible.plot(**kwargs)` to the matplotlib axes object `ax.plot(**kwargs)`.
 - Only add `off_screen` and `notebook` keyword-arguments to `pyvista.Plotter(**kwargs)` if they are `True`. This is needed for not ignoring a global variable like `pyvista.OFF_SCREEN = True`.
 - Enforce `verbose=0` if the environmental variable `"FELUPE_VERBOSE"` is `"false"`. This is useful for running the examples when building the documentation.
+- Don't require a `bilinearform` in `FormItem(bilinearform=None)`. An empty `FormItem` is now a valid item in a `Step`. For empty vectors/matrices, the shape is inferred from `sum(FieldContainer.fieldsizes)` instead of `FieldContainer.fields[0].values.size`.
 
 # Fixed
 - Fix missing support for third-order- and second-order tensor combinations to `math.dot(A, B, mode=(2,3))` and `math.ddot(A, B, mode=(2,3))`.

--- a/src/felupe/assembly/expression/_linear.py
+++ b/src/felupe/assembly/expression/_linear.py
@@ -76,7 +76,7 @@ class LinearForm:
         else:
             v = self.v.basis
 
-        values = np.zeros((len(v), *v.shape[-3:]))
+        values = np.zeros((len(v), v.shape[-4], *v.shape[-2:]))
 
         if not parallel:
             for a, vbasis in enumerate(v):

--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -151,6 +151,16 @@ def test_readme_form():
     step = fem.Step(items=[item], boundaries=boundaries)
     fem.Job(steps=[step]).evaluate()
 
+    item = fem.FormItem(linearform=linearform)
+    item.assemble.vector(field)
+    assert item.assemble.matrix(field).nnz == 0
+
+    item = fem.FormItem()
+    item.assemble.vector(field)
+    item.assemble.matrix(field)
+    assert item.assemble.vector(field).nnz == 0
+    assert item.assemble.matrix(field).nnz == 0
+
 
 if __name__ == "__main__":
     test_readme()


### PR DESCRIPTION
fixes #674 

**Also changed within this PR**
- Don't require a `bilinearform` in `FormItem(bilinearform=None)`. An empty `FormItem` is now a valid item in a `Step`. For empty vectors/matrices, the shape is inferred from `sum(FieldContainer.fieldsizes)` instead of `FieldContainer.fields[0].values.size`. closes #676 and closes #677