### PR TITLE
Fix the assembly performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to this project will be documented in this file. The format 
 - Change the visibility of the internal helpers `Assemble`, `Evaluate` and `Results` of the mechanics-module `felupe.mechanics` from private to public.
 - Import the `assembly` module to the global namespace.
 - Isolate the submodules, i.e. a submodule only uses the public API of another submodule. If necessary, this will help to change one or more modules to a future extension package.
+- Enforce contiguous arrays for the region shape-function and -gradient arrays `h` and `dhdX`. This recovers the integral-form assembly performance from v8.6.0.
 
 ### Deprecated
 - Deprecate `SolidBodyGravity`, `SolidBodyForce` should be used instead.

--- a/src/felupe/region/_region.py
+++ b/src/felupe/region/_region.py
@@ -271,13 +271,14 @@ class Region:
             region.element.h = np.array(
                 [region.element.function(q) for q in region.quadrature.points]
             ).T
-            region.h = np.expand_dims(region.element.h, -1)
+            region.h = np.ascontiguousarray(np.expand_dims(region.element.h, -1))
 
             # partial derivative of element shape function
             region.element.dhdr = np.array(
                 [region.element.gradient(q) for q in region.quadrature.points]
             ).transpose(1, 2, 0)
-            region.dhdr = np.expand_dims(region.element.dhdr, -1)
+
+            region.dhdr = np.ascontiguousarray(np.expand_dims(region.element.dhdr, -1))
 
             if region.evaluate_gradient:
                 # geometric gradient
@@ -286,8 +287,8 @@ class Region:
                 if uniform:
                     cells = cells[:1]
 
-                region.dXdr = np.einsum(
-                    "caI,aJqc->IJqc", region.mesh.points[cells], region.dhdr
+                region.dXdr = np.ascontiguousarray(
+                    np.einsum("caI,aJqc->IJqc", region.mesh.points[cells], region.dhdr)
                 )
 
                 # determinant and inverse of dXdr


### PR DESCRIPTION
due to non-contiguous region attributes.

```python
import felupe as fem

mesh = fem.Cube(n=21)
region = fem.RegionHexahedron(mesh)
```

```
region.dhdX.flags
Out[1]: 
  C_CONTIGUOUS : True
  F_CONTIGUOUS : False
  OWNDATA : True
  WRITEABLE : True
  ALIGNED : True
  WRITEBACKIFCOPY : False
```

closes #827 