### PR TITLE
Simplify `tools.topoints(values, region)`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ All notable changes to this project will be documented in this file. The format 
 - Permute the 2- and 3-dimensional `GaussLegendre` quadrature schemes for order > 2 according to the VTK-Lagrange element formulations. That means for linear and quadratic quads and hexahedrons, the points of `GaussLegendre` are sorted according to the default VTK elements and for all higher-order elements according to the Lagrange-elements.
 - Enable default point-permutations in `RegionLagrange(permute=True)` by default.
 - Hide internal edges of higher-order cell-types in `ViewScene.plot()` by default.
+- Simplify `tools.topoints(values, region)`. Remove all other arguments. If values of single quadrature-point per cells is given, then the values are broadcasted to the number of points-per-cell. If values are provided on more quadrature points than the number of points-per-cell, then the values are trimmed. E.g., this is required for `QuadraticHexahedron` with 20 points and 27 quadrature-points.
 
 ### Fixed
 - Fix mesh-expansion with one layer `mesh.expand(n=1)`. This expands the dimension of the points-array.

--- a/src/felupe/field/_container.py
+++ b/src/felupe/field/_container.py
@@ -184,7 +184,11 @@ class FieldContainer:
         """
 
         return ViewField(
-            self, point_data=point_data, cell_data=cell_data, cell_type=cell_type, project=project
+            self,
+            point_data=point_data,
+            cell_data=cell_data,
+            cell_type=cell_type,
+            project=project,
         )
 
     def plot(self, *args, project=None, **kwargs):

--- a/src/felupe/tools/_plot.py
+++ b/src/felupe/tools/_plot.py
@@ -451,7 +451,7 @@ class ViewField(ViewMesh):
         point_data_from_field = {}
         cell_data_from_field = {}
 
-        if not callable(project):
+        if project is None:
             cell_data_from_field = {
                 "Deformation Gradient": deformation_gradient(field).mean(-2).T,
                 "Logarithmic Strain": strain(field, tensor=True, asvoigt=True)
@@ -461,7 +461,7 @@ class ViewField(ViewMesh):
                 .mean(-2)[::-1]
                 .T,
             }
-        elif project is None:
+        elif callable(project):
             point_data_from_field = {
                 "Deformation Gradient": project(
                     deformation_gradient(field), field.region
@@ -559,7 +559,7 @@ class ViewSolid(ViewField):
             stress = stress_from_field[stress_type.lower()](field)
             stress_label = f"{stress_type.title()} Stress"
 
-            if not callable(project):
+            if project is None:
                 cell_data_from_solid[stress_label] = tovoigt(stress.mean(-2)).T
                 cell_data_from_solid[f"Principal Values of {stress_label}"] = (
                     eigvalsh(stress).mean(-2)[::-1].T
@@ -568,7 +568,7 @@ class ViewSolid(ViewField):
                     equivalent_von_mises(stress).mean(-2).T
                 )
 
-            elif project is None:
+            elif callable(project):
                 point_data_from_solid[stress_label] = project(
                     tovoigt(stress), solid.field.region
                 )

--- a/src/felupe/tools/_plot.py
+++ b/src/felupe/tools/_plot.py
@@ -446,7 +446,7 @@ class ViewField(ViewMesh):
     """
 
     def __init__(
-        self, field, point_data=None, cell_data=None, cell_type=None, project=False
+        self, field, point_data=None, cell_data=None, cell_type=None, project=None
     ):
         point_data_from_field = {}
         cell_data_from_field = {}
@@ -461,7 +461,7 @@ class ViewField(ViewMesh):
                 .mean(-2)[::-1]
                 .T,
             }
-        else:
+        elif project is None:
             point_data_from_field = {
                 "Deformation Gradient": project(
                     deformation_gradient(field), field.region
@@ -473,6 +473,8 @@ class ViewField(ViewMesh):
                     strain(field, tensor=False)[::-1], field.region
                 ),
             }
+        else:
+            raise TypeError("The project-argument must be callable or None.")
 
         point_data_from_field["Displacement"] = displacement(field)
 
@@ -566,7 +568,7 @@ class ViewSolid(ViewField):
                     equivalent_von_mises(stress).mean(-2).T
                 )
 
-            else:
+            elif project is None:
                 point_data_from_solid[stress_label] = project(
                     tovoigt(stress), solid.field.region
                 )
@@ -576,6 +578,8 @@ class ViewSolid(ViewField):
                 point_data_from_solid[f"Equivalent of {stress_label}"] = project(
                     equivalent_von_mises(stress), solid.field.region
                 )
+            else:
+                raise TypeError("The project-argument must be callable or None.")
 
         super().__init__(
             field=field,

--- a/src/felupe/tools/_save.py
+++ b/src/felupe/tools/_save.py
@@ -95,17 +95,17 @@ def save(
         sp = np.sort(eigvalsh(s), axis=0)
 
         # shift stresses to points and average nodal values
-        cauchy = topoints(s, region=region, sym=True)
-        cauchyprinc = [topoints(sp_i, region=region, mode="scalar") for sp_i in sp]
+        cauchy = topoints(s, region=region)
+        cauchyprinc = topoints(sp, region=region)
 
         point_data["Cauchy Stress"] = cauchy
 
-        point_data["Cauchy Stress (Max. Principal)"] = cauchyprinc[2]
-        point_data["Cauchy Stress (Int. Principal)"] = cauchyprinc[1]
-        point_data["Cauchy Stress (Min. Principal)"] = cauchyprinc[0]
+        point_data["Cauchy Stress (Max. Principal)"] = cauchyprinc[:, 2]
+        point_data["Cauchy Stress (Int. Principal)"] = cauchyprinc[:, 1]
+        point_data["Cauchy Stress (Min. Principal)"] = cauchyprinc[:, 0]
 
         point_data["Cauchy Stress (Max. Principal Shear)"] = (
-            cauchyprinc[2] - cauchyprinc[0]
+            cauchyprinc[:, 2] - cauchyprinc[:, 0]
         )
 
     import meshio

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -25,6 +25,8 @@ along with Felupe.  If not, see <http://www.gnu.org/licenses/>.
 
 """
 
+import pytest
+
 import felupe as fem
 
 
@@ -162,6 +164,10 @@ def test_mesh():
 def test_model():
     try:
         mesh, field, solid = pre(n=3)
+        with pytest.raises(TypeError):
+            fem.ViewField(field, project=True)
+        with pytest.raises(TypeError):
+            fem.View(field, solid=solid, project=True)
         view = fem.View(field, solid=solid, project=fem.project)
         plotter = view.plot(
             "Equivalent of Cauchy Stress",

--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -100,7 +100,7 @@ def test_readme():
     s = dot(PK1, transpose(F)) / det(F)
 
     # stress shifted and averaged to mesh-points
-    cauchy_shifted = fem.topoints(s, region, sym=True, mode="tensor")
+    cauchy_shifted = fem.topoints(fem.math.tovoigt(s), region)
 
     # stress projected and averaged to mesh-points
     cauchy_projected = fem.project(s, region)

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -383,6 +383,26 @@ def test_project():
         projected = fem.project(values, region, average=True)
 
 
+def test_topoints():
+    mesh = fem.Rectangle(n=2).triangulate()
+    region = fem.RegionTriangle(mesh)
+    field = fem.FieldAxisymmetric(region, dim=2)
+    values = field.extract()
+
+    # single quadrature-point values
+    data = fem.topoints(values, region)
+    assert data.shape == (mesh.npoints, 3, 3)
+
+    mesh = fem.Rectangle(n=2).convert(2, 1)
+    region = fem.RegionQuadraticQuad(mesh)
+    field = fem.FieldAxisymmetric(region, dim=2)
+    values = field.extract()
+
+    # trim values array to number of points-per-cell
+    data = fem.topoints(values, region)
+    assert data.shape == (mesh.npoints, 3, 3)
+
+
 def test_extrapolate():
     # rectangle (triangle)
     mesh = fem.Rectangle(n=2)
@@ -468,4 +488,5 @@ if __name__ == "__main__":
     test_newton_linearelastic()
     test_newton_body()
     test_project()
+    test_topoints()
     test_extrapolate()

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -92,19 +92,13 @@ def test_solve():
     cauchy = fem.tools.project(fem.math.tovoigt(s), region=r, mean=True)
     assert cauchy.shape == (r.mesh.npoints, 6)
 
-    cauchy = fem.tools.topoints(s, region=r, sym=False)
-    assert cauchy.shape == (r.mesh.npoints, 9)
+    cauchy = fem.tools.topoints(s, region=r)
+    assert cauchy.shape == (r.mesh.npoints, 3, 3)
 
-    cauchy = fem.tools.topoints(s, region=r, sym=True)
-    assert cauchy.shape == (r.mesh.npoints, 6)
+    cauchy = fem.tools.topoints(s[:2, :2], region=r)
+    assert cauchy.shape == (r.mesh.npoints, 2, 2)
 
-    cauchy = fem.tools.topoints(s[:2, :2], region=r, sym=True)
-    assert cauchy.shape == (r.mesh.npoints, 3)
-
-    cauchy = fem.tools.topoints(s[:2, :2], region=r, sym=False)
-    assert cauchy.shape == (r.mesh.npoints, 4)
-
-    cauchy = fem.tools.topoints(s[0, 0], region=r, mode="scalar")
+    cauchy = fem.tools.topoints(s[0, 0], region=r)
     assert cauchy.shape == (r.mesh.npoints,)
 
 


### PR DESCRIPTION
This removes all other arguments from `topoints(values, region)`.

See also #711 