### PR TITLE
Enhance `mesh.expand(expand_dim=True)` and `mesh.revolve(expand_dim=True)` 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file. The format 
 
 ## [Unreleased]
 
+### Added
+- Add an argument to disable the (default) expansion of the points-array of a mesh in `mesh.expand(expand_dim=True)` and `mesh.revolve(expand_dim=True)`. E.g., this allows the expansion and / or revolution of a quad-mesh with points in 3d-space.
+
 ### Changed
 - Don't raise an error if the total angle of revolution is greater than 360 degree in `mesh.revolve(phi=361)`.
 

--- a/src/felupe/mesh/_mesh.py
+++ b/src/felupe/mesh/_mesh.py
@@ -625,7 +625,7 @@ class Mesh(DiscreteGeometry):
             )
         )
 
-    def expand(self, n=11, z=1, axis=-1):
+    def expand(self, n=11, z=1, axis=-1, expand_dim=True):
         """Expand a 0d-Point to a 1d-Line, a 1d-Line to a 2d-Quad or a 2d-Quad to a
         3d-Hexahedron Mesh.
 
@@ -642,6 +642,8 @@ class Mesh(DiscreteGeometry):
             Axis of expansion (default is -1).
         mask : ndarray or None, optional
             A boolean mask to select points which are rotated (default is None).
+        expand_dim : bool, optional
+            Expand the dimension of the point coordinates (default is True).
 
         Returns
         -------
@@ -669,7 +671,7 @@ class Mesh(DiscreteGeometry):
         felupe.mesh.expand : Expand a 0d-Point to a 1d-Line, a 1d-Line to a 2d-Quad or a
             2d-Quad to a 3d-Hexahedron Mesh.
         """
-        return as_mesh(expand(self, n=n, z=z, axis=axis))
+        return as_mesh(expand(self, n=n, z=z, axis=axis, expand_dim=expand_dim))
 
     def rotate(self, angle_deg, axis, center=None, mask=None):
         """Rotate a Mesh.
@@ -714,7 +716,7 @@ class Mesh(DiscreteGeometry):
             rotate(self, angle_deg=angle_deg, axis=axis, center=center, mask=mask)
         )
 
-    def revolve(self, n=11, phi=180, axis=0):
+    def revolve(self, n=11, phi=180, axis=0, expand_dim=True):
         """Revolve a 2d-Quad to a 3d-Hexahedron Mesh.
 
         Parameters
@@ -726,6 +728,8 @@ class Mesh(DiscreteGeometry):
             Revolution angle in degree (default is 180).
         axis : int, optional
             Revolution axis (default is 0).
+        expand_dim : bool, optional
+            Expand the dimension of the point coordinates (default is True).
 
         Returns
         -------
@@ -752,7 +756,7 @@ class Mesh(DiscreteGeometry):
         --------
         felupe.mesh.revolve : Revolve a 2d-Quad to a 3d-Hexahedron Mesh.
         """
-        return as_mesh(revolve(self, n=n, phi=phi, axis=axis))
+        return as_mesh(revolve(self, n=n, phi=phi, axis=axis, expand_dim=expand_dim))
 
     def merge_duplicate_points(self, decimals=None):
         """Merge duplicate points and update cells of a Mesh.


### PR DESCRIPTION
This allows to generate meshes like

```python
import felupe as fem
import numpy as np
import pypardiso

R = 50
r = 10
N = 3.75
L = 200

details = 4
sections = 80

phi = np.rad2deg(np.arctan(L / (2 * R * np.pi * N)))
area = fem.Circle(n=details, centerpoint=(0, R), radius=r).expand(0).rotate(phi, axis=1)
mesh = area.revolve(int(sections * N), 360 * N, axis=0, expand_dim=False)
p = mesh.points.reshape(int(sections * N), area.npoints, -1)
p[..., 0] += np.linspace(0, L, int(sections * N)).reshape(-1, 1)
mesh.points[:] = p.reshape(*mesh.points.shape)
mesh.update(
    points=np.vstack(
        [mesh.points, [[mesh.x.min() - 1e-1, 0, 0], [mesh.x.max() + 1e-1, 0, 0]]]
    )
)
mesh = mesh.rotate(-90, axis=1)
```

![image](https://github.com/adtzlr/felupe/assets/5793153/688783a3-c7a6-4bbf-8dc0-90a715372df4)