### PR TITLE
Change default `verbose=None` in `Job.evaluate()` and `newtonrhapson()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file. The format 
 
 ## [Unreleased]
 
+### Changed
+- Set the default verbosity level to None in `newtonrhapson(verbose=None)` and `Job.evaluate(verbose=None)`. If None, this defaults to True (as before) but evaluates the environmental variable `FELUPE_VERBOSE` if present with `FELUPE_VERBOSE == "true"`.
+
 ## [8.3.0] - 2024-04-02
 
 ### Added

--- a/docs/tutorial/examples/README.rst
+++ b/docs/tutorial/examples/README.rst
@@ -3,5 +3,4 @@
 Tutorials
 =========
 
-This section is all about learning. Each tutorial focusses on a some lessons to learn
-with straightforward code blocks.
+This section is all about learning. Each tutorial focusses on some lessons to learn.

--- a/docs/tutorial/examples/extut01_getting_started.py
+++ b/docs/tutorial/examples/extut01_getting_started.py
@@ -50,8 +50,8 @@ solid = fem.SolidBody(umat=umat, field=field)
 
 # %%
 # The problem is solved by an iterative :func:`Newton-Rhapson <felupe.newtonrhapson>`
-# procedure.
-res = fem.newtonrhapson(items=[solid], **loadcase)
+# procedure. A verbosity level of 2 enables a detailed text-based logging.
+res = fem.newtonrhapson(items=[solid], verbose=2, **loadcase)
 
 # %%
 # Results may be viewed in an interactive window.

--- a/docs/tutorial/examples/extut02_job.py
+++ b/docs/tutorial/examples/extut02_job.py
@@ -43,6 +43,6 @@ uniaxial = fem.Step(
 # This step is now added to a **Job**. The results are exported after each completed and
 # successful substep as a time-series XDMF-file.
 job = fem.Job(steps=[uniaxial])
-job.evaluate(filename="result.xdmf")
+job.evaluate(filename="result.xdmf", verbose=True)
 
 field.plot("Principal Values of Logarithmic Strain").show()

--- a/docs/tutorial/examples/extut03_building_blocks.py
+++ b/docs/tutorial/examples/extut03_building_blocks.py
@@ -278,9 +278,10 @@ for iteration in range(8):
 # %%
 # By alternative, one may also use the :func:`Newton-Rhapson <felupe.newtonrhapson>`
 # function of FElupe.
+field[0].fill(0)
 solid = fem.SolidBody(umat, field)
 loadcase = {"dof1": dof1, "dof0": dof0, "ext0": ext0}
-res = fem.newtonrhapson(items=[solid], **loadcase)
+res = fem.newtonrhapson(items=[solid], verbose=2, tol=1e-12, **loadcase)
 field = res.x
 
 

--- a/examples/ex01_beam.py
+++ b/examples/ex01_beam.py
@@ -51,9 +51,9 @@ step = fem.Step(items=[solid, gravity], boundaries=boundaries)
 job = fem.Job(steps=[step]).evaluate()
 
 # %%
-# The magnitude of the displacement field are plotted on a 100x scaled deformed
+# The magnitude of the displacement field are plotted on a 300x scaled deformed
 # configuration.
-field.plot("Displacement", component=None, factor=100).show()
+field.plot("Displacement", component=None, factor=300).show()
 
 # %%
 # References

--- a/src/felupe/mechanics/_job.py
+++ b/src/felupe/mechanics/_job.py
@@ -146,7 +146,7 @@ class Job:
         cell_data=None,
         point_data_default=True,
         cell_data_default=True,
-        verbose=True,
+        verbose=None,
         parallel=False,
         **kwargs,
     ):
@@ -174,13 +174,13 @@ class Job:
             Flag to write default cell-data to the XDMF result file. This includes
             ``"Principal Values of Logarithmic Strain"``, ``"Logarithmic Strain"`` and
             ``"Deformation Gradient"``. Default is True.
-        verbose : bool or int, optional
+        verbose : bool or int or None, optional
             Verbosity level to control how messages are printed during evaluation. If
             1 or True and ``tqdm`` is installed, a progress bar is shown. If ``tqdm`` is
             missing or verbose is 2, more detailed text-based messages are printed.
-            Default is True. If the environmental variable FELUPE_VERBOSE is set and
-            its value is ``false``, then this argument is ignored and logging is turned
-            off.
+            Default is None. If None, verbosity is set to True. If None and the
+            environmental variable FELUPE_VERBOSE is set and its value is not ``true``,
+            then logging is turned off.
         parallel : bool, optional
             Flag to use a threaded version of :func:`numpy.einsum` during assembly.
             Requires ``einsumt``. This may add additional overhead to small-sized
@@ -211,11 +211,12 @@ class Job:
         tools.NewtonResult : A data class which represents the result found by
             Newton's method.
         """
-        VERBOSE = os.environ.get("FELUPE_VERBOSE")
-        if VERBOSE is None:
-            verbose = verbose
-        else:
-            verbose = VERBOSE == "true"
+        if verbose is None:
+            FELUPE_VERBOSE = os.environ.get("FELUPE_VERBOSE")
+            if FELUPE_VERBOSE is None:
+                verbose = True
+            else:
+                verbose = FELUPE_VERBOSE == "true"
 
         if verbose:
             try:

--- a/src/felupe/tools/_newton.py
+++ b/src/felupe/tools/_newton.py
@@ -214,7 +214,7 @@ def newtonrhapson(
     dof0=None,
     ext0=None,
     solver=spsolve,
-    verbose=True,
+    verbose=None,
 ):
     r"""Find a root of a real function using the Newton-Raphson method.
 
@@ -257,7 +257,7 @@ def newtonrhapson(
     solver : callable, optional
         A sparse or dense solver (default is :func:`scipy.sparse.linalg.spsolve`). For a
         more performant alternative install PyPardiso and use :func:`pypardiso.spsolve`.
-    verbose : bool or int, optional
+    verbose : bool or int or None, optional
         Verbosity level to control how messages are printed during evaluation. If
         1 or True and ``tqdm`` is installed, a progress bar is shown. If ``tqdm`` is
         missing or verbose is 2, more detailed text-based messages are printed.

--- a/src/felupe/tools/_newton.py
+++ b/src/felupe/tools/_newton.py
@@ -258,10 +258,12 @@ def newtonrhapson(
         A sparse or dense solver (default is :func:`scipy.sparse.linalg.spsolve`). For a
         more performant alternative install PyPardiso and use :func:`pypardiso.spsolve`.
     verbose : bool or int, optional
-        Verbosity level: False or 0 for no logging, True or 1 for a progress bar and
-        2 for a text-based logging output (default is True).If the environmental
-        variable FELUPE_VERBOSE is set and its value is ``false``, then this argument is
-        ignored and logging is turned off.
+        Verbosity level to control how messages are printed during evaluation. If
+        1 or True and ``tqdm`` is installed, a progress bar is shown. If ``tqdm`` is
+        missing or verbose is 2, more detailed text-based messages are printed.
+        Default is None. If None, verbosity is set to True. If None and the
+        environmental variable FELUPE_VERBOSE is set and its value is not ``true``,
+        then logging is turned off.
 
     Returns
     -------
@@ -345,11 +347,12 @@ def newtonrhapson(
     2.7482611016095555e-15
 
     """
-    VERBOSE = os.environ.get("FELUPE_VERBOSE")
-    if VERBOSE is None:
-        verbose = verbose
-    else:
-        verbose = VERBOSE == "true"
+    if verbose is None:
+        FELUPE_VERBOSE = os.environ.get("FELUPE_VERBOSE")
+        if FELUPE_VERBOSE is None:
+            verbose = True
+        else:
+            verbose = FELUPE_VERBOSE == "true"
 
     if verbose:
         runtimes = [perf_counter()]

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -4,6 +4,7 @@ Created on Sun Aug 21 00:27:38 2022
 
 @author: z0039mte
 """
+import os
 
 import numpy as np
 import pytest
@@ -92,6 +93,8 @@ def test_curve():
     with pytest.raises(ValueError):
         curve.plot()
 
+    os.environ["FELUPE_VERBOSE"] = "true"
+
     curve.evaluate()
     curve.plot(xaxis=0, yaxis=0)
     curve.plot(x=np.zeros((10, 2)), y=np.ones((10, 2)), xaxis=0, yaxis=0)
@@ -99,6 +102,8 @@ def test_curve():
     stretch = 1 + np.array(curve.x)[:, 0]
     area = 1**2 * np.pi
     force = (stretch - 1 / stretch**2) * area
+
+    os.environ.pop("FELUPE_VERBOSE")
 
     assert np.allclose(np.array(curve.y)[:, 0], force, rtol=0.01)
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -24,6 +24,7 @@ You should have received a copy of the GNU General Public License
 along with Felupe.  If not, see <http://www.gnu.org/licenses/>.
 
 """
+import os
 
 import numpy as np
 import pytest
@@ -157,9 +158,13 @@ def test_newton_simple():
 
     x0 = np.array([3.1])
 
+    os.environ["FELUPE_VERBOSE"] = "true"
+
     res = fem.tools.newtonrhapson(
         x0, fun, jac, solve=np.linalg.solve, maxiter=32, verbose=True
     )
+
+    os.environ.pop("FELUPE_VERBOSE")
 
     assert abs(res.fun) < 1e-6
     assert np.isclose(res.x, 3, rtol=1e-2)

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -160,9 +160,7 @@ def test_newton_simple():
 
     os.environ["FELUPE_VERBOSE"] = "true"
 
-    res = fem.tools.newtonrhapson(
-        x0, fun, jac, solve=np.linalg.solve, maxiter=32, verbose=True
-    )
+    res = fem.tools.newtonrhapson(x0, fun, jac, solve=np.linalg.solve, maxiter=32)
 
     os.environ.pop("FELUPE_VERBOSE")
 


### PR DESCRIPTION
this will show progress bars for `verbose=True` e.g. in the docs when the global verbosity level is deactivated by `FELUPE_VERBOSE = "false"`.

closes #735 