### PR TITLE
Fix the Alexander model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file. The format 
 ## [Unreleased]
 
 ### Added
-- Add the isotropic-hyperelastic `alexander(C1, C2, C2, gamma)` model.
+- Add the isotropic-hyperelastic `alexander(C1, C2, C2, gamma, k)` model.
 
 ### Changed
 - Recfactor the `constitution` module.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ All notable changes to this project will be documented in this file. The format 
 ### Changed
 - Recfactor the `constitution` module.
 
+### Fixed
+- Fix plotting the keyword-arguments of a constitutive material `ConstitutiveMaterial.plot(show_kwargs=True)`. For list-based material parameters of length 1, the brackets aren't shown now. E.g., this affects optimized material parameters.
+
 ## [8.5.1] - 2024-05-08
 
 ### Fixed

--- a/src/felupe/constitution/_view.py
+++ b/src/felupe/constitution/_view.py
@@ -95,7 +95,9 @@ class PlotMaterial:
                 p = []
                 for key, value in self.umat.kwargs.items():
                     if hasattr(value, "__len__"):
-                        val = "[" + " ".join([f"{v:.3g}" for v in value]) + "]"
+                        val = " ".join([f"{v:.3g}" for v in value])
+                        if len(value) > 1:
+                            val = f"[{val}]"
                     else:
                         val = f"{value:.3g}"
                     p.append(f"{key}={val}")

--- a/src/felupe/constitution/hyperelasticity/models/__init__.py
+++ b/src/felupe/constitution/hyperelasticity/models/__init__.py
@@ -27,7 +27,7 @@ __all__ = [
 ]
 
 # default (stable) material parameters
-alexander.kwargs = dict(C1=0, C2=0, C3=0, gamma=100)
+alexander.kwargs = dict(C1=0, C2=0, C3=0, gamma=100, k=0)
 arruda_boyce.kwargs = dict(C1=0, limit=100)
 extended_tube.kwargs = dict(Gc=0, Ge=0, beta=1, delta=0)
 mooney_rivlin.kwargs = dict(C10=0, C01=0)

--- a/tests/test_constitution.py
+++ b/tests/test_constitution.py
@@ -332,7 +332,7 @@ def test_umat_hyperelastic():
         ),
         (
             fem.constitution.alexander,
-            dict(C1=0.117, C2=0.137, C3=0.00690, gamma=0.735),
+            dict(C1=0.117, C2=0.137, C3=0.00690, gamma=0.735, k=0.00015),
             True,
         ),
     ]:
@@ -550,6 +550,7 @@ def test_optimize():
         fem.ogden,
         fem.third_order_deformation,
         fem.extended_tube,
+        fem.alexander,
     ]:
         umat = fem.Hyperelastic(model)
         umat_new, res = umat.optimize(ux=[stretches, stresses], incompressible=True)


### PR DESCRIPTION
fixes #760 

This also resolves a minor issue when plotting the keyword-arguments of a constitutive material. For list-based material parameters of length 1, the brackets aren't shown.