### PR TITLE
Add optional `SolidBody.assemble.matrix(block=False)`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file. The format 
 - Add `Field.extract(dtype=None)` to cast the extracted field gradient/interpolated values to a specified type.
 - Add `hello_world()` to print the lines of a minimal-working-example to the console.
 - Add `mesh.interpolate_line(mesh, xi, axis)` to interpolate a line mesh. The attribute `points_derivative` holds the derivatives of the independent variable w.r.t. the dependent variable(s). The column of the independent variable is filled with zeros.
+- Add optional keyword-argument `SolidBody.assemble.matrix(block=True)`, also for `SolidBody.assemble.vector(block=True)` and the assemble-methods of `SolidBodyNearlyIncompressible`. If `block=False`, these methods will assemble a list of the upper-triangle sub block-vectors/-matrices instead of the combined block-vector/-matrix.
 
 ### Changed
 - Change the internal initialization of `field = Field(region, values=1, dtype=None)` values from `field.values = np.ones(shape) * values` to `field = np.full(shape, fill_value=values, dtype=dtype)`. This enforces `field = Field(region, values=1)` to return the gradient array with data-type `int` which was of type `float` before.

--- a/src/felupe/mechanics/_solidbody.py
+++ b/src/felupe/mechanics/_solidbody.py
@@ -243,7 +243,9 @@ class SolidBody(Solid):
 
         self._form = IntegralForm
 
-    def _vector(self, field=None, parallel=False, items=None, args=(), kwargs=None):
+    def _vector(
+        self, field=None, parallel=False, items=None, args=(), kwargs=None, block=True
+    ):
         if kwargs is None:
             kwargs = {}
 
@@ -255,11 +257,13 @@ class SolidBody(Solid):
             fun=self.results.stress[slice(items)],
             v=self.field,
             dV=self.field.region.dV,
-        ).assemble(parallel=parallel)
+        ).assemble(parallel=parallel, block=block)
 
         return self.results.force
 
-    def _matrix(self, field=None, parallel=False, items=None, args=(), kwargs=None):
+    def _matrix(
+        self, field=None, parallel=False, items=None, args=(), kwargs=None, block=True
+    ):
         if kwargs is None:
             kwargs = {}
 
@@ -279,7 +283,9 @@ class SolidBody(Solid):
             parallel=parallel, out=self.results.stiffness_values
         )
 
-        self.results.stiffness = form.assemble(values=self.results.stiffness_values)
+        self.results.stiffness = form.assemble(
+            values=self.results.stiffness_values, block=block
+        )
 
         return self.results.stiffness
 

--- a/src/felupe/mechanics/_solidbody_incompressible.py
+++ b/src/felupe/mechanics/_solidbody_incompressible.py
@@ -364,7 +364,9 @@ class SolidBodyNearlyIncompressible(Solid):
             kirchhoff_stress=self._kirchhoff_stress,
         )
 
-    def _vector(self, field=None, parallel=False, items=None, args=(), kwargs=None):
+    def _vector(
+        self, field=None, parallel=False, items=None, args=(), kwargs=None, block=True
+    ):
         if kwargs is None:
             kwargs = {}
 
@@ -393,11 +395,15 @@ class SolidBodyNearlyIncompressible(Solid):
             self.results.force_values[0], constraint, out=self.results.force_values[0]
         )
 
-        self.results.force = form.assemble(values=self.results.force_values)
+        self.results.force = form.assemble(
+            values=self.results.force_values, block=block
+        )
 
         return self.results.force
 
-    def _matrix(self, field=None, parallel=False, items=None, args=(), kwargs=None):
+    def _matrix(
+        self, field=None, parallel=False, items=None, args=(), kwargs=None, block=True
+    ):
         if kwargs is None:
             kwargs = {}
 
@@ -428,7 +434,9 @@ class SolidBodyNearlyIncompressible(Solid):
             out=self.results.stiffness_values[0],
         )
 
-        self.results.stiffness = form.assemble(values=self.results.stiffness_values)
+        self.results.stiffness = form.assemble(
+            values=self.results.stiffness_values, block=block
+        )
 
         return self.results.stiffness
 


### PR DESCRIPTION
also for `SolidBodyNearlyIncompressible` and for `vector()`.

This PR provides the (optional) `block`-argument of an integral form in the solid-body assemble-methods. If `block=False`, the vector/matrix is not assembled to a block matrix/vector but the list of sub-blocks is assembled instead.