### PR TITLE
Extract C-contiguous arrays by default from fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file. The format 
 
 ### Added
 - Add the hessian of the element shape functions for a quadratic quad element `QuadraticQuad.hessian()`.
+- Add the `order`-argument to `FieldContainer.extract(order="C")` to return C-contiguous arrays by default.
+
+### Changed
+- Change default `np.einsum(..., order="K")` to `np.einsum(..., order="C")` in the methods of `Field`, `FieldAxisymmetric` and `FieldPlaneStrain`.
 
 ## [9.0.0] - 2024-09-06
 

--- a/src/felupe/field/_base.py
+++ b/src/felupe/field/_base.py
@@ -138,7 +138,7 @@ class Field:
 
         return cai, ai
 
-    def grad(self, sym=False, dtype=None, out=None):
+    def grad(self, sym=False, dtype=None, out=None, order="C"):
         r"""Gradient as partial derivative of field values w.r.t. undeformed
         coordinates, evaluated at the integration points of all cells in the region.
         Optionally, the symmetric part the gradient is evaluated.
@@ -159,6 +159,12 @@ class Field:
             A location into which the result is stored. If provided, it must have a
             shape that the inputs broadcast to. If not provided or None, a freshly-
             allocated array is returned (default is None).
+        order : {'C', 'F', 'A', 'K'}, optional
+            Controls the memory layout of the output. 'C' means it should be C
+            contiguous. 'F' means it should be Fortran contiguous, 'A' means it should
+            be 'F' if the inputs are all 'F', 'C' otherwise. 'K' means it should be as
+            close to the layout as the inputs as is possible, including arbitrarily
+            permuted axes. Default is 'C'.
 
         Returns
         -------
@@ -177,6 +183,7 @@ class Field:
             self.region.dhdX,
             dtype=dtype,
             out=out,
+            order=order,
         )
 
         if sym:
@@ -184,7 +191,7 @@ class Field:
         else:
             return g
 
-    def hess(self, dtype=None, out=None):
+    def hess(self, dtype=None, out=None, order="C"):
         r"""Hessian as second partial derivative of field values w.r.t. undeformed
         coordinates, evaluated at the integration points of all cells in the region.
 
@@ -204,6 +211,12 @@ class Field:
             A location into which the result is stored. If provided, it must have a
             shape that the inputs broadcast to. If not provided or None, a freshly-
             allocated array is returned (default is None).
+        order : {'C', 'F', 'A', 'K'}, optional
+            Controls the memory layout of the output. 'C' means it should be C
+            contiguous. 'F' means it should be Fortran contiguous, 'A' means it should
+            be 'F' if the inputs are all 'F', 'C' otherwise. 'K' means it should be as
+            close to the layout as the inputs as is possible, including arbitrarily
+            permuted axes. Default is 'C'.
 
         Returns
         -------
@@ -222,11 +235,12 @@ class Field:
             self.region.d2hdXdX,
             dtype=dtype,
             out=out,
+            order=order,
         )
 
         return h
 
-    def interpolate(self, dtype=None, out=None):
+    def interpolate(self, dtype=None, out=None, order="C"):
         r"""Interpolate field values located at mesh-points to the quadrature points
         ``q`` of cells ``c`` in the region.
 
@@ -243,6 +257,12 @@ class Field:
             A location into which the result is stored. If provided, it must have a
             shape that the inputs broadcast to. If not provided or None, a freshly-
             allocated array is returned (default is None).
+        order : {'C', 'F', 'A', 'K'}, optional
+            Controls the memory layout of the output. 'C' means it should be C
+            contiguous. 'F' means it should be Fortran contiguous, 'A' means it should
+            be 'F' if the inputs are all 'F', 'C' otherwise. 'K' means it should be as
+            close to the layout as the inputs as is possible, including arbitrarily
+            permuted axes. Default is 'C'.
 
         Returns
         -------
@@ -259,10 +279,13 @@ class Field:
             self.values[self.region.mesh.cells],
             self.region.h,
             dtype=dtype,
-            out=None,
+            out=out,
+            order=order,
         )
 
-    def extract(self, grad=True, sym=False, add_identity=True, dtype=None, out=None):
+    def extract(
+        self, grad=True, sym=False, add_identity=True, dtype=None, out=None, order="C"
+    ):
         """Generalized extraction method which evaluates either the gradient or the
         field values at the integration points of all cells in the region. Optionally,
         the symmetric part of the gradient is evaluated and/or the identity matrix is
@@ -284,6 +307,12 @@ class Field:
             A location into which the result is stored. If provided, it must have a
             shape that the inputs broadcast to. If not provided or None, a freshly-
             allocated array is returned (default is None).
+        order : {'C', 'F', 'A', 'K'}, optional
+            Controls the memory layout of the outputs. 'C' means it should be C
+            contiguous. 'F' means it should be Fortran contiguous, 'A' means it should
+            be 'F' if the inputs are all 'F', 'C' otherwise. 'K' means it should be as
+            close to the layout as the inputs as is possible, including arbitrarily
+            permuted axes. Default is 'C'.
 
         Returns
         -------
@@ -298,7 +327,7 @@ class Field:
         """
 
         if grad:
-            gr = self.grad(out=out, dtype=dtype)
+            gr = self.grad(out=out, dtype=dtype, order=order)
 
             if sym:
                 gr = symmetric(gr, out=gr)
@@ -308,7 +337,7 @@ class Field:
 
             return gr
         else:
-            return self.interpolate(out=out, dtype=dtype)
+            return self.interpolate(out=out, dtype=dtype, order=order)
 
     def copy(self):
         "Return a copy of the field."

--- a/src/felupe/field/_base.py
+++ b/src/felupe/field/_base.py
@@ -308,7 +308,7 @@ class Field:
             shape that the inputs broadcast to. If not provided or None, a freshly-
             allocated array is returned (default is None).
         order : {'C', 'F', 'A', 'K'}, optional
-            Controls the memory layout of the outputs. 'C' means it should be C
+            Controls the memory layout of the output. 'C' means it should be C
             contiguous. 'F' means it should be Fortran contiguous, 'A' means it should
             be 'F' if the inputs are all 'F', 'C' otherwise. 'K' means it should be as
             close to the layout as the inputs as is possible, including arbitrarily

--- a/src/felupe/field/_container.py
+++ b/src/felupe/field/_container.py
@@ -168,7 +168,7 @@ class FieldContainer:
             out = [None] * len(self.fields)
 
         grads = np.pad(grad, (0, len(self.fields) - 1))
-        orders = np.pad(order, (0, len(self.fields) - 1))
+        orders = order * len(self.fields)
 
         return tuple(
             f.extract(g, sym, add_identity=add_identity, dtype=dtype, out=res, order=od)

--- a/src/felupe/field/_planestrain.py
+++ b/src/felupe/field/_planestrain.py
@@ -67,7 +67,7 @@ class FieldPlaneStrain(Field):
         # init base Field
         super().__init__(region, dim=dim, values=values, dtype=dtype)
 
-    def _interpolate_2d(self, dtype=None, out=None):
+    def _interpolate_2d(self, dtype=None, out=None, order="C"):
         """Interpolate 2D field values at points and evaluate them at the
         integration points of all cells in the region."""
 
@@ -80,19 +80,21 @@ class FieldPlaneStrain(Field):
             self.region.h,
             dtype=dtype,
             out=out,
+            order=order,
         )
 
-    def interpolate(self, dtype=None, out=None):
+    def interpolate(self, dtype=None, out=None, order="C"):
         # out-argument is not supported
         # if out is not None:
         #     out = out[:2]
 
-        # extend dimension of in-plane 2d-gradient
+        # extend dimension of in-plane 2d-gradient (out-keyword can't be used here)
         return np.pad(
-            self._interpolate_2d(dtype=dtype, out=None), ((0, 1), (0, 0), (0, 0))
+            self._interpolate_2d(dtype=dtype, out=None, order=order),
+            ((0, 1), (0, 0), (0, 0)),
         )
 
-    def _grad_2d(self, sym=False, dtype=None, out=None):
+    def _grad_2d(self, sym=False, dtype=None, out=None, order="C"):
         """In-plane 2D gradient as partial derivative of field values at points
         w.r.t. the undeformed coordinates, evaluated at the integration points
         of all cells in the region. Optionally, the symmetric part of the
@@ -109,6 +111,12 @@ class FieldPlaneStrain(Field):
             A location into which the result is stored. If provided, it must have a
             shape that the inputs broadcast to. If not provided or None, a freshly-
             allocated array is returned (default is None).
+        order : {'C', 'F', 'A', 'K'}, optional
+            Controls the memory layout of the output. 'C' means it should be C
+            contiguous. 'F' means it should be Fortran contiguous, 'A' means it should
+            be 'F' if the inputs are all 'F', 'C' otherwise. 'K' means it should be as
+            close to the layout as the inputs as is possible, including arbitrarily
+            permuted axes. Default is 'C'.
 
         Returns
         -------
@@ -127,6 +135,7 @@ class FieldPlaneStrain(Field):
             self.region.dhdX,
             dtype=dtype,
             out=out,
+            order=order,
         )
 
         if sym:
@@ -134,7 +143,7 @@ class FieldPlaneStrain(Field):
         else:
             return g
 
-    def _hess_2d(self, dtype=None, out=None):
+    def _hess_2d(self, dtype=None, out=None, order="C"):
         r"""In-plane 2D Hessian as second partial derivative of field values w.r.t.
         undeformed coordinates, evaluated at the integration points of all cells in the
         region.
@@ -148,6 +157,12 @@ class FieldPlaneStrain(Field):
             A location into which the result is stored. If provided, it must have a
             shape that the inputs broadcast to. If not provided or None, a freshly-
             allocated array is returned (default is None).
+        order : {'C', 'F', 'A', 'K'}, optional
+            Controls the memory layout of the output. 'C' means it should be C
+            contiguous. 'F' means it should be Fortran contiguous, 'A' means it should
+            be 'F' if the inputs are all 'F', 'C' otherwise. 'K' means it should be as
+            close to the layout as the inputs as is possible, including arbitrarily
+            permuted axes. Default is 'C'.
 
         Returns
         -------
@@ -166,11 +181,12 @@ class FieldPlaneStrain(Field):
             self.region.d2hdXdX,
             dtype=dtype,
             out=out,
+            order=order,
         )
 
         return h
 
-    def grad(self, sym=False, dtype=None, out=None):
+    def grad(self, sym=False, dtype=None, out=None, order="C"):
         """3D-gradient as partial derivative of field values at points w.r.t.
         the undeformed coordinates, evaluated at the integration points of all
         cells in the region. Optionally, the symmetric part of the gradient is
@@ -193,6 +209,12 @@ class FieldPlaneStrain(Field):
             A location into which the result is stored. If provided, it must have a
             shape that the inputs broadcast to. If not provided or None, a freshly-
             allocated array is returned (default is None).
+        order : {'C', 'F', 'A', 'K'}, optional
+            Controls the memory layout of the output. 'C' means it should be C
+            contiguous. 'F' means it should be Fortran contiguous, 'A' means it should
+            be 'F' if the inputs are all 'F', 'C' otherwise. 'K' means it should be as
+            close to the layout as the inputs as is possible, including arbitrarily
+            permuted axes. Default is 'C'.
 
         Returns
         -------
@@ -206,15 +228,15 @@ class FieldPlaneStrain(Field):
         # if out is not None:
         #     out = out[:2, :2]
 
-        # extend dimension of in-plane 2d-gradient
+        # extend dimension of in-plane 2d-gradient (out-keyword can't be used here)
         g = np.pad(
-            self._grad_2d(sym=sym, dtype=dtype, out=None),
+            self._grad_2d(sym=sym, dtype=dtype, out=None, order=order),
             ((0, 1), (0, 1), (0, 0), (0, 0)),
         )
 
         return g
 
-    def hess(self, dtype=None, out=None):
+    def hess(self, dtype=None, out=None, order="C"):
         """3D-Hessian as second partial derivative of field values at points w.r.t.
         the undeformed coordinates, evaluated at the integration points of all
         cells in the region. Optionally, the symmetric part of the gradient is
@@ -231,6 +253,12 @@ class FieldPlaneStrain(Field):
             A location into which the result is stored. If provided, it must have a
             shape that the inputs broadcast to. If not provided or None, a freshly-
             allocated array is returned (default is None).
+        order : {'C', 'F', 'A', 'K'}, optional
+            Controls the memory layout of the output. 'C' means it should be C
+            contiguous. 'F' means it should be Fortran contiguous, 'A' means it should
+            be 'F' if the inputs are all 'F', 'C' otherwise. 'K' means it should be as
+            close to the layout as the inputs as is possible, including arbitrarily
+            permuted axes. Default is 'C'.
 
         Returns
         -------
@@ -240,9 +268,9 @@ class FieldPlaneStrain(Field):
             of all cells in the region.
         """
 
-        # extend dimension of in-plane 2d-hessian
+        # extend dimension of in-plane 2d-hessian (out-keyword can't be used here)
         h = np.pad(
-            self._hess_2d(dtype=dtype, out=None),
+            self._hess_2d(dtype=dtype, out=None, order=order),
             ((0, 1), (0, 1), (0, 1), (0, 0), (0, 0)),
         )
 

--- a/src/felupe/region/_region.py
+++ b/src/felupe/region/_region.py
@@ -344,8 +344,8 @@ class Region:
                 if uniform:
                     cells = cells[:1]
 
-                region.dXdr = np.ascontiguousarray(
-                    np.einsum("caI,aJqc->IJqc", region.mesh.points[cells], region.dhdr)
+                region.dXdr = np.einsum(
+                    "caI,aJqc->IJqc", region.mesh.points[cells], region.dhdr, order="C"
                 )
 
                 # determinant and inverse of dXdr


### PR DESCRIPTION
closes #857.

### Example
```pycon
>>> import felupe as fem
>>> 
>>> mesh = fem.Cube(n=11).triangulate().add_midpoints_volumes(cell_type="tetra")
>>> region = fem.RegionTetraMINI(mesh)
>>> field = fem.FieldsMixed(region, n=3)
>>> 
>>> field.extract()[0].flags
  C_CONTIGUOUS : True
  F_CONTIGUOUS : False
  OWNDATA : True
  WRITEABLE : True
  ALIGNED : True
  WRITEBACKIFCOPY : False
```