### PR TITLE
Fall-back to `tools.extrapolate(mean=True)` for `project(mean=True)`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ All notable changes to this project will be documented in this file. The format 
 - The internal `BasisField.basis` is now a subclassed array `BasisArray` with a `grad`-attribute.
 - `math.grad(x, **kwargs)` is enhanced to return gradients of fields (like before) and the gradient-attribute of basis-arrays (added).
 - The `grad_v` and `grad_u` arguments are removed from the form-expression decorator `Form`. This changes the required function signature of the weakform-callable to `weakform(v, u, **kwargs)`. The tuple of optional arguments is also removed. Gradients of `v` and `u` are now obtained by `math.grad(v)` or `v.grad`.
+- Enforce quadrature schemes with minimal order for projections in `project()` for `Triangle`, `Tetra` as well as their MINI- and Quadratic-variants.
+- Fall-back to `extrapolate(mean=True)` in `project(mean=True)`.
+- Don't ravel the results of `res = extrapolate(values, region)`, i.e. `values.shape = (3, 3, 4, 100)` will be returned as `res.shape = (121, 3, 3)` instead of `res.shape = (121, 9)`.
 
 ### Removed
 - Remove the deprecated old-style argument `move` in `dof.biaxial()`.

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -349,11 +349,8 @@ def test_project():
     assert np.all([np.allclose(np.eye(3), res) for res in projected])
 
     # this is wrong
-    projected = fem.project(values, region, average=True)
-    assert projected.shape == (mesh.npoints, 3, 3)
-    assert not np.any(np.isnan(projected))
-    with pytest.raises(AssertionError):
-        assert np.all([np.allclose(np.eye(3), res) for res in projected])
+    with pytest.raises(ValueError):
+        projected = fem.project(values, region, average=True)
 
     # cube (tetra)
     mesh = fem.Cube(n=2).triangulate()
@@ -388,11 +385,8 @@ def test_project():
     assert np.all([np.allclose(np.eye(3), res) for res in projected])
 
     # this is wrong
-    projected = fem.project(values, region, average=True)
-    assert projected.shape == (mesh.npoints, 3, 3)
-    assert not np.any(np.isnan(projected))
-    with pytest.raises(AssertionError):
-        assert np.all([np.allclose(np.eye(3), res) for res in projected])
+    with pytest.raises(ValueError):
+        projected = fem.project(values, region, average=True)
 
 
 def test_extrapolate():
@@ -404,19 +398,19 @@ def test_extrapolate():
     values = field.extract()
 
     projected = fem.tools.extrapolate(values, region, average=False)
-    assert projected.shape == (mesh.cells.size, 9)
+    assert projected.shape == (mesh.cells.size, 3, 3)
     assert not np.any(np.isnan(projected))
-    assert np.all([np.allclose(np.eye(3).ravel(), res) for res in projected[:-1]])
+    assert np.all([np.allclose(np.eye(3), res) for res in projected[:-1]])
 
     projected = fem.tools.extrapolate(values, region, average=True)
-    assert projected.shape == (mesh.npoints, 9)
+    assert projected.shape == (mesh.npoints, 3, 3)
     assert not np.any(np.isnan(projected))
-    assert np.all([np.allclose(np.eye(3).ravel(), res) for res in projected[:-1]])
+    assert np.all([np.allclose(np.eye(3), res) for res in projected[:-1]])
 
     projected = fem.tools.extrapolate(values, region, average=True, mean=True)
-    assert projected.shape == (mesh.npoints, 9)
+    assert projected.shape == (mesh.npoints, 3, 3)
     assert not np.any(np.isnan(projected))
-    assert np.all([np.allclose(np.eye(3).ravel(), res) for res in projected[:-1]])
+    assert np.all([np.allclose(np.eye(3), res) for res in projected[:-1]])
 
     # rectangle (quadratic triangle)
     mesh = fem.Rectangle(n=2).add_midpoints_edges()
@@ -425,9 +419,9 @@ def test_extrapolate():
     values = field.extract()
 
     projected = fem.tools.extrapolate(values, region, average=True, mean=True)
-    assert projected.shape == (mesh.npoints, 9)
+    assert projected.shape == (mesh.npoints, 3, 3)
     assert not np.any(np.isnan(projected))
-    assert np.all([np.allclose(np.eye(3).ravel(), res) for res in projected])
+    assert np.all([np.allclose(np.eye(3), res) for res in projected])
 
     # this is wrong
     with pytest.raises(ValueError):
@@ -440,19 +434,19 @@ def test_extrapolate():
     values = field.extract()
 
     projected = fem.tools.extrapolate(values, region, average=False)
-    assert projected.shape == (mesh.cells.size, 9)
+    assert projected.shape == (mesh.cells.size, 3, 3)
     assert not np.any(np.isnan(projected))
-    assert np.all([np.allclose(np.eye(3).ravel(), res) for res in projected])
+    assert np.all([np.allclose(np.eye(3), res) for res in projected])
 
     projected = fem.tools.extrapolate(values, region, average=True)
-    assert projected.shape == (mesh.npoints, 9)
+    assert projected.shape == (mesh.npoints, 3, 3)
     assert not np.any(np.isnan(projected))
-    assert np.all([np.allclose(np.eye(3).ravel(), res) for res in projected])
+    assert np.all([np.allclose(np.eye(3), res) for res in projected])
 
     projected = fem.tools.extrapolate(values, region, average=True, mean=True)
-    assert projected.shape == (mesh.npoints, 9)
+    assert projected.shape == (mesh.npoints, 3, 3)
     assert not np.any(np.isnan(projected))
-    assert np.all([np.allclose(np.eye(3).ravel(), res) for res in projected])
+    assert np.all([np.allclose(np.eye(3), res) for res in projected])
 
     # cube (quadratic tetra)
     mesh = fem.Cube(n=2).add_midpoints_edges()
@@ -461,9 +455,9 @@ def test_extrapolate():
     values = field.extract()
 
     projected = fem.tools.extrapolate(values, region, average=True, mean=True)
-    assert projected.shape == (mesh.npoints, 9)
+    assert projected.shape == (mesh.npoints, 3, 3)
     assert not np.any(np.isnan(projected))
-    assert np.all([np.allclose(np.eye(3).ravel(), res) for res in projected])
+    assert np.all([np.allclose(np.eye(3), res) for res in projected])
 
     # this is wrong
     with pytest.raises(ValueError):


### PR DESCRIPTION
Throw errors if the (quadrature of the) region is not suitable for projection for triangle/tetra elements.

For further details see #690 