### PR TITLE
Change the visibility of the helpers in the mechanics-module from private to public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be documented in this file. The format 
 - Change the internal initialization of `field = Field(region, values=1, dtype=None)` values from `field.values = np.ones(shape) * values` to `field = np.full(shape, fill_value=values, dtype=dtype)`. This enforces `field = Field(region, values=1)` to return the gradient array with data-type `int` which was of type `float` before.
 - Initialize empty matrices of `SolidBodyForce`, `SolidBodyGravity` and `PointLoad` with `dtype=float`.
 - Don't multiply the assembled vectors of `SolidBodyForce`, `SolidBodyGravity` and `PointLoad` by `-1.0`.
+- Change the visibility of the internal helpers `Assemble`, `Evaluate` and `Results` of the mechanics-module `felupe.mechanics` from private to public.
 
 ### Deprecated
 - Deprecate `SolidBodyGravity`, `SolidBodyForce` should be used instead.

--- a/docs/felupe/mechanics.rst
+++ b/docs/felupe/mechanics.rst
@@ -14,12 +14,6 @@ Mechanics
    SolidBodyPressure
    SolidBodyForce
 
-**State Variables**
-
-.. autosummary::
-
-   StateNearlyIncompressible
-
 **Steps and Jobs**
 
 .. autosummary::
@@ -35,6 +29,15 @@ Mechanics
    PointLoad
    MultiPointConstraint
    MultiPointContact
+   
+**Helpers for Custom Items and State Variables**
+
+.. autosummary::
+
+   StateNearlyIncompressible
+   mechanics.Assemble
+   mechanics.Evaluate
+   mechanics.Results
 
 **Detailed API Reference**
    
@@ -44,11 +47,6 @@ Mechanics
    :show-inheritance:
 
 .. autoclass:: felupe.SolidBodyNearlyIncompressible
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-.. autoclass:: felupe.StateNearlyIncompressible
    :members:
    :undoc-members:
    :show-inheritance:
@@ -89,6 +87,26 @@ Mechanics
    :inherited-members:
 
 .. autoclass:: felupe.MultiPointContact
+   :members:
+   :undoc-members:
+   :inherited-members:
+   
+.. autoclass:: felupe.StateNearlyIncompressible
+   :members:
+   :undoc-members:
+   :inherited-members:
+
+.. autoclass:: felupe.mechanics.Assemble
+   :members:
+   :undoc-members:
+   :inherited-members:
+
+.. autoclass:: felupe.mechanics.Evaluate
+   :members:
+   :undoc-members:
+   :inherited-members:
+   
+.. autoclass:: felupe.mechanics.Results
    :members:
    :undoc-members:
    :inherited-members:

--- a/src/felupe/mechanics/__init__.py
+++ b/src/felupe/mechanics/__init__.py
@@ -1,5 +1,5 @@
 from ._curve import CharacteristicCurve
-from ._helpers import StateNearlyIncompressible
+from ._helpers import Assemble, Evaluate, Results, StateNearlyIncompressible
 from ._item import FormItem
 from ._job import Job
 from ._multipoint import MultiPointConstraint, MultiPointContact
@@ -12,11 +12,14 @@ from ._solidbody_pressure import SolidBodyPressure
 from ._step import Step
 
 __all__ = [
+    "Assemble",
     "CharacteristicCurve",
+    "Evaluate",
     "FormItem",
     "StateNearlyIncompressible",
     "Job",
     "PointLoad",
+    "Results",
     "SolidBody",
     "SolidBodyGravity",
     "SolidBodyForce",

--- a/src/felupe/mechanics/_helpers.py
+++ b/src/felupe/mechanics/_helpers.py
@@ -24,7 +24,7 @@ from ..math import det
 
 
 class Assemble:
-    "A class with methods for assembling vectors and matrices of a SolidBody."
+    "A class with methods for assembling vectors and matrices of an Item."
 
     def __init__(self, vector, matrix, multiplier=None):
         self.vector = vector
@@ -33,7 +33,7 @@ class Assemble:
 
 
 class Evaluate:
-    "A class with evaluate methods of a SolidBody."
+    "A class with evaluate methods of an Item."
 
     def __init__(self, gradient, hessian, cauchy_stress=None, kirchhoff_stress=None):
         self.gradient = gradient
@@ -45,7 +45,7 @@ class Evaluate:
 
 
 class Results:
-    "A class with intermediate results of a SolidBody."
+    "A class with intermediate results of an Item."
 
     def __init__(self, stress=False, elasticity=False):
         self.force = None


### PR DESCRIPTION
Change the visibility of the internal helpers `Assemble`, `Evaluate` and `Results` of the mechanics-module `felupe.mechanics` from private to public.