### PR TITLE
Simplify `Form`: Remove required `grad_v` and `grad_u` args and obtain the gradient by `v.grad` or `grad(v)`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ All notable changes to this project will be documented in this file. The format 
 
 ## [Unreleased]
 
+### Changed
+- The internal `BasisField.basis` is now a subclassed array `BasisArray` with a `grad`-attribute.
+- `math.grad(x, **kwargs)` is enhanced to return gradients of fields (like before) and the gradient-attribute of basis-arrays (added).
+- The `grad_v` and `grad_u` arguments are removed from the form-expression decorator `Form`. This changes the required function signature of the weakform-callable to `weakform(v, u, **kwargs)`. The tuple of optional arguments is also removed. Gradients of `v` and `u` are now obtained by `math.grad(v)` or `v.grad`.
+
 ## [7.19.1] - 2024-03-08
 
 ### Fixed

--- a/examples/ex10_poisson-equation.py
+++ b/examples/ex10_poisson-equation.py
@@ -42,22 +42,22 @@ field = fem.FieldContainer([scalar])
 # For the :func:`~felupe.newtonrhapson` to converge, the *linear form* of the Poisson
 # equation is also required.
 
-from felupe.math import grad
+from felupe.math import ddot, grad
 
 
 @fem.Form(v=field, u=field)
 def a():
     "Container for a bilinear form."
-    return [lambda v, u: fem.math.ddot(grad(v), grad(u))]
+    return [lambda v, u, **kwargs: ddot(grad(v), grad(u))]
 
 
 @fem.Form(v=field)
 def L():
     "Container for a linear form."
-    return [lambda v: fem.math.ddot(grad(v), grad(scalar)) - 1.0 * v]
+    return [lambda v, **kwargs: ddot(grad(v), grad(scalar)) - kwargs["scale"] * v]
 
 
-poisson = fem.FormItem(bilinearform=a, linearform=L)
+poisson = fem.FormItem(bilinearform=a, linearform=L, kwargs={"scale": 1.0})
 
 boundaries = {
     "bottom-or-left": fem.Boundary(field[0], fx=0, fy=0, mode="or"),

--- a/examples/ex10_poisson-equation.py
+++ b/examples/ex10_poisson-equation.py
@@ -22,13 +22,6 @@ and a unit load
 is solved on a unit rectangle with triangles.
 """
 
-import felupe as fem
-
-mesh = fem.Rectangle(n=2**5).triangulate()
-region = fem.RegionTriangle(mesh)
-scalar = fem.Field(region)
-field = fem.FieldContainer([scalar])
-
 
 # %%
 # The Poisson equation is transformed into integral form representation by the
@@ -42,7 +35,13 @@ field = fem.FieldContainer([scalar])
 # For the :func:`~felupe.newtonrhapson` to converge, the *linear form* of the Poisson
 # equation is also required.
 
+import felupe as fem
 from felupe.math import ddot, grad
+
+mesh = fem.Rectangle(n=2**5).triangulate()
+region = fem.RegionTriangle(mesh)
+scalar = fem.Field(region)
+field = fem.FieldContainer([scalar])
 
 
 @fem.Form(v=field, u=field)

--- a/examples/ex11_notch-stress.py
+++ b/examples/ex11_notch-stress.py
@@ -48,6 +48,6 @@ solid = fem.SolidBody(umat=fem.LinearElastic(E=2.1e5, nu=0.30), field=field)
 step = fem.Step(items=[solid], boundaries=boundaries)
 job = fem.Job(steps=[step]).evaluate(parallel=True, solver=pypardiso.spsolve)
 
-solid.view(
-    point_data={"Stress": fem.project(solid.results.gradient, region)}
-).plot("Stress", component=0, show_edges=False, show_undeformed=False, view="xy").show()
+solid.view(point_data={"Stress": fem.project(solid.results.gradient, region)}).plot(
+    "Stress", component=0, show_edges=False, show_undeformed=False, view="xy"
+).show()

--- a/src/felupe/assembly/expression/_bilinear.py
+++ b/src/felupe/assembly/expression/_bilinear.py
@@ -34,27 +34,21 @@ class BilinearForm:
     Parameters
     ----------
     v : BasisField
-        An object with basis functions (gradients) of a field.
-    grad_v : bool, optional (default is False)
-        Flag to use the gradient of ``v``.
+        Basis (shape) functions and gradients of a field.
     u : BasisField
-        An object with basis function (gradients) of a field.
-    grad_u : bool, optional (default is False)
-        Flag to use the gradient of ``u``.
+        Basis (shape) functions and gradients of a field.
     dx : ndarray or None, optional (default is None)
         Array with (numerical) differential volumes.
 
     """
 
-    def __init__(self, v, u, grad_v=False, grad_u=False, dx=None):
+    def __init__(self, v, u, dx=None, **kwargs):
         self.v = v
-        self.grad_v = grad_v
         self.u = u
-        self.grad_u = grad_u
         self.dx = dx
 
         self._form = IntegralFormCartesian(
-            None, v.field, self.dx, u.field, grad_v, grad_u
+            fun=None, v=v.field, dV=self.dx, u=u.field, **kwargs
         )
 
     def integrate(self, weakform, args=(), kwargs={}, parallel=False, sym=False):
@@ -63,15 +57,15 @@ class BilinearForm:
         Parameters
         ----------
         weakform : callable
-            A callable function ``weakform(v, *args, **kwargs)``.
+            A callable function ``weakform(v, u, *args, **kwargs)``.
         args : tuple, optional
             Optional arguments for callable weakform
         kwargs : dict, optional
             Optional named arguments for callable weakform
-        parallel : bool, optional (default is False)
-            Flag to activate parallel threading.
-        sym : bool, optional (default is False)
-            Flag to active symmetric integration/assembly.
+        parallel : bool, optional
+            Flag to activate parallel threading (default is False).
+        sym : bool, optional
+            Flag to active symmetric integration/assembly (default is False).
 
         Returns
         -------
@@ -79,32 +73,34 @@ class BilinearForm:
             Integrated (but not assembled) matrix values.
         """
 
-        if self.grad_v:
-            v = self.v.grad
-        else:
-            v = self.v.basis
-
-        if self.grad_u:
-            u = self.u.grad
-        else:
-            u = self.u.basis
-
-        values = np.zeros((len(v), v.shape[-4], len(u), u.shape[-4], *u.shape[-2:]))
+        values = np.zeros(
+            (
+                len(self.v.basis),
+                self.v.basis.shape[-4],
+                len(self.u.basis),
+                self.u.basis.shape[-4],
+                *self.u.basis.shape[-2:],
+            )
+        )
 
         if not parallel:
-            for a, vbasis in enumerate(v):
+            for a, vbasis in enumerate(self.v.basis):
                 for i, vb in enumerate(vbasis):
-                    for b, ubasis in enumerate(u):
+                    for b, ubasis in enumerate(self.u.basis):
                         for j, ub in enumerate(ubasis):
                             if sym:
+                                v = type(self.v.basis)(vb, self.v.basis.grad[a, i])
+                                u = type(self.u.basis)(ub, self.u.basis.grad[b, j])
                                 if len(vbasis) * a + i <= len(ubasis) * b + j:
                                     values[a, i, b, j] = values[b, j, a, i] = (
-                                        weakform(vb, ub, *args, **kwargs) * self.dx
+                                        weakform(v, u, *args, **kwargs) * self.dx
                                     )
 
                             else:
+                                v = type(self.v.basis)(vb, self.v.basis.grad[a, i])
+                                u = type(self.u.basis)(ub, self.u.basis.grad[b, j])
                                 values[a, i, b, j] = (
-                                    weakform(vb, ub, *args, **kwargs) * self.dx
+                                    weakform(v, u, *args, **kwargs) * self.dx
                                 )
 
         else:
@@ -124,15 +120,15 @@ class BilinearForm:
                 )
 
             def contribution(values, a, i, b, j, sym, args, kwargs):
+                v = type(self.v.basis)(self.v.basis[a, i], self.v.basis.grad[a, i])
+                u = type(self.u.basis)(self.u.basis[b, j], self.u.basis.grad[b, j])
                 if sym:
                     values[a, i, b, j] = values[b, j, a, i] = (
-                        weakform(v[a, i], u[b, j], *args, **kwargs) * self.dx
+                        weakform(v, u, *args, **kwargs) * self.dx
                     )
 
                 else:
-                    values[a, i, b, j] = (
-                        weakform(v[a, i], u[b, j], *args, **kwargs) * self.dx
-                    )
+                    values[a, i, b, j] = weakform(v, u, *args, **kwargs) * self.dx
 
             threads = [
                 Thread(

--- a/src/felupe/assembly/expression/_bilinear.py
+++ b/src/felupe/assembly/expression/_bilinear.py
@@ -97,9 +97,7 @@ class BilinearForm:
                             else:
                                 v = type(self.v.basis)(vb, self.v.basis.grad[a, i])
                                 u = type(self.u.basis)(ub, self.u.basis.grad[b, j])
-                                values[a, i, b, j] = (
-                                    weakform(v, u, **kwargs) * self.dx
-                                )
+                                values[a, i, b, j] = weakform(v, u, **kwargs) * self.dx
 
         else:
             idx_a, idx_i, idx_b, idx_j = np.indices(values.shape[:4])
@@ -129,9 +127,7 @@ class BilinearForm:
                     values[a, i, b, j] = weakform(v, u, **kwargs) * self.dx
 
             threads = [
-                Thread(
-                    target=contribution, args=(values, a, i, b, j, sym, kwargs)
-                )
+                Thread(target=contribution, args=(values, a, i, b, j, sym, kwargs))
                 for a, i, b, j in aibj
             ]
 

--- a/src/felupe/assembly/expression/_bilinear.py
+++ b/src/felupe/assembly/expression/_bilinear.py
@@ -51,15 +51,13 @@ class BilinearForm:
             fun=None, v=v.field, dV=self.dx, u=u.field, **kwargs
         )
 
-    def integrate(self, weakform, args=(), kwargs={}, parallel=False, sym=False):
+    def integrate(self, weakform, kwargs={}, parallel=False, sym=False):
         r"""Return evaluated (but not assembled) integrals.
 
         Parameters
         ----------
         weakform : callable
-            A callable function ``weakform(v, u, *args, **kwargs)``.
-        args : tuple, optional
-            Optional arguments for callable weakform
+            A callable function ``weakform(v, u, **kwargs)``.
         kwargs : dict, optional
             Optional named arguments for callable weakform
         parallel : bool, optional
@@ -93,14 +91,14 @@ class BilinearForm:
                                 u = type(self.u.basis)(ub, self.u.basis.grad[b, j])
                                 if len(vbasis) * a + i <= len(ubasis) * b + j:
                                     values[a, i, b, j] = values[b, j, a, i] = (
-                                        weakform(v, u, *args, **kwargs) * self.dx
+                                        weakform(v, u, **kwargs) * self.dx
                                     )
 
                             else:
                                 v = type(self.v.basis)(vb, self.v.basis.grad[a, i])
                                 u = type(self.u.basis)(ub, self.u.basis.grad[b, j])
                                 values[a, i, b, j] = (
-                                    weakform(v, u, *args, **kwargs) * self.dx
+                                    weakform(v, u, **kwargs) * self.dx
                                 )
 
         else:
@@ -119,20 +117,20 @@ class BilinearForm:
                     idx_j[mask],
                 )
 
-            def contribution(values, a, i, b, j, sym, args, kwargs):
+            def contribution(values, a, i, b, j, sym, kwargs):
                 v = type(self.v.basis)(self.v.basis[a, i], self.v.basis.grad[a, i])
                 u = type(self.u.basis)(self.u.basis[b, j], self.u.basis.grad[b, j])
                 if sym:
                     values[a, i, b, j] = values[b, j, a, i] = (
-                        weakform(v, u, *args, **kwargs) * self.dx
+                        weakform(v, u, **kwargs) * self.dx
                     )
 
                 else:
-                    values[a, i, b, j] = weakform(v, u, *args, **kwargs) * self.dx
+                    values[a, i, b, j] = weakform(v, u, **kwargs) * self.dx
 
             threads = [
                 Thread(
-                    target=contribution, args=(values, a, i, b, j, sym, args, kwargs)
+                    target=contribution, args=(values, a, i, b, j, sym, kwargs)
                 )
                 for a, i, b, j in aibj
             ]

--- a/src/felupe/assembly/expression/_decorator.py
+++ b/src/felupe/assembly/expression/_decorator.py
@@ -19,9 +19,7 @@ along with FElupe.  If not, see <http://www.gnu.org/licenses/>.
 from ._expression import FormExpression
 
 
-def FormExpressionDecorator(
-    v, u=None, dx=None, kwargs=None, parallel=False
-):
+def FormExpressionDecorator(v, u=None, dx=None, kwargs=None, parallel=False):
     r"""A linear or bilinear form object as function decorator on a weak-form
     with methods for integration and assembly of vectors or sparse matrices.
 

--- a/src/felupe/assembly/expression/_decorator.py
+++ b/src/felupe/assembly/expression/_decorator.py
@@ -20,7 +20,7 @@ from ._expression import FormExpression
 
 
 def FormExpressionDecorator(
-    v, u=None, dx=None, args=None, kwargs=None, parallel=False
+    v, u=None, dx=None, kwargs=None, parallel=False
 ):
     r"""A linear or bilinear form object as function decorator on a weak-form
     with methods for integration and assembly of vectors or sparse matrices.
@@ -33,9 +33,6 @@ def FormExpressionDecorator(
         A container for the ``u`` fields. May be updated during integration / assembly.
     dx : ndarray or None, optional
         Array with (numerical) differential volumes  (default is None).
-    args : tuple or None, optional
-        Tuple with initial optional weakform-arguments. May be updated during
-        integration / assembly (default is None).
     kwargs : dict or None, optional
         Dictionary with initial optional weakform-keyword-arguments. May be
         updated during integration / assembly (default is None).
@@ -146,7 +143,6 @@ def FormExpressionDecorator(
             v=v,
             u=u,
             dx=dx,
-            args=args,
             kwargs=kwargs,
             parallel=parallel,
         )

--- a/src/felupe/assembly/expression/_decorator.py
+++ b/src/felupe/assembly/expression/_decorator.py
@@ -20,7 +20,7 @@ from ._expression import FormExpression
 
 
 def FormExpressionDecorator(
-    v, u=None, grad_v=None, grad_u=None, dx=None, args=None, kwargs=None, parallel=False
+    v, u=None, dx=None, args=None, kwargs=None, parallel=False
 ):
     r"""A linear or bilinear form object as function decorator on a weak-form
     with methods for integration and assembly of vectors or sparse matrices.
@@ -31,10 +31,6 @@ def FormExpressionDecorator(
         A container for the ``v`` fields. May be updated during integration / assembly.
     u : FieldContainer
         A container for the ``u`` fields. May be updated during integration / assembly.
-    grad_v : bool, optional
-        Flag to use the gradient of ``v`` (default is None).
-    grad_u : bool, optional
-        Flag to use the gradient of ``u`` (default is None).
     dx : ndarray or None, optional
         Array with (numerical) differential volumes  (default is None).
     args : tuple or None, optional
@@ -118,18 +114,18 @@ def FormExpressionDecorator(
     as keyword arguments of the weak-form may be defined inside the decorator or as part
     of the assembly arguments.
 
-    >>> from felupe.math import ddot, trace, sym
+    >>> from felupe.math import ddot, trace, sym, grad
 
     >>> @fem.Form(
-    >>>     v=field, u=field, grad_v=[True], grad_u=[True], kwargs={"μ": 1.0, "λ": 2.0}
+    >>>     v=field, u=field, kwargs={"μ": 1.0, "λ": 2.0}
     >>> )
     >>> def bilinearform():
     >>>     "A container for a bilinear form."
     >>>
-    >>>     def linear_elasticity(gradv, gradu, μ, λ):
+    >>>     def linear_elasticity(v, u, μ, λ):
     >>>         "Linear elasticity."
     >>>
-    >>>         δε, ε = sym(gradv), sym(gradu)
+    >>>         δε, ε = sym(grad(v)), sym(grad(u))
     >>>         return 2 * μ * ddot(δε, ε) + λ * trace(δε) * trace(ε)
     >>>
     >>>     return [linear_elasticity,]
@@ -149,8 +145,6 @@ def FormExpressionDecorator(
             weakform=weakform,
             v=v,
             u=u,
-            grad_v=grad_v,
-            grad_u=grad_u,
             dx=dx,
             args=args,
             kwargs=kwargs,

--- a/src/felupe/assembly/expression/_expression.py
+++ b/src/felupe/assembly/expression/_expression.py
@@ -70,11 +70,7 @@ class FormExpression:
         self.form = None
         self.dx = dx
         self.weakform = weakform
-
-        if kwargs is not None:
-            self.kwargs = kwargs
-        else:
-            self.kwargs = {}
+        self.kwargs = kwargs
 
         # init underlying linear or bilinear (mixed) form
         self._init_or_update_forms(v, u, kwargs, parallel)

--- a/src/felupe/assembly/expression/_expression.py
+++ b/src/felupe/assembly/expression/_expression.py
@@ -21,8 +21,8 @@ from ._mixed import BilinearFormExpression, LinearFormExpression
 
 
 class FormExpression:
-    r"""A linear or bilinear form object based on a weak-form with
-    methods for integration and assembly of vectors / sparse matrices.
+    r"""A linear or bilinear form object based on a weak-form with methods for
+    integration and assembly of vectors / sparse matrices.
 
     Linear Form:
 
@@ -39,15 +39,11 @@ class FormExpression:
     Parameters
     ----------
     v : Field or FieldMixed
-        An object with interpolation or gradients of a field. May be
+        An object with interpolation and gradients of a field. May be
         updated during integration / assembly.
     u : Field or FieldMixed
-        An object with interpolation or gradients of a field. May be
+        An object with interpolation and gradients of a field. May be
         updated during integration / assembly.
-    grad_v : bool, optional
-        Flag to use the gradient of ``v`` (default is False).
-    grad_u : bool, optional
-        Flag to use the gradient of ``u`` (default is False).
     dx : ndarray or None, optional
         Array with (numerical) differential volumes (default is None).
     args : tuple or None, optional
@@ -66,8 +62,6 @@ class FormExpression:
         weakform,
         v,
         u=None,
-        grad_v=False,
-        grad_u=False,
         dx=None,
         args=None,
         kwargs=None,
@@ -75,8 +69,6 @@ class FormExpression:
     ):
         # set attributes
         self.form = None
-        self.grad_u = grad_u
-        self.grad_v = grad_v
         self.dx = dx
         self.weakform = weakform
 
@@ -117,7 +109,7 @@ class FormExpression:
 
                 # mixed-field input
                 self.v = Basis(v, parallel=parallel)
-                form = LinearFormExpression(self.v, self.grad_v)
+                form = LinearFormExpression(self.v)
 
                 # evaluate weakform to list of weakforms
                 if isinstance(self.weakform, type(lambda x: x)):
@@ -126,7 +118,7 @@ class FormExpression:
             else:
                 self.v = Basis(v, parallel=parallel)
                 self.u = Basis(u, parallel=parallel)
-                form = BilinearFormExpression(self.v, self.u, self.grad_v, self.grad_u)
+                form = BilinearFormExpression(self.v, self.u)
 
                 # evaluate weakform to list of weakforms
                 if isinstance(self.weakform, type(lambda x: x)):
@@ -151,11 +143,9 @@ class FormExpression:
         Parameters
         ----------
         v : Field, FieldMixed or None, optional
-            An object with interpolation or gradients of a field as specified
-            by boolean flag ``self.grad_v`` (default is None).
+            An object with interpolation and gradients of a field (default is None).
         u : Field, FieldMixed or None, optional
-            An object with interpolation or gradients of a field as specified
-            by boolean flag ``self.grad_v`` (default is None).
+            An object with interpolation and gradients of a field (default is None).
         args : tuple, optional (default is ())
             Tuple with optional weakform-arguments.
         kwargs : dict, optional (default is {})
@@ -191,11 +181,9 @@ class FormExpression:
         Parameters
         ----------
         v : Field, FieldMixed or None, optional
-            An object with interpolation or gradients of a field as specified
-            by boolean flag ``self.grad_v`` (default is None).
+            An object with interpolation and gradients of a field (default is None).
         u : Field, FieldMixed or None, optional
-            An object with interpolation or gradients of a field as specified
-            by boolean flag ``self.grad_v`` (default is None).
+            An object with interpolation and gradients of a field (default is None).
         args : tuple, optional (default is ())
             Tuple with optional weakform-arguments.
         kwargs : dict, optional (default is {})

--- a/src/felupe/assembly/expression/_expression.py
+++ b/src/felupe/assembly/expression/_expression.py
@@ -63,7 +63,6 @@ class FormExpression:
         v,
         u=None,
         dx=None,
-        args=None,
         kwargs=None,
         parallel=False,
     ):
@@ -72,25 +71,16 @@ class FormExpression:
         self.dx = dx
         self.weakform = weakform
 
-        if args is not None:
-            self.args = args
-        else:
-            self.args = ()
-
         if kwargs is not None:
             self.kwargs = kwargs
         else:
             self.kwargs = {}
 
         # init underlying linear or bilinear (mixed) form
-        self._init_or_update_forms(v, u, args, kwargs, parallel)
+        self._init_or_update_forms(v, u, kwargs, parallel)
 
-    def _init_or_update_forms(self, v, u, args, kwargs, parallel):
+    def _init_or_update_forms(self, v, u, kwargs, parallel):
         "Init or update the underlying form object."
-
-        # update args for weakform
-        if args is not None:
-            self.args = args
 
         # update kwargs for weakform
         if kwargs is not None:
@@ -135,9 +125,7 @@ class FormExpression:
             else:
                 self.form = form
 
-    def integrate(
-        self, v=None, u=None, args=None, kwargs=None, parallel=False, sym=False
-    ):
+    def integrate(self, v=None, u=None, kwargs=None, parallel=False, sym=False):
         r"""Return evaluated (but not assembled) integrals.
 
         Parameters
@@ -146,8 +134,6 @@ class FormExpression:
             An object with interpolation and gradients of a field (default is None).
         u : Field, FieldMixed or None, optional
             An object with interpolation and gradients of a field (default is None).
-        args : tuple, optional (default is ())
-            Tuple with optional weakform-arguments.
         kwargs : dict, optional (default is {})
             Dictionary with optional weakform-keyword-arguments.
         parallel : bool, optional (default is False)
@@ -162,20 +148,16 @@ class FormExpression:
             Integrated (but not assembled) vector / matrix values.
         """
 
-        self._init_or_update_forms(v, u, args, kwargs, parallel)
+        self._init_or_update_forms(v, u, kwargs, parallel)
 
         kwargs = dict(parallel=parallel, sym=sym)
 
         if self.u is None:
             kwargs.pop("sym")
 
-        return self.form.integrate(
-            self.weakform, args=self.args, kwargs=self.kwargs, **kwargs
-        )
+        return self.form.integrate(self.weakform, kwargs=self.kwargs, **kwargs)
 
-    def assemble(
-        self, v=None, u=None, args=None, kwargs=None, parallel=False, sym=False
-    ):
+    def assemble(self, v=None, u=None, kwargs=None, parallel=False, sym=False):
         r"""Return the assembled integral as vector / sparse matrix.
 
         Parameters
@@ -184,8 +166,6 @@ class FormExpression:
             An object with interpolation and gradients of a field (default is None).
         u : Field, FieldMixed or None, optional
             An object with interpolation and gradients of a field (default is None).
-        args : tuple, optional (default is ())
-            Tuple with optional weakform-arguments.
         kwargs : dict, optional (default is {})
             Dictionary with optional weakform-keyword-arguments.
         parallel : bool, optional (default is False)
@@ -200,13 +180,11 @@ class FormExpression:
             The assembled vector / sparse matrix.
         """
 
-        self._init_or_update_forms(v, u, args, kwargs, parallel)
+        self._init_or_update_forms(v, u, kwargs, parallel)
 
         kwargs = dict(parallel=parallel, sym=sym)
 
         if self.u is None:
             kwargs.pop("sym")
 
-        return self.form.assemble(
-            self.weakform, args=self.args, kwargs=self.kwargs, **kwargs
-        )
+        return self.form.assemble(self.weakform, kwargs=self.kwargs, **kwargs)

--- a/src/felupe/assembly/expression/_linear.py
+++ b/src/felupe/assembly/expression/_linear.py
@@ -77,14 +77,10 @@ class LinearForm:
 
             def contribution(values, a, i, kwargs):
                 v = type(self.v.basis)(self.v.basis[a, i], self.v.basis.grad[a, i])
-                values[a, i] = (
-                    weakform(v, **kwargs)
-                    * self.dx
-                )
+                values[a, i] = weakform(v, **kwargs) * self.dx
 
             threads = [
-                Thread(target=contribution, args=(values, a, i, kwargs))
-                for a, i in ai
+                Thread(target=contribution, args=(values, a, i, kwargs)) for a, i in ai
             ]
 
             for t in threads:

--- a/src/felupe/assembly/expression/_linear.py
+++ b/src/felupe/assembly/expression/_linear.py
@@ -43,15 +43,13 @@ class LinearForm:
         self.dx = dx
         self._form = IntegralFormCartesian(fun=None, v=v.field, dV=self.dx, **kwargs)
 
-    def integrate(self, weakform, args=(), kwargs={}, parallel=False):
+    def integrate(self, weakform, kwargs={}, parallel=False):
         r"""Return evaluated (but not assembled) integrals.
 
         Parameters
         ----------
         weakform : callable
-            A callable function ``weakform(v, *args, **kwargs)``.
-        args : tuple, optional
-            Optional arguments for callable weakform
+            A callable function ``weakform(v, **kwargs)``.
         kawargs : dict, optional
             Optional named arguments for callable weakform
         parallel : bool, optional (default is False)
@@ -71,21 +69,21 @@ class LinearForm:
             for a, vbasis in enumerate(self.v.basis):
                 for i, vb in enumerate(vbasis):
                     v = type(self.v.basis)(vb, self.v.basis.grad[a, i])
-                    values[a, i] = weakform(v, *args, **kwargs) * self.dx
+                    values[a, i] = weakform(v, **kwargs) * self.dx
 
         else:
             idx_a, idx_i = np.indices(values.shape[:2])
             ai = zip(idx_a.ravel(), idx_i.ravel())
 
-            def contribution(values, a, i, args, kwargs):
+            def contribution(values, a, i, kwargs):
                 v = type(self.v.basis)(self.v.basis[a, i], self.v.basis.grad[a, i])
                 values[a, i] = (
-                    weakform(v, *args, **kwargs)
+                    weakform(v, **kwargs)
                     * self.dx
                 )
 
             threads = [
-                Thread(target=contribution, args=(values, a, i, args, kwargs))
+                Thread(target=contribution, args=(values, a, i, kwargs))
                 for a, i in ai
             ]
 

--- a/src/felupe/assembly/expression/_mixed.py
+++ b/src/felupe/assembly/expression/_mixed.py
@@ -46,15 +46,13 @@ class LinearFormExpression:
 
         self._linearform = [LinearForm(v=vi, dx=self.dx) for vi in self.v]
 
-    def integrate(self, weakform, args=(), kwargs=None, parallel=False):
+    def integrate(self, weakform, kwargs=None, parallel=False):
         r"""Return evaluated (but not assembled) integrals.
 
         Parameters
         ----------
         weakform : callable
-            A callable function ``weakform(v, *args, **kwargs)``.
-        args : tuple, optional
-            Optional arguments for callable weakform.
+            A callable function ``weakform(v, **kwargs)``.
         kwargs : dict or None, optional
             Optional named arguments for callable weakform (default is None).
         parallel : bool, optional
@@ -70,19 +68,17 @@ class LinearFormExpression:
             kwargs = {}
 
         return [
-            form.integrate(fun, args, kwargs, parallel=parallel)
+            form.integrate(fun, kwargs, parallel=parallel)
             for form, fun in zip(self._linearform, weakform)
         ]
 
-    def assemble(self, weakform, args=(), kwargs=None, parallel=False):
+    def assemble(self, weakform, kwargs=None, parallel=False):
         r"""Return the assembled integral as vector.
 
         Parameters
         ----------
         weakform : callable
-            A callable function ``weakform(v, *args, **kwargs)``.
-        args : tuple, optional
-            Optional arguments for callable weakform
+            A callable function ``weakform(v, **kwargs)``.
         kwargs : dict or None, optional
             Optional named arguments for callable weakform (default is None).
         parallel : bool, optional
@@ -94,7 +90,7 @@ class LinearFormExpression:
             The assembled vector.
         """
 
-        values = self.integrate(weakform, args, kwargs, parallel=parallel)
+        values = self.integrate(weakform, kwargs, parallel=parallel)
 
         return self._form.assemble(values)
 
@@ -142,15 +138,13 @@ class BilinearFormExpression:
                 )
             )
 
-    def integrate(self, weakform, args=(), kwargs=None, parallel=False, sym=False):
+    def integrate(self, weakform, kwargs=None, parallel=False, sym=False):
         r"""Return evaluated (but not assembled) integrals.
 
         Parameters
         ----------
         weakform : callable
-            A callable function ``weakform(v, u, *args, **kwargs)``.
-        args : tuple, optional
-            Optional arguments for callable weakform.
+            A callable function ``weakform(v, u, **kwargs)``.
         kwargs : dict or None, optional
             Optional named arguments for callable weakform (default is None).
         parallel : bool, optional (default is False)
@@ -166,19 +160,17 @@ class BilinearFormExpression:
             kwargs = {}
 
         return [
-            form.integrate(fun, args, kwargs, parallel=parallel, sym=sym)
+            form.integrate(fun, kwargs, parallel=parallel, sym=sym)
             for form, fun in zip(self._bilinearform, weakform)
         ]
 
-    def assemble(self, weakform, args=(), kwargs=None, parallel=False, sym=False):
+    def assemble(self, weakform, kwargs=None, parallel=False, sym=False):
         r"""Return the assembled integral as matrix.
 
         Parameters
         ----------
         weakform : callable
-            A callable function ``weakform(v, u, *args, **kwargs)``.
-        args : tuple, optional
-            Optional arguments for callable weakform.
+            A callable function ``weakform(v, u, **kwargs)``.
         kawargs : dict or None, optional
             Optional named arguments for callable weakform (default is None).
         parallel : bool, optional
@@ -190,6 +182,6 @@ class BilinearFormExpression:
             The assembled sparse matrix.
         """
 
-        values = self.integrate(weakform, args, kwargs, parallel=parallel, sym=sym)
+        values = self.integrate(weakform, kwargs, parallel=parallel, sym=sym)
 
         return self._form.assemble(values)

--- a/src/felupe/math/_field.py
+++ b/src/felupe/math/_field.py
@@ -47,10 +47,13 @@ def norm(array, axis=None):
 
 
 def interpolate(field):
-    "Interpolate method of field A."
+    "Interpolate method of a field."
     return field.interpolate()
 
 
-def grad(field, sym=False):
-    "Gradient method of field A."
-    return field.grad(sym=sym)
+def grad(x, **kwargs):
+    "Return the gradient of a field or the gradient of a basis-array."
+    if callable(x.grad):
+        return x.grad(**kwargs)
+    else:
+        return x.grad

--- a/src/felupe/mechanics/_item.py
+++ b/src/felupe/mechanics/_item.py
@@ -44,19 +44,19 @@ class FormItem:
     --------
     >>> import felupe as fem
     >>> from felupe.math import ddot, sym, trace, grad
-    >>> 
+    >>>
     >>> mesh = fem.Cube(n=11)
     >>> region = fem.RegionHexahedron(mesh)
     >>> field = fem.FieldContainer([fem.Field(region, dim=3)])
     >>> boundaries, loadcase = fem.dof.uniaxial(field, clamped=True)
-    >>> 
+    >>>
     >>> @fem.Form(v=field, u=field)
     >>> def bilinearform():
     >>>     def a(v, u, μ=1.0, λ=2.0):
     >>>         δε, ε = sym(grad(v)), sym(grad(u))
     >>>         return 2 * μ * ddot(δε, ε) + λ * trace(δε) * trace(ε)
     >>>     return [a]
-    >>> 
+    >>>
     >>> item = fem.FormItem(bilinearform, linearform=None, sym=True)
     >>> step = fem.Step(items=[item], boundaries=boundaries)
     >>> fem.Job(steps=[step]).evaluate()
@@ -68,14 +68,11 @@ class FormItem:
 
     """
 
-    def __init__(
-        self, bilinearform=None, linearform=None, sym=False, args=None, kwargs=None
-    ):
+    def __init__(self, bilinearform=None, linearform=None, sym=False, kwargs=None):
         self.bilinearform = bilinearform
         self.linearform = linearform
 
         self.sym = sym
-        self.args = args
         self.kwargs = kwargs
 
         self.results = Results(stress=False, elasticity=False)
@@ -93,7 +90,7 @@ class FormItem:
 
         if self.linearform is not None:
             self.results.force = self.linearform.assemble(
-                v=self.field, parallel=parallel, args=self.args, kwargs=self.kwargs
+                v=self.field, parallel=parallel, kwargs=self.kwargs
             )
 
         else:
@@ -113,7 +110,6 @@ class FormItem:
                 u=self.field,
                 parallel=parallel,
                 sym=self.sym,
-                args=self.args,
                 kwargs=self.kwargs,
             )
 

--- a/src/felupe/mechanics/_item.py
+++ b/src/felupe/mechanics/_item.py
@@ -43,20 +43,20 @@ class FormItem:
     Examples
     --------
     >>> import felupe as fem
-    >>> from felupe.math import ddot, sym, trace
-
+    >>> from felupe.math import ddot, sym, trace, grad
+    >>> 
     >>> mesh = fem.Cube(n=11)
     >>> region = fem.RegionHexahedron(mesh)
     >>> field = fem.FieldContainer([fem.Field(region, dim=3)])
     >>> boundaries, loadcase = fem.dof.uniaxial(field, clamped=True)
-
-    >>> @fem.Form(v=field, u=field, grad_v=[True], grad_u=[True])
+    >>> 
+    >>> @fem.Form(v=field, u=field)
     >>> def bilinearform():
-    >>>     def a(gradv, gradu, μ=1.0, λ=2.0):
-    >>>         δε, ε = sym(gradv), sym(gradu)
+    >>>     def a(v, u, μ=1.0, λ=2.0):
+    >>>         δε, ε = sym(grad(v)), sym(grad(u))
     >>>         return 2 * μ * ddot(δε, ε) + λ * trace(δε) * trace(ε)
     >>>     return [a]
-
+    >>> 
     >>> item = fem.FormItem(bilinearform, linearform=None, sym=True)
     >>> step = fem.Step(items=[item], boundaries=boundaries)
     >>> fem.Job(steps=[step]).evaluate()

--- a/src/felupe/tools/_project.py
+++ b/src/felupe/tools/_project.py
@@ -21,7 +21,7 @@ from scipy.sparse import csr_matrix as sparsematrix
 from scipy.sparse.linalg import spsolve
 
 from ..assembly import IntegralFormCartesian
-from ..element import Tetra, Triangle, QuadraticTriangle, QuadraticTetra
+from ..element import QuadraticTetra, QuadraticTriangle, Tetra, Triangle
 from ..field import Field
 from ..quadrature import Tetrahedron as TetrahedronQuadrature
 from ..quadrature import Triangle as TriangleQuadrature

--- a/tests/test_basis.py
+++ b/tests/test_basis.py
@@ -50,22 +50,22 @@ def test_basis():
         r, u = pre(dim=3)
         b = fem.assembly.expression.Basis(u, parallel=parallel)
 
-        assert b[0].grad is not None
+        assert not np.any(b[0].basis.grad == None)
 
         r, u = pre(dim=1)
         b = fem.assembly.expression.Basis(u, parallel=parallel)
 
-        assert b[0].grad is not None
+        assert not np.any(b[0].basis.grad == None)
 
         r, u = pre_constant(dim=3)
         b = fem.assembly.expression.Basis(u, parallel=parallel)
 
-        assert b[0].grad is None
+        assert np.all(b[0].basis.grad == None)
 
         r, u = pre_constant(dim=1)
         b = fem.assembly.expression.Basis(u, parallel=parallel)
 
-        assert b[0].grad is None
+        assert np.all(b[0].basis.grad == None)
 
 
 if __name__ == "__main__":

--- a/tests/test_bilinearform.py
+++ b/tests/test_bilinearform.py
@@ -108,21 +108,17 @@ def test_linear_elastic():
     displacement = fem.Field(region, dim=3)
     field = fem.FieldContainer([displacement])
 
-    from felupe.math import ddot, sym, trace
+    from felupe.math import ddot, sym, trace, grad
 
     @fem.Form(v=field, u=field, kwargs={"mu": 1.0, "lmbda": 2.0})
     def bilinearform():
         "A container for a bilinear form."
 
         def linear_elasticity(v, u, mu, lmbda):
-            "Linear elasticity."
-
             de, e = sym(grad(v)), sym(grad(u))
             return 2 * mu * ddot(de, e) + lmbda * trace(de) * trace(e)
 
-        return [
-            linear_elasticity,
-        ]
+        return [linear_elasticity]
 
     bilinearform.integrate(v=field, u=field, parallel=False)
     bilinearform.integrate(v=field, u=field, parallel=True)

--- a/tests/test_bilinearform.py
+++ b/tests/test_bilinearform.py
@@ -76,30 +76,30 @@ def test_form_decorator():
     def a():
         return (a_uu, a_up, a_pp)
 
-    a.assemble(field, field, args=(F, p))
+    a.assemble(field, field, kwargs=dict(F=F, p=p))
 
     @fem.Form(v=field)
     def L():
         return (lformu, lformp)
 
-    L.assemble(field, args=(F, p), parallel=False)
-    L.assemble(field, args=(F, p), parallel=True)
-    L.assemble(field, args=(F, p), parallel=False, sym=True)
-    L.assemble(field, args=(F, p), parallel=True, sym=True)
+    L.assemble(field, kwargs=dict(F=F, p=p), parallel=False)
+    L.assemble(field, kwargs=dict(F=F, p=p), parallel=True)
+    L.assemble(field, kwargs=dict(F=F, p=p), parallel=False, sym=True)
+    L.assemble(field, kwargs=dict(F=F, p=p), parallel=True, sym=True)
 
     @fem.Form(v=field)
     def L():
         return (lformu, lformp)
 
-    L.integrate(field, args=(F, p), parallel=False)
-    L.integrate(field, args=(F, p), parallel=True)
-    L.integrate(field, args=(F, p), parallel=False, sym=True)
-    L.integrate(field, args=(F, p), parallel=True, sym=True)
+    L.integrate(field, kwargs=dict(F=F, p=p), parallel=False)
+    L.integrate(field, kwargs=dict(F=F, p=p), parallel=True)
+    L.integrate(field, kwargs=dict(F=F, p=p), parallel=False, sym=True)
+    L.integrate(field, kwargs=dict(F=F, p=p), parallel=True, sym=True)
 
-    L.assemble(field, args=(F, p), parallel=False)
-    L.assemble(field, args=(F, p), parallel=True)
-    L.assemble(field, args=(F, p), parallel=False, sym=True)
-    L.assemble(field, args=(F, p), parallel=True, sym=True)
+    L.assemble(field, kwargs=dict(F=F, p=p), parallel=False)
+    L.assemble(field, kwargs=dict(F=F, p=p), parallel=True)
+    L.assemble(field, kwargs=dict(F=F, p=p), parallel=False, sym=True)
+    L.assemble(field, kwargs=dict(F=F, p=p), parallel=True, sym=True)
 
 
 def test_linear_elastic():

--- a/tests/test_bilinearform.py
+++ b/tests/test_bilinearform.py
@@ -108,7 +108,7 @@ def test_linear_elastic():
     displacement = fem.Field(region, dim=3)
     field = fem.FieldContainer([displacement])
 
-    from felupe.math import ddot, sym, trace, grad
+    from felupe.math import ddot, grad, sym, trace
 
     @fem.Form(v=field, u=field, kwargs={"mu": 1.0, "lmbda": 2.0})
     def bilinearform():

--- a/tests/test_bilinearform.py
+++ b/tests/test_bilinearform.py
@@ -25,10 +25,8 @@ along with Felupe.  If not, see <http://www.gnu.org/licenses/>.
 
 """
 
-import pytest
-
 import felupe as fem
-from felupe.math import ddot, dot, dya
+from felupe.math import ddot, dot, dya, grad
 
 
 def lform(v, w):
@@ -40,27 +38,19 @@ def lform_grad(v, F):
 
 
 def lformu(v, F, p):
-    return ddot(F, v)
+    return ddot(F, grad(v))
 
 
 def lformp(q, F, p):
     return dot(p, q)
 
 
-def bform(v, u, w):
-    return dot(w, v) * dot(w, u)
-
-
-def bform_grad(v, u, F):
-    return ddot(F, v) * ddot(F, u)
-
-
 def a_uu(v, u, F, p):
-    return ddot(u, ddot(dya(F, F), v))
+    return ddot(grad(u), ddot(dya(F, F), grad(v)))
 
 
 def a_up(v, r, F, p):
-    return dot(p, r) * ddot(F, v)
+    return dot(p, r) * ddot(F, grad(v))
 
 
 def a_pp(q, r, F, p):
@@ -82,19 +72,13 @@ def test_form_decorator():
     field = pre(dim=3)
     F, p = field.extract()
 
-    @fem.Form(v=field, u=field, grad_v=(True, False), grad_u=(True, False))
+    @fem.Form(v=field, u=field)
     def a():
         return (a_uu, a_up, a_pp)
 
     a.assemble(field, field, args=(F, p))
 
-    @fem.Form(v=field, u=field, grad_v=None, grad_u=None)
-    def a():
-        return (a_uu, a_up, a_pp)
-
-    a.assemble(field, field, args=(F, p))
-
-    @fem.Form(v=field, grad_v=(True, False))
+    @fem.Form(v=field)
     def L():
         return (lformu, lformp)
 
@@ -103,7 +87,7 @@ def test_form_decorator():
     L.assemble(field, args=(F, p), parallel=False, sym=True)
     L.assemble(field, args=(F, p), parallel=True, sym=True)
 
-    @fem.Form(v=field, grad_v=None)
+    @fem.Form(v=field)
     def L():
         return (lformu, lformp)
 
@@ -126,16 +110,14 @@ def test_linear_elastic():
 
     from felupe.math import ddot, sym, trace
 
-    @fem.Form(
-        v=field, u=field, grad_v=[True], grad_u=[True], kwargs={"mu": 1.0, "lmbda": 2.0}
-    )
+    @fem.Form(v=field, u=field, kwargs={"mu": 1.0, "lmbda": 2.0})
     def bilinearform():
         "A container for a bilinear form."
 
-        def linear_elasticity(gradv, gradu, mu, lmbda):
+        def linear_elasticity(v, u, mu, lmbda):
             "Linear elasticity."
 
-            de, e = sym(gradv), sym(gradu)
+            de, e = sym(grad(v)), sym(grad(u))
             return 2 * mu * ddot(de, e) + lmbda * trace(de) * trace(e)
 
         return [

--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -122,7 +122,7 @@ def test_readme_form():
     field = fem.FieldContainer([fem.Field(region, dim=3)])
     boundaries, loadcase = fem.dof.uniaxial(field, clamped=True)
 
-    from felupe.math import ddot, sym, trace, grad
+    from felupe.math import ddot, grad, sym, trace
 
     @fem.Form(v=field, u=field)
     def bilinearform():

--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -122,20 +122,20 @@ def test_readme_form():
     field = fem.FieldContainer([fem.Field(region, dim=3)])
     boundaries, loadcase = fem.dof.uniaxial(field, clamped=True)
 
-    from felupe.math import ddot, sym, trace
+    from felupe.math import ddot, sym, trace, grad
 
-    @fem.Form(v=field, u=field, grad_v=[True], grad_u=[True])
+    @fem.Form(v=field, u=field)
     def bilinearform():
-        def a(gradv, gradu, μ=1.0, λ=2.0):
-            δε, ε = sym(gradv), sym(gradu)
+        def a(v, u, μ=1.0, λ=2.0):
+            δε, ε = sym(grad(v)), sym(grad(u))
             return 2 * μ * ddot(δε, ε) + λ * trace(δε) * trace(ε)
 
         return [a]
 
-    @fem.Form(v=field, grad_v=[True])
+    @fem.Form(v=field)
     def linearform():
-        def L(gradv, μ=1.0, λ=2.0):
-            δε = sym(gradv)
+        def L(v, μ=1.0, λ=2.0):
+            δε = sym(grad(v))
             ε = field.extract(grad=True, sym=True, add_identity=False)[0]
             return 2 * μ * ddot(δε, ε) + λ * trace(δε) * trace(ε)
 


### PR DESCRIPTION
closes #679 

However, the arguments are still supported - they may be still passed within the `**kwargs`. However, they have no effect on the bases passed to the weakform-callables. The weakform must be changed from

```python
from felupe.math import ddot, sym, trace

    @fem.Form(v=field, u=field, grad_v=[True], grad_u=[True], kwargs={"mu": 1.0, "lmbda": 2.0})
    def bilinearform():
        "A container for a bilinear form."

        def linear_elasticity(gradv, gradu, mu, lmbda):
            de, e = sym(gradv), sym(gradu)
            return 2 * mu * ddot(de, e) + lmbda * trace(de) * trace(e)

        return [linear_elasticity]
```

to

```python
from felupe.math import ddot, sym, trace, grad

    @fem.Form(v=field, u=field, kwargs={"mu": 1.0, "lmbda": 2.0})
    def bilinearform():
        "A container for a bilinear form."

        def linear_elasticity(v, u, mu, lmbda):
            de, e = sym(grad(v)), sym(grad(u))
            return 2 * mu * ddot(de, e) + lmbda * trace(de) * trace(e)

        return [linear_elasticity]
```