### PR TITLE
Add `ConstitutiveMaterial.optimize()`

### DIFF
--- a/src/felupe/constitution/_base.py
+++ b/src/felupe/constitution/_base.py
@@ -131,7 +131,34 @@ class ConstitutiveMaterial:
 
         return ax
 
-    def optimize(self, ux=None, bx=None, ps=None, incompressible=False, **kwargs):
+    def optimize(self, ux=None, ps=None, bx=None, incompressible=False, **kwargs):
+        """Optimize the material parameters by a least-squares fit on experimental
+        stretch-stress data.
+
+        Parameters
+        ----------
+        ux : array of shape (2, n) or None, optional
+            Experimental uniaxial stretch and force-per-undeformed-area data (default is
+            None).
+        ps : array of shape (2, n) or None, optional
+            Experimental planar-shear stretch and force-per-undeformed-area data
+            (default is None).
+        bx : array of shape (2, n) or None, optional
+            Experimental biaxial stretch and force-per-undeformed-area data (default is
+            None).
+        incompressible : bool, optional
+            A flag to enforce incompressible deformations (default is False).
+        **kwargs : dict, optional
+            Optional keyword arguments are passed to
+            :func:`scipy.optimize.least_squares`.
+
+        Returns
+        -------
+        ConstitutiveMaterial
+            A copy of the constitutive material with the optimized material parameters.
+        scipy.optimize.OptimizeResult
+            Represents the optimization result.
+        """
         from scipy.optimize import least_squares
 
         experiment = [(None, None) if lc is None else lc for lc in [ux, bx, ps]]
@@ -154,7 +181,7 @@ class ConstitutiveMaterial:
             return np.concatenate(residuals)
 
         res = least_squares(fun=fun, x0=list(self.kwargs.values()), **kwargs)
-        
+
         out = copy(self)
         for key, value in zip(self.kwargs.keys(), res.x):
             out.kwargs[key] = value

--- a/src/felupe/constitution/_view.py
+++ b/src/felupe/constitution/_view.py
@@ -93,7 +93,7 @@ class PlotMaterial:
         if show_kwargs:
             if hasattr(self.umat, "kwargs"):
                 parameters = ", ".join(
-                    [f"{key}={value}" for key, value in self.umat.kwargs.items()]
+                    [f"{key}={value:.3g}" for key, value in self.umat.kwargs.items()]
                 )
                 ax.set_title(parameters, fontdict=dict(fontsize="small"), wrap=True)
 


### PR DESCRIPTION
### Example

```python
import felupe as fem
import numpy as np

ux = np.loadtxt("treloar.csv", skiprows=1, delimiter=",")

umat = fem.Hyperelastic(fem.yeoh, C10=1, C20=0, C30=0)
umat_new, res = umat.optimize(ux=ux.T, incompressible=True)
ax = umat_new.plot(incompressible=True, ux=ux.T[0], bx=None, ps=None)
ax.plot(*ux.T, "C0x")
```

with 

```csv
Stretch,Stress
1.0,0
1.4273,0.2856
1.6163,0.3833
1.882,0.4658
2.1596,0.5935
2.4383,0.6609
3.0585,0.8409
3.6153,1.006
4.1206,1.2087
4.852,1.5617
5.4053,1.915
5.7925,2.2985
6.1803,2.6519
6.4787,3.0205
6.6627,3.3816
6.936,3.7351
7.133,4.0812
7.1769,4.4501
7.2712,4.8414
7.4425,5.2026
7.512,5.5639
```