### PR TITLE
Enhance (isolate) the cross-imports between submodules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to this project will be documented in this file. The format 
 - Initialize empty matrices of `SolidBodyForce`, `SolidBodyGravity` and `PointLoad` with `dtype=float`.
 - Don't multiply the assembled vectors of `SolidBodyForce`, `SolidBodyGravity` and `PointLoad` by `-1.0`.
 - Change the visibility of the internal helpers `Assemble`, `Evaluate` and `Results` of the mechanics-module `felupe.mechanics` from private to public.
+- Import the `assembly` module.
 
 ### Deprecated
 - Deprecate `SolidBodyGravity`, `SolidBodyForce` should be used instead.

--- a/src/felupe/__init__.py
+++ b/src/felupe/__init__.py
@@ -1,4 +1,5 @@
 from . import (
+    assembly,
     constitution,
     dof,
     element,

--- a/src/felupe/assembly/_axi.py
+++ b/src/felupe/assembly/_axi.py
@@ -114,7 +114,7 @@ class IntegralFormAxisymmetric(IntegralFormCartesian):
     See Also
     --------
     felupe.IntegralForm : Mixed-field integral form container with methods for integration and assembly.
-    felupe.IntegralFormCartesian : Single-field integral form.
+    felupe.assembly.IntegralFormCartesian : Single-field integral form.
 
     """
 

--- a/src/felupe/assembly/_axi.py
+++ b/src/felupe/assembly/_axi.py
@@ -18,8 +18,7 @@ along with FElupe.  If not, see <http://www.gnu.org/licenses/>.
 
 import numpy as np
 
-from ..field._axi import FieldAxisymmetric
-from ..field._base import Field
+from ..field import Field, FieldAxisymmetric
 from ._cartesian import IntegralFormCartesian
 
 

--- a/src/felupe/assembly/_cartesian.py
+++ b/src/felupe/assembly/_cartesian.py
@@ -97,7 +97,7 @@ class IntegralFormCartesian:
     See Also
     --------
     felupe.IntegralForm : Mixed-field integral form container with methods for integration and assembly.
-    felupe.IntegralFormAxisymmetric : An Integral Form for axisymmetric fields.
+    felupe.assembly.IntegralFormAxisymmetric : An Integral Form for axisymmetric fields.
 
     """
 

--- a/src/felupe/assembly/_integral.py
+++ b/src/felupe/assembly/_integral.py
@@ -19,7 +19,7 @@ along with FElupe.  If not, see <http://www.gnu.org/licenses/>.
 import numpy as np
 from scipy.sparse import bmat, vstack
 
-from ..field import Field, FieldDual, FieldAxisymmetric, FieldPlaneStrain
+from ..field import Field, FieldAxisymmetric, FieldDual, FieldPlaneStrain
 from ._axi import IntegralFormAxisymmetric
 from ._cartesian import IntegralFormCartesian
 
@@ -184,8 +184,8 @@ class IntegralForm:
 
     See Also
     --------
-    felupe.IntegralFormAxisymmetric : An Integral Form for axisymmetric fields.
-    felupe.IntegralFormCartesian : Single-field integral form.
+    felupe.assembly.IntegralFormAxisymmetric : An Integral Form for axisymmetric fields.
+    felupe.assembly.IntegralFormCartesian : Single-field integral form.
     felupe.Form : A weak-form expression decorator.
 
     """

--- a/src/felupe/assembly/_integral.py
+++ b/src/felupe/assembly/_integral.py
@@ -19,10 +19,7 @@ along with FElupe.  If not, see <http://www.gnu.org/licenses/>.
 import numpy as np
 from scipy.sparse import bmat, vstack
 
-from ..field._axi import FieldAxisymmetric
-from ..field._base import Field
-from ..field._dual import FieldDual
-from ..field._planestrain import FieldPlaneStrain
+from ..field import Field, FieldDual, FieldAxisymmetric, FieldPlaneStrain
 from ._axi import IntegralFormAxisymmetric
 from ._cartesian import IntegralFormCartesian
 

--- a/src/felupe/constitution/_view.py
+++ b/src/felupe/constitution/_view.py
@@ -21,8 +21,7 @@ from copy import deepcopy
 
 import numpy as np
 
-from ..math._math import linsteps
-from ..math._tensor import det
+from ..math import det, linsteps
 
 
 class PlotMaterial:

--- a/src/felupe/field/_dual.py
+++ b/src/felupe/field/_dual.py
@@ -16,7 +16,7 @@ You should have received a copy of the GNU General Public License
 along with FElupe.  If not, see <http://www.gnu.org/licenses/>.
 """
 
-from ..region._templates import (
+from ..region import (
     RegionBiQuadraticQuad,
     RegionConstantHexahedron,
     RegionConstantQuad,

--- a/src/felupe/field/_evaluate.py
+++ b/src/felupe/field/_evaluate.py
@@ -16,7 +16,7 @@ You should have received a copy of the GNU General Public License
 along with FElupe.  If not, see <http://www.gnu.org/licenses/>.
 """
 
-from ..math._field import strain, strain_stretch_1d
+from ..math import strain, strain_stretch_1d
 
 
 class EvaluateFieldContainer:


### PR DESCRIPTION
use only public API's in imports from other submodules, see #822 for more details. Also add the `assembly` submodule to the global namespace.

closes #822 