### PR TITLE
Add `Region.astype(dtype=None)` and `Field(..., dtype=None)`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file. The format 
 
 ## [Unreleased]
 
+### Added
+- Add `Region.astype(dtype=None)` to copy and cast the region arrays to a specified type.
+- Add `Field.extract(dtype=None)` to cast the extracted field gradient/interpolated values to a specified type.
+
 ## [8.8.0] - 2024-06-16
 
 ### Added

--- a/docs/howto/mixed.rst
+++ b/docs/howto/mixed.rst
@@ -33,7 +33,7 @@ Next, let's create a meshed cube for a Hood-Taylor element formulation. The fami
 
     displacement = fem.Field(region_q2,  dim=3)
     pressure     = fem.Field(region_p1, dim=1)
-    volumeratio  = fem.Field(region_p1, dim=1, values=1)
+    volumeratio  = fem.Field(region_p1, dim=1, values=1.0)
 
     field = fem.FieldContainer(fields=[displacement, pressure, volumeratio])
     solid = fem.SolidBody(umat=umat, field=field)

--- a/src/felupe/assembly/expression/_linear.py
+++ b/src/felupe/assembly/expression/_linear.py
@@ -62,7 +62,12 @@ class LinearForm:
         """
 
         values = np.zeros(
-            (len(self.v.basis), self.v.basis.shape[-4], self.v.basis.shape[-2], self.v.field.region.mesh.ncells)
+            (
+                len(self.v.basis),
+                self.v.basis.shape[-4],
+                self.v.basis.shape[-2],
+                self.v.field.region.mesh.ncells,
+            )
         )
 
         if not parallel:

--- a/src/felupe/constitution/hyperelasticity/core/_neo_hooke_nearly_incompressible.py
+++ b/src/felupe/constitution/hyperelasticity/core/_neo_hooke_nearly_incompressible.py
@@ -323,7 +323,7 @@ class NeoHooke(ConstitutiveMaterial):
 
         A4 = out
         if A4 is None:
-            A4 = np.zeros((*F.shape[:2], *F.shape[:2], *F.shape[-2:]))
+            A4 = np.zeros((*F.shape[:2], *F.shape[:2], *F.shape[-2:]), dtype=F.dtype)
         else:
             np.multiply(A4, 0, out=A4)
 

--- a/src/felupe/field/_axi.py
+++ b/src/felupe/field/_axi.py
@@ -36,7 +36,9 @@ class FieldAxisymmetric(Field):
     values : float or array, optional
         A single value for all components of the field or an array of
         shape (region.mesh.npoints, dim)`. Default is 0.0.
-    
+    dtype : data-type or None, optional
+        Data-type of the array containing the field values.
+
     Notes
     -----
     * component 1 =  axial component
@@ -75,12 +77,12 @@ class FieldAxisymmetric(Field):
 
     """
 
-    def __init__(self, region, dim=2, values=0.0):
+    def __init__(self, region, dim=2, values=0.0, dtype=None):
         # init base Field
-        super().__init__(region, dim=dim, values=values)
+        super().__init__(region, dim=dim, values=values, dtype=dtype)
 
         # create scalar-valued field of radial point values
-        self.scalar = Field(region, dim=1, values=region.mesh.points[:, 1])
+        self.scalar = Field(region, dim=1, values=region.mesh.points[:, 1], dtype=dtype)
 
         # interpolate radial point values to integration points of each cell
         # in the region

--- a/src/felupe/field/_axi.py
+++ b/src/felupe/field/_axi.py
@@ -86,7 +86,7 @@ class FieldAxisymmetric(Field):
         # in the region
         self.radius = self.scalar.interpolate()
 
-    def _interpolate_2d(self, out=None):
+    def _interpolate_2d(self, dtype=None, out=None):
         """Interpolate 2D field values at points and evaluate them at the
         integration points of all cells in the region."""
 
@@ -97,18 +97,21 @@ class FieldAxisymmetric(Field):
             "ca...,aqc->...qc",
             self.values[self.region.mesh.cells],
             self.region.h,
+            dtype=dtype,
             out=out,
         )
 
-    def interpolate(self, out=None):
+    def interpolate(self, dtype=None, out=None):
         # out-argument is not supported
         # if out is not None:
         #     out = out[:2]
 
         # extend dimension of in-plane 2d-gradient
-        return np.pad(self._interpolate_2d(out=None), ((0, 1), (0, 0), (0, 0)))
+        return np.pad(
+            self._interpolate_2d(dtype=dtype, out=None), ((0, 1), (0, 0), (0, 0))
+        )
 
-    def _grad_2d(self, sym=False, out=None):
+    def _grad_2d(self, sym=False, dtype=None, out=None):
         """In-plane 2D gradient as partial derivative of field values at points
         w.r.t. the undeformed coordinates, evaluated at the integration points
         of all cells in the region. Optionally, the symmetric part of the
@@ -118,6 +121,9 @@ class FieldAxisymmetric(Field):
         ---------
         sym : bool, optional (default is False)
             Calculate the symmetric part of the gradient.
+        dtype : data-type or None, optional
+            If provided, forces the calculation to use the data type specified. Default
+            is None.
         out : None or ndarray, optional
             A location into which the result is stored. If provided, it must have a
             shape that the inputs broadcast to. If not provided or None, a freshly-
@@ -138,6 +144,7 @@ class FieldAxisymmetric(Field):
             "ca...,aJqc->...Jqc",
             self.values[self.region.mesh.cells],
             self.region.dhdX,
+            dtype=dtype,
             out=out,
         )
 
@@ -146,7 +153,7 @@ class FieldAxisymmetric(Field):
         else:
             return g
 
-    def grad(self, sym=False, out=None):
+    def grad(self, sym=False, dtype=None, out=None):
         """3D-gradient as partial derivative of field values at points w.r.t.
         the undeformed coordinates, evaluated at the integration points of all
         cells in the region. Optionally, the symmetric part of the gradient is
@@ -162,6 +169,9 @@ class FieldAxisymmetric(Field):
         ---------
         sym : bool, optional
             Calculate the symmetric part of the gradient (default is False).
+        dtype : data-type or None, optional
+            If provided, forces the calculation to use the data type specified. Default
+            is None.
         out : None or ndarray, optional
             A location into which the result is stored. If provided, it must have a
             shape that the inputs broadcast to. If not provided or None, a freshly-
@@ -180,9 +190,12 @@ class FieldAxisymmetric(Field):
         #     out = out[:2, :2]
 
         # extend dimension of in-plane 2d-gradient
-        g = np.pad(self._grad_2d(sym=sym, out=None), ((0, 1), (0, 1), (0, 0), (0, 0)))
+        g = np.pad(
+            self._grad_2d(sym=sym, dtype=dtype, out=None),
+            ((0, 1), (0, 1), (0, 0), (0, 0)),
+        )
 
         # set dudX_33 = u_r / R
-        g[-1, -1] = self.interpolate()[1] / self.radius
+        g[-1, -1] = self.interpolate(dtype=dtype)[1] / self.radius
 
         return g

--- a/src/felupe/field/_base.py
+++ b/src/felupe/field/_base.py
@@ -174,7 +174,7 @@ class Field:
         )
 
         if sym:
-            return symmetric(g)
+            return symmetric(g, out=g)
         else:
             return g
 

--- a/src/felupe/field/_container.py
+++ b/src/felupe/field/_container.py
@@ -111,7 +111,7 @@ class FieldContainer:
 
         return "\n".join([header, size, fields_header, *fields])
 
-    def extract(self, grad=True, sym=False, add_identity=True, out=None):
+    def extract(self, grad=True, sym=False, add_identity=True, dtype=None, out=None):
         """Generalized extraction method which evaluates either the gradient or the
         field values at the integration points of all cells in the region. Optionally,
         the symmetric part of the gradient is evaluated and/or the identity matrix is
@@ -129,6 +129,9 @@ class FieldContainer:
         add_identity : bool, optional
             Flag for the addition of the identity matrix if the gradient is evaluated
             (default is True).
+        dtype : data-type or None, optional
+            If provided, forces the calculation to use the data type specified. Default
+            is None.
         out : None or ndarray, optional
             A location into which the result is stored. If provided, it must have a
             shape that the inputs broadcast to. If not provided or None, a freshly-
@@ -149,7 +152,7 @@ class FieldContainer:
 
         grads = np.pad(grad, (0, len(self.fields) - 1))
         return tuple(
-            f.extract(g, sym, add_identity=add_identity, out=res)
+            f.extract(g, sym, add_identity=add_identity, dtype=dtype, out=res)
             for g, f, res in zip(grads, self.fields, out)
         )
 

--- a/src/felupe/field/_planestrain.py
+++ b/src/felupe/field/_planestrain.py
@@ -130,7 +130,7 @@ class FieldPlaneStrain(Field):
         )
 
         if sym:
-            return symmetric(g, dtype=dtype, out=g)
+            return symmetric(g, out=g)
         else:
             return g
 

--- a/src/felupe/field/_planestrain.py
+++ b/src/felupe/field/_planestrain.py
@@ -65,7 +65,7 @@ class FieldPlaneStrain(Field):
         # init base Field
         super().__init__(region, dim=dim, values=values)
 
-    def _interpolate_2d(self, out=None):
+    def _interpolate_2d(self, dtype=None, out=None):
         """Interpolate 2D field values at points and evaluate them at the
         integration points of all cells in the region."""
 
@@ -76,18 +76,21 @@ class FieldPlaneStrain(Field):
             "ca...,aqc->...qc",
             self.values[self.region.mesh.cells],
             self.region.h,
+            dtype=dtype,
             out=out,
         )
 
-    def interpolate(self, out=None):
+    def interpolate(self, dtype=None, out=None):
         # out-argument is not supported
         # if out is not None:
         #     out = out[:2]
 
         # extend dimension of in-plane 2d-gradient
-        return np.pad(self._interpolate_2d(out=None), ((0, 1), (0, 0), (0, 0)))
+        return np.pad(
+            self._interpolate_2d(dtype=dtype, out=None), ((0, 1), (0, 0), (0, 0))
+        )
 
-    def _grad_2d(self, sym=False, out=None):
+    def _grad_2d(self, sym=False, dtype=None, out=None):
         """In-plane 2D gradient as partial derivative of field values at points
         w.r.t. the undeformed coordinates, evaluated at the integration points
         of all cells in the region. Optionally, the symmetric part of the
@@ -97,6 +100,9 @@ class FieldPlaneStrain(Field):
         ---------
         sym : bool, optional
             Calculate the symmetric part of the gradient (default is False).
+        dtype : data-type or None, optional
+            If provided, forces the calculation to use the data type specified. Default
+            is None.
         out : None or ndarray, optional
             A location into which the result is stored. If provided, it must have a
             shape that the inputs broadcast to. If not provided or None, a freshly-
@@ -117,15 +123,16 @@ class FieldPlaneStrain(Field):
             "ca...,aJqc->...Jqc",
             self.values[self.region.mesh.cells],
             self.region.dhdX,
+            dtype=dtype,
             out=out,
         )
 
         if sym:
-            return symmetric(g, out=g)
+            return symmetric(g, dtype=dtype, out=g)
         else:
             return g
 
-    def grad(self, sym=False, out=None):
+    def grad(self, sym=False, dtype=None, out=None):
         """3D-gradient as partial derivative of field values at points w.r.t.
         the undeformed coordinates, evaluated at the integration points of all
         cells in the region. Optionally, the symmetric part of the gradient is
@@ -141,6 +148,9 @@ class FieldPlaneStrain(Field):
         ---------
         sym : bool, optional
             Calculate the symmetric part of the gradient (default is False).
+        dtype : data-type or None, optional
+            If provided, forces the calculation to use the data type specified. Default
+            is None.
         out : None or ndarray, optional
             A location into which the result is stored. If provided, it must have a
             shape that the inputs broadcast to. If not provided or None, a freshly-
@@ -159,6 +169,9 @@ class FieldPlaneStrain(Field):
         #     out = out[:2, :2]
 
         # extend dimension of in-plane 2d-gradient
-        g = np.pad(self._grad_2d(sym=sym, out=None), ((0, 1), (0, 1), (0, 0), (0, 0)))
+        g = np.pad(
+            self._grad_2d(sym=sym, dtype=dtype, out=None),
+            ((0, 1), (0, 1), (0, 0), (0, 0)),
+        )
 
         return g

--- a/src/felupe/field/_planestrain.py
+++ b/src/felupe/field/_planestrain.py
@@ -36,7 +36,9 @@ class FieldPlaneStrain(Field):
     values : float or array
         A single value for all components of the field or an array of
         shape (region.mesh.npoints, dim)`. Default is 0.0.
-    
+    dtype : data-type or None, optional
+        Data-type of the array containing the field values.
+
     Notes
     -----
     This is a modified :class:`~felupe.Field` for plane strain. The :meth:`grad`-method
@@ -61,9 +63,9 @@ class FieldPlaneStrain(Field):
 
     """
 
-    def __init__(self, region, dim=2, values=0.0):
+    def __init__(self, region, dim=2, values=0.0, dtype=None):
         # init base Field
-        super().__init__(region, dim=dim, values=values)
+        super().__init__(region, dim=dim, values=values, dtype=dtype)
 
     def _interpolate_2d(self, dtype=None, out=None):
         """Interpolate 2D field values at points and evaluate them at the

--- a/src/felupe/math/_tensor.py
+++ b/src/felupe/math/_tensor.py
@@ -165,7 +165,7 @@ def sym(A, out=None):
 
     """
     out = np.add(A, transpose(A), out=out)
-    return np.multiply(out, 0.5, out=out, dtype=out.dtype)
+    return np.multiply(out, 0.5, out=out)
 
 
 def dya(A, B, mode=2, parallel=False, **kwargs):

--- a/src/felupe/math/_tensor.py
+++ b/src/felupe/math/_tensor.py
@@ -26,7 +26,7 @@ except ModuleNotFoundError:
     from numpy import einsum as einsumt
 
 
-def identity(A=None, dim=None, shape=None):
+def identity(A=None, dim=None, shape=None, dtype=None):
     r"""Return identity matrices with ones on the diagonal of the first two axes and
     zeros elsewhere. 
     
@@ -42,7 +42,11 @@ def identity(A=None, dim=None, shape=None):
     shape : tuple of int or None, optional
         A tuple containing the shape of the trailing axes (batch dimensions). Default is
         None.
-    
+    dtype : data-type or None, optional
+        Data-type of the returned array. If None and ``A`` is not None, the data-type of
+        ``A`` is used. If None and ``A`` is None, the data-type of the returned array is
+        ``float``.
+
     Returns
     -------
     ndarray of shape (N, M, *np.ones_like(...)) or (dim, dim, *np.ones_like(...))
@@ -106,9 +110,11 @@ def identity(A=None, dim=None, shape=None):
             dim = N
         if shape is None:
             shape = shapeA
+        if dtype is None:
+            dtype = A.dtype
 
     ones = (1,) * len(shape)
-    eye = np.eye(N=dim, M=M)
+    eye = np.eye(N=dim, M=M, dtype=dtype)
     return eye.reshape(*eye.shape, *ones)
 
 
@@ -159,7 +165,7 @@ def sym(A, out=None):
 
     """
     out = np.add(A, transpose(A), out=out)
-    return np.multiply(out, 0.5, out=out)
+    return np.multiply(out, 0.5, out=out, dtype=out.dtype)
 
 
 def dya(A, B, mode=2, parallel=False, **kwargs):

--- a/src/felupe/mechanics/_item.py
+++ b/src/felupe/mechanics/_item.py
@@ -17,6 +17,7 @@ along with FElupe.  If not, see <http://www.gnu.org/licenses/>.
 """
 
 from copy import deepcopy
+
 from ._helpers import Assemble, Results
 
 

--- a/src/felupe/region/_region.py
+++ b/src/felupe/region/_region.py
@@ -141,6 +141,37 @@ class Region:
         self.evaluate_gradient = grad
         self.reload(mesh=mesh, element=element, quadrature=quadrature, uniform=uniform)
 
+    def astype(self, dtype=None):
+        """Copy the region and cast the arrays to a specified type.
+
+        Parameters
+        ----------
+        dtype : data-type or None, optional
+            The data-type of the arrays of the Region. If None, a copy of the Region is
+            returned.
+
+        Returns
+        -------
+        Region
+            A copy of the region with arrays casted to a specified type.
+
+        See Also
+        --------
+        felupe.region.copy : Return a copy of the region and reload it if necessary.
+        """
+
+        region = self.copy()
+        region.h = region.h.astype(dtype)
+        region.dhdr = region.dhdr.astype(dtype)
+
+        if region.evaluate_gradient:
+            region.drdX = region.drdX.astype(dtype)
+            region.dXdr = region.dXdr.astype(dtype)
+            region.dhdX = region.dhdX.astype(dtype)
+            region.dV = region.dV.astype(dtype)
+
+        return region
+
     def copy(self, mesh=None, element=None, quadrature=None, uniform=None):
         """Return a copy of the region and reload it if necessary.
 

--- a/tests/test_constitution.py
+++ b/tests/test_constitution.py
@@ -53,7 +53,7 @@ def pre_mixed(sym, add_identity):
     r = fem.Region(m, e, q)
     u = fem.Field(r, dim=3)
     v = fem.Field(r, dim=1)
-    z = fem.Field(r, dim=1, values=1)
+    z = fem.Field(r, dim=1, values=1.0)
     w = fem.FieldContainer([u, v, z])
     return r, w.extract(grad=True, sym=sym, add_identity=add_identity), m
 

--- a/tests/test_dtype.py
+++ b/tests/test_dtype.py
@@ -1,0 +1,66 @@
+# -*- coding: utf-8 -*-
+"""
+ _______  _______  ___      __   __  _______  _______ 
+|       ||       ||   |    |  | |  ||       ||       |
+|    ___||    ___||   |    |  | |  ||    _  ||    ___|
+|   |___ |   |___ |   |    |  |_|  ||   |_| ||   |___ 
+|    ___||    ___||   |___ |       ||    ___||    ___|
+|   |    |   |___ |       ||       ||   |    |   |___ 
+|___|    |_______||_______||_______||___|    |_______|
+
+This file is part of felupe.
+
+Felupe is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Felupe is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Felupe.  If not, see <http://www.gnu.org/licenses/>.
+
+"""
+
+import numpy as np
+
+import felupe as fem
+
+
+def test_dtype():
+    mesh = fem.Cube(n=3)
+    region = fem.RegionHexahedron(mesh).astype(np.float32)
+    displacement = fem.Field(region, dtype=np.float32)
+    field = fem.FieldContainer([displacement])
+
+    assert field.extract()[0].dtype == np.float32
+    assert field.extract(grad=False)[0].dtype == np.float32
+
+
+def test_dtype_axi():
+    mesh = fem.Rectangle(n=3)
+    region = fem.RegionQuad(mesh).astype(np.float32)
+    displacement = fem.FieldAxisymmetric(region, dtype=np.float32)
+    field = fem.FieldContainer([displacement])
+
+    assert field.extract()[0].dtype == np.float32
+    assert field.extract(grad=False)[0].dtype == np.float32
+
+
+def test_dtype_planestrain():
+    mesh = fem.Rectangle(n=3)
+    region = fem.RegionQuad(mesh).astype(np.float32)
+    displacement = fem.FieldPlaneStrain(region, dtype=np.float32)
+    field = fem.FieldContainer([displacement])
+
+    assert field.extract()[0].dtype == np.float32
+    assert field.extract(grad=False)[0].dtype == np.float32
+
+
+if __name__ == "__main__":
+    test_dtype()
+    test_dtype_axi()
+    test_dtype_planestrain()

--- a/tests/test_field.py
+++ b/tests/test_field.py
@@ -64,7 +64,7 @@ def pre_mixed():
 
     u = fem.Field(r, dim=3)
     p = fem.Field(r)
-    J = fem.Field(r, values=1)
+    J = fem.Field(r, values=1.0)
 
     f = fem.FieldContainer([u, p, J])
     g = fem.FieldsMixed(fem.RegionHexahedron(m), n=3, disconnect=True)
@@ -98,7 +98,7 @@ def pre_axi_mixed():
 
     u = fem.FieldAxisymmetric(r, dim=2)
     p = fem.Field(r)
-    J = fem.Field(r, values=1)
+    J = fem.Field(r, values=1.0)
 
     f = fem.FieldContainer((u, p, J))
 

--- a/tests/test_form.py
+++ b/tests/test_form.py
@@ -97,7 +97,7 @@ def pre_mixed():
 
     u = fem.Field(r, dim=3)
     p = fem.Field(r)
-    J = fem.Field(r, values=1)
+    J = fem.Field(r, values=1.0)
 
     f = fem.FieldContainer((u, p, J))
 
@@ -115,7 +115,7 @@ def pre_axi_mixed():
 
     u = fem.FieldAxisymmetric(r, dim=2)
     p = fem.Field(r)
-    J = fem.Field(r, values=1)
+    J = fem.Field(r, values=1.0)
 
     f = fem.FieldContainer((u, p, J))
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -37,7 +37,7 @@ def pre():
 
     u = fem.Field(r, dim=3)
     p = fem.Field(r)
-    J = fem.Field(r, values=1)
+    J = fem.Field(r, values=1.0)
 
     f = fem.FieldContainer((u, p, J))
 
@@ -261,7 +261,7 @@ def test_newton_mixed():
     # add a displacement field and apply a uniaxial elongation on the cube
     u = fem.Field(region, dim=3)
     p = fem.Field(region0)
-    J = fem.Field(region0, values=1)
+    J = fem.Field(region0, values=1.0)
     field = fem.FieldContainer((u, p, J))
 
     assert len(field) == 3
@@ -288,7 +288,7 @@ def test_newton_body():
     # add a displacement field and apply a uniaxial elongation on the cube
     u = fem.Field(region, dim=3)
     p = fem.Field(region0)
-    J = fem.Field(region0, values=1)
+    J = fem.Field(region0, values=1.0)
     field = fem.FieldContainer((u, p, J))
 
     boundaries, loadcase = fem.dof.uniaxial(field, move=0.2, clamped=True)


### PR DESCRIPTION
also for axisymmetric and plane-strain fields.

This PR enables the assembly of single-precision vectors/matrices.

```python
import felupe as fem
import numpy as np

mesh = fem.Cube(n=3)
region = fem.RegionHexahedron(mesh).astype(dtype)
displacement = fem.Field(region, dim=3, dtype=dtype)
field = fem.FieldContainer([displacement])

boundaries, loadcase = fem.dof.uniaxial(field, clamped=True)

solid = fem.SolidBody(fem.NeoHooke(mu=1.0, bulk=2.0), field)
job = fem.Job([fem.Step([solid], boundaries=boundaries)]).evaluate(tol=tol)
```