### PR TITLE
Add `ConstitutiveMaterial.optimize(relative=False)`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file. The format 
 ### Added
 - Add the isotropic-hyperelastic `alexander(C1, C2, C2, gamma, k)` material model formulation to be used in `Hyperelastic()`.
 - Add the pseudo-elastic `ogden_roxburgh(r, m, beta, material, **kwargs)` material model formulation to be used in `Hyperelastic()`.
+- Add an optional relative-residuals argument to `ConstitutiveMaterial.optimize(relative=False)`.
 
 ### Changed
 - Recfactor the `constitution` module.

--- a/tests/test_constitution.py
+++ b/tests/test_constitution.py
@@ -584,6 +584,18 @@ def test_optimize():
         ax = umat_new.plot(incompressible=True, ux=ux, bx=None, ps=None)
         ax.plot(stretches, stresses, "C0x")
 
+    for model in [
+        fem.neo_hooke,
+    ]:
+        umat = fem.Hyperelastic(model)
+        umat_new, res = umat.optimize(
+            ux=[stretches, stresses], incompressible=True, relative=True
+        )
+
+        ux = np.linspace(stretches.min(), stretches.max(), num=200)
+        ax = umat_new.plot(incompressible=True, ux=ux, bx=None, ps=None)
+        ax.plot(stretches, stresses, "C0x")
+
 
 if __name__ == "__main__":
     test_nh()


### PR DESCRIPTION
to optimize the material parameters with relative residuals instead of absolute residuals.

closes #765 