### PR TITLE
Fix wrong result of `ConstitutiveMaterial.plot()` if any stretch <= 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ All notable changes to this project will be documented in this file. The format 
 - Change default `np.einsum(..., order="K")` to `np.einsum(..., order="C")` in the methods of `Field`, `FieldAxisymmetric`, `FieldPlaneStrain` and `FieldContainer`.
 - Fix the number of points for non-disconnected dual meshes. This reduces the assembled (sparse) vector- and matrix-shapes, which are defined on mixed-fields.
 
+### Fixed
+- Fix wrong results of `ConstitutiveMaterial.plot()` if any stretch is non-physical, i.e. lower or equal zero. This raises an error now.
+
 ## [9.0.0] - 2024-09-06
 
 ### Added

--- a/src/felupe/constitution/_view.py
+++ b/src/felupe/constitution/_view.py
@@ -24,6 +24,15 @@ import numpy as np
 from ..math import det, linsteps
 
 
+def check_stretches(stretches):
+    "Check if any stretch is lower or equal zero."
+
+    if np.any(stretches <= 0.0):
+        raise ValueError("All stretches must greater than 0.")
+
+    return
+
+
 class PlotMaterial:
     "Plot force-stretch curves of constitutive material formulations."
 
@@ -203,7 +212,10 @@ class ViewMaterial(PlotMaterial):
         if stretches is None:
             stretches = self.ux
 
+        check_stretches(stretches)
+
         λ1 = stretches
+
         λ2 = λ3 = 1 / np.sqrt(λ1)
         eye = np.eye(3).reshape(3, 3, 1, 1)
 
@@ -264,6 +276,8 @@ class ViewMaterial(PlotMaterial):
 
         if stretches is None:
             stretches = self.ps
+
+        check_stretches(stretches)
 
         λ1 = stretches
         λ2 = np.ones_like(λ1)
@@ -326,6 +340,8 @@ class ViewMaterial(PlotMaterial):
 
         if stretches is None:
             stretches = self.bx
+
+        check_stretches(stretches)
 
         λ1 = λ2 = stretches
         λ3 = 1 / λ1**2
@@ -475,6 +491,8 @@ class ViewMaterialIncompressible(PlotMaterial):
         if stretches is None:
             stretches = self.ux
 
+        check_stretches(stretches)
+
         λ1 = stretches
         λ2 = λ3 = 1 / np.sqrt(λ1)
         eye = np.eye(3).reshape(3, 3, 1, 1)
@@ -511,6 +529,8 @@ class ViewMaterialIncompressible(PlotMaterial):
 
         if stretches is None:
             stretches = self.ps
+
+        check_stretches(stretches)
 
         λ1 = stretches
         λ2 = np.ones_like(λ1)
@@ -553,6 +573,8 @@ class ViewMaterialIncompressible(PlotMaterial):
 
         if stretches is None:
             stretches = self.bx
+
+        check_stretches(stretches)
 
         λ1 = λ2 = stretches
         λ3 = 1 / λ1**2

--- a/tests/test_constitution.py
+++ b/tests/test_constitution.py
@@ -707,6 +707,21 @@ def test_laplace():
     assert A[0].shape == (3, 3, 3, 3, 1, 1)
 
 
+def test_plot_negative_stretches():
+    stretches = np.linspace(-0.5, 1, 16)
+    umat = fem.NeoHooke(mu=1.0, bulk=2.0)
+
+    for incompressible in [False, True]:
+        with pytest.raises(ValueError):
+            umat.plot(ux=stretches, incompressible=incompressible)
+
+        with pytest.raises(ValueError):
+            umat.plot(bx=stretches, incompressible=incompressible)
+
+        with pytest.raises(ValueError):
+            umat.plot(ps=stretches, incompressible=incompressible)
+
+
 if __name__ == "__main__":
     test_nh()
     test_linear()
@@ -728,3 +743,4 @@ if __name__ == "__main__":
     test_lagrange()
     test_lagrange_statevars()
     test_laplace()
+    test_plot_negative_stretches()


### PR DESCRIPTION
this raises an error now to avoid the wrong results.

fixes #852 