### PR TITLE
Import the `assembly` module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to this project will be documented in this file. The format 
 - Initialize empty matrices of `SolidBodyForce`, `SolidBodyGravity` and `PointLoad` with `dtype=float`.
 - Don't multiply the assembled vectors of `SolidBodyForce`, `SolidBodyGravity` and `PointLoad` by `-1.0`.
 - Change the visibility of the internal helpers `Assemble`, `Evaluate` and `Results` of the mechanics-module `felupe.mechanics` from private to public.
+- Import the `assembly` module.
 
 ### Deprecated
 - Deprecate `SolidBodyGravity`, `SolidBodyForce` should be used instead.

--- a/src/felupe/__init__.py
+++ b/src/felupe/__init__.py
@@ -1,4 +1,5 @@
 from . import (
+    assembly,
     constitution,
     dof,
     element,

--- a/src/felupe/assembly/_axi.py
+++ b/src/felupe/assembly/_axi.py
@@ -115,7 +115,7 @@ class IntegralFormAxisymmetric(IntegralFormCartesian):
     See Also
     --------
     felupe.IntegralForm : Mixed-field integral form container with methods for integration and assembly.
-    felupe.IntegralFormCartesian : Single-field integral form.
+    felupe.assembly.IntegralFormCartesian : Single-field integral form.
 
     """
 

--- a/src/felupe/assembly/_cartesian.py
+++ b/src/felupe/assembly/_cartesian.py
@@ -97,7 +97,7 @@ class IntegralFormCartesian:
     See Also
     --------
     felupe.IntegralForm : Mixed-field integral form container with methods for integration and assembly.
-    felupe.IntegralFormAxisymmetric : An Integral Form for axisymmetric fields.
+    felupe.assembly.IntegralFormAxisymmetric : An Integral Form for axisymmetric fields.
 
     """
 

--- a/src/felupe/assembly/_integral.py
+++ b/src/felupe/assembly/_integral.py
@@ -187,9 +187,9 @@ class IntegralForm:
 
     See Also
     --------
-    felupe.IntegralFormAxisymmetric : An Integral Form for axisymmetric fields.
-    felupe.IntegralFormCartesian : Single-field integral form.
     felupe.Form : A weak-form expression decorator.
+    felupe.assembly.IntegralFormAxisymmetric : An Integral Form for axisymmetric fields.
+    felupe.assembly.IntegralFormCartesian : Single-field integral form.
 
     """
 


### PR DESCRIPTION
Add `from . import assembly` to `__init__.py` and fix some *See Also* docstring references.

Hmm. Currently, this is not possible due to circular imports. Try to isolate the modules in the future.