### PR TITLE
Add `math.solve_nd(A, b, n=1)`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes to this project will be documented in this file. The format 
 
 ## [Unreleased]
 
+## Added
+- Add `math.solve_nd(A, b, n=1)` as a generalized function of `math.solve_2d(A, b)`.
+
+## Changed
+- Rebase `math.solve_2d(A, b)` on `math.solve_nd(A, b, n=2)`.
+
 ## Fixes
 - Reset state variables in `PlotMaterial.evaluate()` after each completed load case.
 

--- a/examples/ex18_nonlinear-viscoelasticity-newton.py
+++ b/examples/ex18_nonlinear-viscoelasticity-newton.py
@@ -10,6 +10,7 @@ internal variable are solved using Newton's method [2]_.
 
 import tensortrax as tr
 import tensortrax.math as tm
+
 import felupe as fem
 
 

--- a/src/felupe/math/__init__.py
+++ b/src/felupe/math/__init__.py
@@ -12,7 +12,7 @@ from ._field import (
     values,
 )
 from ._math import linsteps
-from ._solve import solve_2d
+from ._solve import solve_2d, solve_nd
 from ._spatial import rotation_matrix
 from ._tensor import (
     cdya,
@@ -79,4 +79,5 @@ __all__ = [
     "trace",
     "transpose",
     "solve_2d",
+    "solve_nd",
 ]


### PR DESCRIPTION
and rebase `math.solve_2d(A, b)` on `math.solve_nd(A, b, n=2)`. This function also supports batched arrays with zero dimensions (scalars).