### PR TITLE
Rebase `morph_representative_directions()` as Total-Lagrange material for `MaterialAD`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ All notable changes to this project will be documented in this file. The format 
 - Add the pseudo-elastic `ogden_roxburgh(r, m, beta, material, **kwargs)` material model formulation to be used in `Hyperelastic()`.
 - Add an optional relative-residuals argument to `ConstitutiveMaterial.optimize(relative=False)`.
 - Add a class-decorator `constitutive_material(Msterial, name=None)`.
-- Add the MORPH material formulation implemented by the concept of representative directions `morph_representative_directions(p)` to be used in `Hyperelastic()`.
-- Add the MORPH material formulation `morph(p)` to be used in `Hyperelastic()`.
+- Add the Total-Lagrange MORPH material formulation implemented by the concept of representative directions `morph_representative_directions(p)` to be used in `MaterialAD()`.
+- Add the Total-Lagrange (original) MORPH material formulation `morph(p)` to be used in `Hyperelastic()`.
 - Add decorators `@total_lagrange` and `@updated_lagrange` for Total / Updated Lagrange material formulations to be used in `MaterialAD`.
 
 ### Changed

--- a/docs/felupe/constitution/hyperelasticity.rst
+++ b/docs/felupe/constitution/hyperelasticity.rst
@@ -23,7 +23,7 @@ This page contains hyperelastic material model formulations with automatic diffe
    finite_strain_viscoelastic
    miehe_goektepe_lulei
    mooney_rivlin
-   morph_representative_directions
+   constitution.hyperelasticity.models.morph_representative_directions
    neo_hooke
    ogden
    ogden_roxburgh

--- a/docs/felupe/constitution/lagrange.rst
+++ b/docs/felupe/constitution/lagrange.rst
@@ -20,6 +20,7 @@ This page contains Total- and Updated-Lagrange material formulations with automa
 .. autosummary::
 
    morph
+   morph_representative_directions
 
 **Detailed API Reference**
 
@@ -29,6 +30,8 @@ This page contains Total- and Updated-Lagrange material formulations with automa
    :inherited-members:
 
 .. autofunction:: felupe.morph
+
+.. autofunction:: felupe.morph_representative_directions
 
 .. autofunction:: felupe.total_lagrange
 

--- a/examples/ex13_morph-rubber-wheel.py
+++ b/examples/ex13_morph-rubber-wheel.py
@@ -14,7 +14,9 @@ is used as internal state variable, see Eq. :eq:`morph-state`.
     While the `MORPH <https://doi.org/10.1016/s0749-6419(02)00091-8>`_-material
     formulation captures the Mullins effect and quasi-static hysteresis effects of
     rubber mixtures very nicely, it has been observed to be unstable for medium- to
-    highly-distorted states of deformation.
+    highly-distorted states of deformation. An alternative implementation by the method
+    of `representative directions <https://nbn-resolving.org/urn:nbn:de:bsz:ch1-qucosa-114428>`_
+    provides better stability but is computationally more costly [2]_, [3]_.
 
 ..  math::
     :label: morph-state
@@ -171,6 +173,10 @@ umat = fem.MaterialAD(
 )
 
 # %%
+# .. note::
+#    The MORPH material model formulation is also available in FElupe, see
+#    :class:`~felupe.morph`.
+#
 # The force-stress curves are shown for uniaxial incompressible tension cycles.
 ux = fem.math.linsteps([1, 1.5, 1, 2, 1, 2.5, 1, 2.5], num=(10, 10, 20, 20, 30, 30, 30))
 ax = umat.plot(
@@ -266,3 +272,13 @@ solid.plot(
 #    materials and its numerical applications", International Journal of Plasticity,
 #    vol. 19, no. 7. Elsevier BV, pp. 1019–1036, Jul. 2003. doi:
 #    `10.1016/s0749-6419(02)00091-8 <https://doi.org/10.1016/s0749-6419(02)00091-8>`_.
+#
+# .. [2] M. Freund, "Verallgemeinerung eindimensionaler Materialmodelle für die
+#    Finite-Elemente-Methode", Dissertation, Technische Universität Chemnitz,
+#    Chemnitz, 2013.
+#
+# .. [3] C. Miehe, S. Göktepe and F. Lulei, "A micro-macro approach to rubber-like
+#    materials - Part I: the non-affine micro-sphere model of rubber elasticity",
+#    Journal of the Mechanics and Physics of Solids, vol. 52, no. 11. Elsevier BV, pp.
+#    2617–2660, Nov. 2004. doi:
+#    `10.1016/j.jmps.2004.03.011 <https://doi.org/10.1016/j.jmps.2004.03.011>`_.

--- a/src/felupe/constitution/__init__.py
+++ b/src/felupe/constitution/__init__.py
@@ -28,7 +28,7 @@ from .hyperelasticity.models import (
     yeoh,
 )
 from .lagrange import MaterialAD, total_lagrange, updated_lagrange
-from .lagrange.models import morph
+from .lagrange.models import morph, morph_representative_directions
 from .linear_elasticity import (
     LinearElastic,
     LinearElasticLargeStrain,

--- a/src/felupe/constitution/hyperelasticity/models/__init__.py
+++ b/src/felupe/constitution/hyperelasticity/models/__init__.py
@@ -16,7 +16,7 @@ from ._finite_strain_viscoelastic import finite_strain_viscoelastic
 from ._helpers import isochoric_volumetric_split
 from ._miehe_goektepe_lulei import miehe_goektepe_lulei
 from ._mooney_rivlin import mooney_rivlin
-from ._morph import morph_representative_directions
+from ._morph_representative_directions import morph_representative_directions
 from ._neo_hooke import neo_hooke
 from ._ogden import ogden
 from ._ogden_roxburgh import ogden_roxburgh

--- a/src/felupe/constitution/hyperelasticity/models/_morph_representative_directions.py
+++ b/src/felupe/constitution/hyperelasticity/models/_morph_representative_directions.py
@@ -1,0 +1,103 @@
+# -*- coding: utf-8 -*-
+"""
+This file is part of FElupe.
+
+FElupe is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+FElupe is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with FElupe.  If not, see <http://www.gnu.org/licenses/>.
+"""
+from ...lagrange.models import morph_uniaxial
+from .microsphere import affine_stretch_statevars
+
+
+def morph_representative_directions(C, statevars, p, ε=1e-8):
+    """Strain energy function of the
+    `MORPH <https://doi.org/10.1016/s0749-6419(02)00091-8>`_ model formulation [1]_,
+    implemented by the concept of
+    `representative directions <https://nbn-resolving.org/urn:nbn:de:bsz:ch1-qucosa-114428>`_
+    [2]_, [3]_.
+
+    Parameters
+    ----------
+    C : tensortrax.Tensor
+        Right Cauchy-Green deformation tensor.
+    statevars : array
+        Vector of stacked state variables (CTS, λ - 1, SA1, SA2).
+    p : list of float
+        A list which contains the 8 material parameters.
+    ε : float, optional
+        A small stabilization parameter (default is 1e-8).
+
+    Examples
+    --------
+    ..  pyvista-plot::
+        :context:
+
+        >>> import felupe as fem
+        >>>
+        >>> umat = fem.Hyperelastic(
+        ...     fem.constitution.hyperelasticity.models.morph_representative_directions,
+        ...     p=[0.011, 0.408, 0.421, 6.85, 0.0056, 5.54, 5.84, 0.117],
+        ...     nstatevars=84,
+        ... )
+        >>> ax = umat.plot(
+        ...    incompressible=True,
+        ...    ux=fem.math.linsteps(
+        ...        # [1, 2, 1, 2.75, 1, 3.5, 1, 4.2, 1, 4.8, 1, 4.8, 1],
+        ...        [1, 2.75, 1, 2.75],
+        ...        num=20,
+        ...    ),
+        ...    ps=None,
+        ...    bx=None,
+        ... )
+
+    ..  pyvista-plot::
+        :include-source: False
+        :context:
+        :force_static:
+
+        >>> import pyvista as pv
+        >>>
+        >>> fig = ax.get_figure()
+        >>> chart = pv.ChartMPL(fig)
+        >>> chart.show()
+
+    References
+    ----------
+    .. [1] D. Besdo and J. Ihlemann, "A phenomenological constitutive model for
+       rubberlike materials and its numerical applications", International Journal
+       of Plasticity, vol. 19, no. 7. Elsevier BV, pp. 1019–1036, Jul. 2003. doi:
+       `10.1016/s0749-6419(02)00091-8 <https://doi.org/10.1016/s0749-6419(02)00091-8>`_.
+
+    .. [2] M. Freund, "Verallgemeinerung eindimensionaler Materialmodelle für die
+       Finite-Elemente-Methode", Dissertation, Technische Universität Chemnitz,
+       Chemnitz, 2013.
+
+    .. [3] C. Miehe, S. Göktepe and F. Lulei, "A micro-macro approach to rubber-like
+       materials - Part I: the non-affine micro-sphere model of rubber elasticity",
+       Journal of the Mechanics and Physics of Solids, vol. 52, no. 11. Elsevier BV, pp.
+       2617–2660, Nov. 2004. doi:
+       `10.1016/j.jmps.2004.03.011 <https://doi.org/10.1016/j.jmps.2004.03.011>`_.
+
+    See Also
+    --------
+    felupe.morph : Strain energy function of the MORPH model formulation.
+    felupe.morph_representative_directions : First Piola-Kirchhoff stress tensor of the
+        MORPH model formulation, implemented by the concept of representative
+        directions.
+    """
+
+    def f(λ, statevars, **kwargs):
+        dψdλ, statevars_new = morph_uniaxial(λ, statevars, **kwargs)
+        return 5 * dψdλ.real_to_dual(λ), statevars_new
+
+    return affine_stretch_statevars(C, statevars, f=f, kwargs={"p": p, "ε": ε})

--- a/src/felupe/constitution/lagrange/models/__init__.py
+++ b/src/felupe/constitution/lagrange/models/__init__.py
@@ -7,10 +7,16 @@ Hence, all math-functions must be taken from :mod:`tensortrax.math`.
 """
 
 from ._morph import morph
+from ._morph_representative_directions import morph_representative_directions
+from ._morph_uniaxial import morph_uniaxial
 
 __all__ = [
     "morph",
+    "morph_representative_directions",
+    "morph_uniaxial",
 ]
 
 # default (stable) material parameters
 morph.kwargs = dict(p=[0, 0, 0, 0, 0, 1, 0, 0])
+morph_representative_directions.kwargs = dict(p=[0, 0, 0, 0, 0, 1, 0, 0])
+morph_uniaxial.kwargs = dict(p=[0, 0, 0, 0, 0, 1, 0, 0])

--- a/src/felupe/constitution/lagrange/models/_morph_representative_directions.py
+++ b/src/felupe/constitution/lagrange/models/_morph_representative_directions.py
@@ -15,15 +15,12 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with FElupe.  If not, see <http://www.gnu.org/licenses/>.
 """
-from tensortrax.math import abs as tensor_abs
-from tensortrax.math import array, exp, maximum, sqrt
-from tensortrax.math.special import try_stack
-
-from .microsphere import affine_stretch_statevars
+from ._morph_uniaxial import morph_uniaxial
+from .microsphere import affine_force_statevars
 
 
-def morph_representative_directions(C, statevars, p, ε=1e-8):
-    """Strain energy function of the
+def morph_representative_directions(F, statevars, p, ε=1e-8):
+    """First Piola-Kirchhoff stress tensor of the
     `MORPH <https://doi.org/10.1016/s0749-6419(02)00091-8>`_ model formulation [1]_,
     implemented by the concept of
     `representative directions <https://nbn-resolving.org/urn:nbn:de:bsz:ch1-qucosa-114428>`_
@@ -47,7 +44,7 @@ def morph_representative_directions(C, statevars, p, ε=1e-8):
 
         >>> import felupe as fem
         >>>
-        >>> umat = fem.Hyperelastic(
+        >>> umat = fem.MaterialAD(
         ...     fem.morph_representative_directions,
         ...     p=[0.011, 0.408, 0.421, 6.85, 0.0056, 5.54, 5.84, 0.117],
         ...     nstatevars=84,
@@ -96,66 +93,8 @@ def morph_representative_directions(C, statevars, p, ε=1e-8):
     felupe.morph : Strain energy function of the MORPH model formulation.
     """
 
-    def morph_uniaxial(λ, statevars, p, ε=1e-8):
-        """Return the force (per undeformed area) for a given longitudinal stretch in
-        uniaxial incompressible tension or compression for the MORPH material
-        formulation [1]_, [2]_.
+    def f(λ, statevars, **kwargs):
+        dψdλ, statevars_new = morph_uniaxial(λ, statevars, **kwargs)
+        return 5 * dψdλ, statevars_new
 
-        Parameters
-        ----------
-        λ : tensortrax.Tensor
-            Longitudinal stretch of uniaxial incompressible deformation.
-        statevars : array
-            Vector of stacked state variables (CTS, λ - 1, SA1, SA2).
-        p : list of float
-            A list which contains the 8 material parameters.
-        ε : float, optional
-            A small stabilization parameter (default is 1e-8).
-
-        References
-        ----------
-        .. [1] D. Besdo and J. Ihlemann, "A phenomenological constitutive model for
-           rubberlike materials and its numerical applications", International Journal
-           of Plasticity, vol. 19, no. 7. Elsevier BV, pp. 1019–1036, Jul. 2003. doi:
-           `10.1016/s0749-6419(02)00091-8 <https://doi.org/10.1016/s0749-6419(02)00091-8>`_.
-
-        .. [2] M. Freund, "Verallgemeinerung eindimensionaler Materialmodelle für die
-           Finite-Elemente-Methode", Dissertation, Technische Universität Chemnitz,
-           Chemnitz, 2013.
-
-        """
-        CTSn = array(statevars[:21], like=C, shape=(21,))
-        λn = array(statevars[21:42], like=C, shape=(21,)) + 1
-        SA1n = array(statevars[42:63], like=C, shape=(21,))
-        SA2n = array(statevars[63:84], like=C, shape=(21,))
-
-        CT = tensor_abs(λ**2 - 1 / λ)
-        CTS = maximum(CT, CTSn)
-
-        L1 = 2 * (λ**3 / λn - λn**2) / 3
-        L2 = (λn**2 / λ**3 - 1 / λn) / 3
-        LT = tensor_abs(L1 - L2)
-
-        sigmoid = lambda x: 1 / sqrt(1 + x**2)
-        α = p[0] + p[1] * sigmoid(p[2] * CTS)
-        β = p[3] * sigmoid(p[2] * CTS)
-        γ = p[4] * CTS * (1 - sigmoid(CTS / p[5]))
-
-        L1_LT = L1 / (ε + LT)
-        L2_LT = L2 / (ε + LT)
-        CT_CTS = CT / (ε + CTS)
-
-        SL1 = (γ * exp(p[6] * L1_LT * CT_CTS) + p[7] * L1_LT) / λ**2
-        SL2 = (γ * exp(p[6] * L2_LT * CT_CTS) + p[7] * L2_LT) * λ
-
-        SA1 = (SA1n + β * LT * SL1) / (1 + β * LT)
-        SA2 = (SA2n + β * LT * SL2) / (1 + β * LT)
-
-        dψdλ = (2 * α + SA1) * λ - (2 * α + SA2) / λ**2
-        statevars_new = try_stack([CTS, (λ - 1), SA1, SA2], fallback=statevars)
-
-        return 5 * dψdλ.real_to_dual(λ), statevars_new
-
-    return affine_stretch_statevars(
-        C, statevars, f=morph_uniaxial, kwargs={"p": p, "ε": ε}
-    )
+    return affine_force_statevars(F, statevars, f=f, kwargs={"p": p, "ε": ε})

--- a/src/felupe/constitution/lagrange/models/_morph_uniaxial.py
+++ b/src/felupe/constitution/lagrange/models/_morph_uniaxial.py
@@ -1,0 +1,81 @@
+# -*- coding: utf-8 -*-
+"""
+This file is part of FElupe.
+
+FElupe is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+FElupe is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with FElupe.  If not, see <http://www.gnu.org/licenses/>.
+"""
+from tensortrax.math import abs as tensor_abs
+from tensortrax.math import array, exp, maximum, sqrt
+from tensortrax.math.special import try_stack
+
+
+def morph_uniaxial(λ, statevars, p, ε=1e-8):
+    """Return the force (per undeformed area) for a given longitudinal stretch in
+    uniaxial incompressible tension or compression for the MORPH material
+    formulation [1]_, [2]_.
+
+    Parameters
+    ----------
+    λ : tensortrax.Tensor
+        Longitudinal stretch of uniaxial incompressible deformation.
+    statevars : array
+        Vector of stacked state variables (CTS, λ - 1, SA1, SA2).
+    p : list of float
+        A list which contains the 8 material parameters.
+    ε : float, optional
+        A small stabilization parameter (default is 1e-8).
+
+    References
+    ----------
+    .. [1] D. Besdo and J. Ihlemann, "A phenomenological constitutive model for
+       rubberlike materials and its numerical applications", International Journal
+       of Plasticity, vol. 19, no. 7. Elsevier BV, pp. 1019–1036, Jul. 2003. doi:
+       `10.1016/s0749-6419(02)00091-8 <https://doi.org/10.1016/s0749-6419(02)00091-8>`_.
+
+    .. [2] M. Freund, "Verallgemeinerung eindimensionaler Materialmodelle für die
+       Finite-Elemente-Methode", Dissertation, Technische Universität Chemnitz,
+       Chemnitz, 2013.
+
+    """
+    CTSn = array(statevars[:21], like=λ, shape=(21,))
+    λn = array(statevars[21:42], like=λ, shape=(21,)) + 1
+    SA1n = array(statevars[42:63], like=λ, shape=(21,))
+    SA2n = array(statevars[63:84], like=λ, shape=(21,))
+
+    CT = tensor_abs(λ**2 - 1 / λ)
+    CTS = maximum(CT, CTSn)
+
+    L1 = 2 * (λ**3 / λn - λn**2) / 3
+    L2 = (λn**2 / λ**3 - 1 / λn) / 3
+    LT = tensor_abs(L1 - L2)
+
+    sigmoid = lambda x: 1 / sqrt(1 + x**2)
+    α = p[0] + p[1] * sigmoid(p[2] * CTS)
+    β = p[3] * sigmoid(p[2] * CTS)
+    γ = p[4] * CTS * (1 - sigmoid(CTS / p[5]))
+
+    L1_LT = L1 / (ε + LT)
+    L2_LT = L2 / (ε + LT)
+    CT_CTS = CT / (ε + CTS)
+
+    SL1 = (γ * exp(p[6] * L1_LT * CT_CTS) + p[7] * L1_LT) / λ**2
+    SL2 = (γ * exp(p[6] * L2_LT * CT_CTS) + p[7] * L2_LT) * λ
+
+    SA1 = (SA1n + β * LT * SL1) / (1 + β * LT)
+    SA2 = (SA2n + β * LT * SL2) / (1 + β * LT)
+
+    dψdλ = (2 * α + SA1) * λ - (2 * α + SA2) / λ**2
+    statevars_new = try_stack([CTS, (λ - 1), SA1, SA2], fallback=statevars)
+
+    return dψdλ, statevars_new

--- a/src/felupe/constitution/lagrange/models/microsphere/__init__.py
+++ b/src/felupe/constitution/lagrange/models/microsphere/__init__.py
@@ -1,0 +1,5 @@
+from ._framework_affine import affine_force_statevars
+
+__all__ = [
+    "affine_force_statevars",
+]

--- a/src/felupe/constitution/lagrange/models/microsphere/_framework_affine.py
+++ b/src/felupe/constitution/lagrange/models/microsphere/_framework_affine.py
@@ -1,0 +1,26 @@
+from tensortrax.math import einsum, sqrt, trace
+from tensortrax.math.linalg import det, inv
+
+from .....quadrature import BazantOh
+from ..._total_lagrange import total_lagrange
+
+
+@total_lagrange
+def affine_force_statevars(F, statevars, f, kwargs, quadrature=BazantOh(n=21)):
+    "Micro-sphere model: Affine force (stretch) part."
+
+    r = quadrature.points
+    M = einsum("ai,aj->aij", r, r)
+    Mw = einsum("aij,a->aij", M, quadrature.weights)
+
+    # affine stretches (unimodular part)
+    J = det(F)
+    C = F.T @ F
+    λ = J ** (-1 / 3) * sqrt(einsum("ij...,aij->a...", C, M))
+
+    dψdλ, statevars_new = f(λ, statevars, **kwargs)
+    dψdE = einsum("a...,aij->ij...", dψdλ / λ, Mw)
+
+    S = J ** (-2 / 3) * (dψdE - trace(dψdE @ C) / 3 * inv(C))
+
+    return S, statevars_new

--- a/tests/test_constitution.py
+++ b/tests/test_constitution.py
@@ -310,7 +310,7 @@ def test_umat_hyperelastic_statevars():
             True,
         ),
         (
-            fem.constitution.morph_representative_directions,
+            fem.constitution.hyperelasticity.models.morph_representative_directions,
             dict(
                 p=[0.011, 0.408, 0.421, 6.85, 0.0056, 5.54, 5.84, 0.117], nstatevars=84
             ),
@@ -665,6 +665,16 @@ def test_lagrange_statevars():
     umat = fem.MaterialAD(fem.morph, p=p, nstatevars=13)
 
     statevars = np.zeros((13, 8, 1))
+    P = umat.gradient([F, statevars])
+    A4 = umat.hessian([F, statevars])
+
+    assert not np.isnan(P[0]).any()
+    assert not np.isnan(A4[0]).any()
+
+    p = [0.011, 0.408, 0.421, 6.85, 0.0056, 5.54, 5.84, 0.117]
+    umat = fem.MaterialAD(fem.morph_representative_directions, p=p, nstatevars=84)
+
+    statevars = np.zeros((84, 8, 1))
     P = umat.gradient([F, statevars])
     A4 = umat.hessian([F, statevars])
 


### PR DESCRIPTION
This enhances the performance by a more effective automatic differentiation. The old-version for `Hyperelastic` is still available in `constitution.hyperelasticity.models.morph_representative_directions()`.