### PR TITLE
Add `MultiPointContact.plot(**kwargs)` method

### DIFF
--- a/examples/ex06_rubber-metal-spring.py
+++ b/examples/ex06_rubber-metal-spring.py
@@ -116,9 +116,13 @@ job.evaluate(
     point_data={"Logarithmic Strain (Max. Principal)": log_strain},
     tol=1e-1,
 )
-field.view(
+view = field.view(
     point_data={"Logarithmic Strain (Max. Principal)": log_strain(field)},
-).plot("Logarithmic Strain (Max. Principal)").show()
+)
+plotter = view.plot("Logarithmic Strain (Max. Principal)")
+plotter = top.plot(plotter=plotter, offset=1e-1)
+plotter = bottom.plot(plotter=plotter, offset=-1e-1)
+plotter.show()
 
 # %%
 # The axial-compressive and lateral-shear force-displacement curves are obtained from

--- a/src/felupe/mechanics/_multipoint.py
+++ b/src/felupe/mechanics/_multipoint.py
@@ -93,7 +93,15 @@ class MultiPointContact:
         self.results = Results(stress=False, elasticity=False)
         self.assemble = Assemble(vector=self._vector, matrix=self._matrix)
 
-    def plot(self, plotter=None, color="lightgrey", **kwargs):
+    def plot(
+        self,
+        plotter=None,
+        offset=0,
+        show_edges=True,
+        color="black",
+        opacity=0.5,
+        **kwargs
+    ):
         import pyvista as pv
 
         if plotter is None:
@@ -101,13 +109,13 @@ class MultiPointContact:
 
         # get edge lengths of deformed enclosing box
         x = self.mesh.points + self.field[0].values
-        edges = np.diag((x.max(axis=0) - x.min(axis=0)))
+        edges = np.diag((x.max(axis=0) - x.min(axis=0))) + x.min(axis=0)
 
         # plot a line or a rectangle for each active contact plane
         for ax in self.axes:
             # fill the point values of the normal axis with the centerpoint values
             points = edges.copy()
-            points[:, ax] = x[self.centerpoint, ax]
+            points[:, ax] = x[self.centerpoint, ax] + offset
 
             # scale the line or rectangle at the origin
             origin = points.mean(axis=0)
@@ -115,10 +123,14 @@ class MultiPointContact:
 
             # plot a line or a rectangle
             if len(points) == 3:
-                plotter.add_mesh(pv.Rectangle(points), **kwargs)
+                plotter.add_mesh(
+                    pv.Rectangle(points), color=color, opacity=opacity, **kwargs
+                )
             else:
                 points = np.pad(points, ((0, 0), (0, 3 - points.shape[1])))
-                plotter.add_mesh(pv.Line(*points), color=color, **kwargs)
+                plotter.add_mesh(
+                    pv.Line(*points), color=color, opacity=opacity, **kwargs
+                )
 
         return plotter
 

--- a/tests/test_mpc.py
+++ b/tests/test_mpc.py
@@ -237,7 +237,20 @@ def test_mpc_isolated():
     )
 
 
+def test_mpc_plot_2d():
+    mesh = fem.Rectangle(n=3)
+    field = fem.FieldContainer([fem.FieldPlaneStrain(fem.RegionQuad(mesh), dim=2)])
+    plane = fem.MultiPointContact(field, [0, 1], -1, skip=(0, 1))
+
+    try:
+        plotter = mesh.plot(off_screen=True)
+        plane.plot(plotter=plotter, line_width=8)
+    except ModuleNotFoundError:
+        pass
+
+
 if __name__ == "__main__":
     test_mpc()
     test_mpc_mixed()
     test_mpc_isolated()
+    test_mpc_plot_2d()

--- a/tests/test_mpc.py
+++ b/tests/test_mpc.py
@@ -100,6 +100,11 @@ def pre_mpc_mixed(point, values):
     RBE2 = fem.MultiPointConstraint(fields, points=mpc, centerpoint=cpoint)
     CONT = fem.MultiPointContact(fields, points=mpc, centerpoint=cpoint)
 
+    try:
+        CONT.plot()
+    except ModuleNotFoundError:
+        pass
+
     for f in [None, fields]:
         K_RBE2 = RBE2.assemble.matrix(f)
         r_RBE2 = RBE2.assemble.vector(f)


### PR DESCRIPTION
where the keyword-arguments are passed to the PyVista Line/Rectangle. By default, the contact plane(s) are plotted as black-transparent rectangles at an optional offset. This offset avoids the flickering of the next cells.