### PR TITLE
Add Total-Lagrange and Updated-Lagrange decorators for JAX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ All notable changes to this project will be documented in this file. The format 
 - Add `math.inplane(A, vectors)` to return the in-plane components of a symmetric tensor `A`, where the plane is defined by its standard unit vectors.
 - Add `constitution.jax.Hyperelastic` as a feature-equivalent alternative to `Hyperelastic` with `jax` as backend.
 - Add `constitution.jax.Material` as a feature-equivalent alternative to `MaterialAD` with `jax` as backend.
-- Add the MORPH-material formulation for a JAX-based material `felupe.constitution.jax.models.lagrange.morph()`.
+- Add the material models for JAX-based materials `felupe.constitution.jax.models.hyperelastic.mooney_rivlin()`, `felupe.constitution.jax.models.hyperelastic.yeoh()`, `felupe.constitution.jax.models.hyperelastic.third_order_deformation()` and `felupe.constitution.jax.models.lagrange.morph()`.
+- Add `felupe.constitution.jax.total_lagrange()` and `felupe.constitution.jax.updated_lagrange()` function decorators for JAX materials.
 
 ### Changed
 - Change default `np.einsum(..., order="K")` to `np.einsum(..., order="C")` in the methods of `Field`, `FieldAxisymmetric`, `FieldPlaneStrain` and `FieldContainer`.

--- a/docs/felupe/constitution/autodiff/jax.rst
+++ b/docs/felupe/constitution/autodiff/jax.rst
@@ -13,6 +13,16 @@ This page contains material model formulations with automatic differentiation us
    
    constitution.jax.Hyperelastic
    constitution.jax.Material
+   constitution.jax.total_lagrange
+   constitution.jax.updated_lagrange
+
+**Material Models for** :class:`felupe.constitution.jax.Hyperelastic`
+
+These material model formulations are defined by a strain energy density function.
+
+.. autosummary::
+
+   felupe.constitution.jax.models.hyperelastic.mooney_rivlin
 
 **Material Models for** :class:`felupe.constitution.jax.Material`
 
@@ -37,6 +47,12 @@ This page contains material model formulations with automatic differentiation us
    :members:
    :undoc-members:
    :inherited-members:
+
+.. autofunction:: felupe.constitution.jax.total_lagrange
+
+.. autofunction:: felupe.constitution.jax.updated_lagrange
+
+.. autofunction:: felupe.constitution.jax.models.hyperelastic.mooney_rivlin
 
 .. autofunction:: felupe.constitution.jax.models.lagrange.morph
 

--- a/docs/felupe/constitution/autodiff/jax.rst
+++ b/docs/felupe/constitution/autodiff/jax.rst
@@ -23,6 +23,8 @@ These material model formulations are defined by a strain energy density functio
 .. autosummary::
 
    felupe.constitution.jax.models.hyperelastic.mooney_rivlin
+   felupe.constitution.jax.models.hyperelastic.third_order_deformation
+   felupe.constitution.jax.models.hyperelastic.yeoh
 
 **Material Models for** :class:`felupe.constitution.jax.Material`
 
@@ -53,6 +55,10 @@ These material model formulations are defined by a strain energy density functio
 .. autofunction:: felupe.constitution.jax.updated_lagrange
 
 .. autofunction:: felupe.constitution.jax.models.hyperelastic.mooney_rivlin
+
+.. autofunction:: felupe.constitution.jax.models.hyperelastic.third_order_deformation
+
+.. autofunction:: felupe.constitution.jax.models.hyperelastic.yeoh
 
 .. autofunction:: felupe.constitution.jax.models.lagrange.morph
 

--- a/docs/tutorial/examples/extut01_getting_started.py
+++ b/docs/tutorial/examples/extut01_getting_started.py
@@ -24,6 +24,7 @@ cells with ``n`` points per axis. A numeric region, pre-defined for hexahedrons,
 created on the mesh. A vector-valued displacement field is initiated on the region.
 Next, a field container is created on top of the displacement field.
 """
+
 import felupe as fem
 
 mesh = fem.Cube(n=6)

--- a/docs/tutorial/examples/extut02_job.py
+++ b/docs/tutorial/examples/extut02_job.py
@@ -22,6 +22,7 @@ realistic analysis of rubber-like materials. Note that the bulk modulus is now a
 argument of the (nearly) incompressible solid body instead of the constitutive
 Neo-Hookean material definition.
 """
+
 import felupe as fem
 
 mesh = fem.Cube(n=6)

--- a/docs/tutorial/examples/extut03_building_blocks.py
+++ b/docs/tutorial/examples/extut03_building_blocks.py
@@ -23,6 +23,7 @@ Start setting up a problem in FElupe by the creation of a numeric :class:`~felup
 .. image:: examples/extut03_building_blocks_sketch.svg
    :width: 600px
 """
+
 # sphinx_gallery_thumbnail_number = -1
 import felupe as fem
 

--- a/examples/ex02_plate-with-hole.py
+++ b/examples/ex02_plate-with-hole.py
@@ -21,6 +21,7 @@ over the hole.
 .. image:: ../../examples/ex02_plate-with-hole_sketch.svg
    :width: 400px
 """
+
 # sphinx_gallery_thumbnail_number = -2
 h = 1
 L = 2

--- a/examples/ex03_plasticity.py
+++ b/examples/ex03_plasticity.py
@@ -22,6 +22,7 @@ First, let's create a meshed cube out of hexahedron cells with ``n=(16, 6, 6)`` 
 per axis. A three-dimensional vector-valued displacement field is initiated on the
 numeric region.
 """
+
 import numpy as np
 
 import felupe as fem

--- a/examples/ex04_balloon.py
+++ b/examples/ex04_balloon.py
@@ -39,6 +39,7 @@ hyperelastic material formulation, see Eq. :eq:`neo-hookean-strain-energy`.
        \text{tr}(\boldsymbol{C}) - \ln(\det(\boldsymbol{C})) 
    \right)
 """
+
 # sphinx_gallery_thumbnail_number = -1
 import contique
 import numpy as np

--- a/examples/ex05_rubber-metal-bushing.py
+++ b/examples/ex05_rubber-metal-bushing.py
@@ -24,6 +24,7 @@ Elastic bearing with torsional loading
 An elastic bearing is subjected to combined multiaxial radial-torsional-cardanic
 loading. First the meshes for the rubber and the metal sheet rings are created.
 """
+
 # sphinx_gallery_thumbnail_number = -2
 import numpy as np
 import pypardiso

--- a/examples/ex06_rubber-metal-spring.py
+++ b/examples/ex06_rubber-metal-spring.py
@@ -24,6 +24,7 @@ a rubber-metal spring is loaded by an external axial and lateral displacement.
 Simplified elastic-to-rigid contact definitions simulate the end stops caused by steel
 plates at the bottom and the top in direction :math:`z`.
 """
+
 # sphinx_gallery_thumbnail_number = -3
 import numpy as np
 import pypardiso

--- a/examples/ex07_engine-mount.py
+++ b/examples/ex07_engine-mount.py
@@ -29,6 +29,7 @@ example:
 * a `mesh for the air <../_static/ex07_engine-mount_mesh-air.vtk>`_ inside the
   engine mount.
 """
+
 # sphinx_gallery_thumbnail_number = -1
 import numpy as np
 

--- a/examples/ex08_shear.py
+++ b/examples/ex08_shear.py
@@ -37,6 +37,7 @@ constraint (MPC). By default, FElupe stores points not connected to any cells in
 :attr:`Mesh.points_without_cells` and adds them to the list of inactive
 degrees of freedom. Hence, we have to drop our MPC-centerpoint from that list.
 """
+
 # sphinx_gallery_thumbnail_number = -2
 import numpy as np
 

--- a/examples/ex11_notch-stress.py
+++ b/examples/ex11_notch-stress.py
@@ -26,6 +26,7 @@ the stress tensor is projected to the mesh-points and its maximum principal valu
 implemented and hence, the quadratic wedges in the mesh are converted to quadratic
 hexahedrons.
 """
+
 # sphinx_gallery_thumbnail_number = -1
 import numpy as np
 import pypardiso

--- a/examples/ex13_morph-rubber-wheel.py
+++ b/examples/ex13_morph-rubber-wheel.py
@@ -96,6 +96,7 @@ this example.
     variables are stored in the solid body.
 
 """
+
 # sphinx_gallery_thumbnail_number = -1
 # sphinx_gallery_start_ignore
 PYVISTA_GALLERY_FORCE_STATIC_IN_DOCUMENT = True

--- a/examples/ex14_hyperelasticity.py
+++ b/examples/ex14_hyperelasticity.py
@@ -13,6 +13,7 @@ Best-fit Hyperelastic Material Parameters
 The :func:`Extended Tube <felupe.extended_tube>` material model formulation [1]_ is
 best-fitted on Treloar's uniaxial and biaxial tension data [2]_.
 """
+
 import numpy as np
 import tensortrax.math as tm
 

--- a/examples/ex15_hexmesh-metacone.py
+++ b/examples/ex15_hexmesh-metacone.py
@@ -8,6 +8,7 @@ Script-based Hex-meshing
    
    * create a :class:`~felupe.MeshContainer` for meshes associated to two materials
 """
+
 import numpy as np
 
 import felupe as fem

--- a/examples/ex16_deeplearning-torch.py
+++ b/examples/ex16_deeplearning-torch.py
@@ -22,6 +22,7 @@ completed substep. Only very few substeps are used to run the simulation.
       
       pip install torch
 """
+
 # sphinx_gallery_thumbnail_number = -1
 import numpy as np
 

--- a/examples/ex20_third-medium-contact.py
+++ b/examples/ex20_third-medium-contact.py
@@ -15,6 +15,7 @@ based regularization [2]_. First, let's create sub meshes with quad cells for th
 body. All sub meshes are merged by stacking the meshes of the
 :class:`mesh container <felupe.MeshContainer>` into a :class:`mesh <felupe.Mesh>`.
 """
+
 import numpy as np
 
 import felupe as fem

--- a/src/felupe/constitution/jax/__init__.py
+++ b/src/felupe/constitution/jax/__init__.py
@@ -2,5 +2,14 @@ from . import models
 from ._hyperelastic import Hyperelastic
 from ._material import Material
 from ._tools import vmap
+from ._total_lagrange import total_lagrange
+from ._updated_lagrange import updated_lagrange
 
-__all__ = ["Hyperelastic", "Material", "models", "vmap"]
+__all__ = [
+    "Hyperelastic",
+    "Material",
+    "models",
+    "total_lagrange",
+    "updated_lagrange",
+    "vmap",
+]

--- a/src/felupe/constitution/jax/_total_lagrange.py
+++ b/src/felupe/constitution/jax/_total_lagrange.py
@@ -1,0 +1,78 @@
+# -*- coding: utf-8 -*-
+"""
+This file is part of FElupe.
+
+FElupe is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+FElupe is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with FElupe.  If not, see <http://www.gnu.org/licenses/>.
+"""
+from functools import wraps
+
+
+def total_lagrange(material):
+    r"""Decorate a second Piola-Kirchhoff stress Total-Lagrange material formulation as
+    a first Piola-Kirchoff stress function.
+
+    Notes
+    -----
+    ..  math::
+
+        \delta \psi = \boldsymbol{F} \boldsymbol{S} : \delta \boldsymbol{F}
+
+    Examples
+    --------
+    >>> import felupe as fem
+    >>> import felupe.constitution.jax as mat
+    >>> import jax.numpy as jnp
+    >>>
+    >>> @mat.total_lagrange
+    >>> def neo_hooke_total_lagrange(F, mu=1):
+    >>>     C = F.T @ F
+    >>>     dev = lambda C: C - jnp.trace(C) / 3 * jnp.eye(3)
+    >>>     S = mu * dev(jnp.linalg.det(C)**(-1/3) * C) @ jnp.linalg.inv(C)
+    >>>     return S
+    >>>
+    >>> umat = mat.Material(neo_hooke_total_lagrange, mu=1)
+
+    See Also
+    --------
+    felupe.constitution.jax.Hyperelastic : A hyperelastic material definition with a
+        given function for the strain energy density function per unit undeformed volume
+        with Automatic Differentiation provided by jax.
+    felupe.constitution.jax.Material : A material definition with a given function for
+        the partial derivative of the strain energy function w.r.t. the deformation
+        gradient tensor with Automatic Differentiation provided by jax.
+    """
+    from jax import Array
+
+    @wraps(material)
+    def first_piola_kirchhoff_stress(F, *args, **kwargs):
+        # evaluate the second Piola-Kirchhoff stress
+        res = material(F, *args, **kwargs)
+
+        # check if the material formulation returns state variables and extract
+        # the second Piola-Kirchhoff stress tensor
+        if isinstance(res, Array):
+            S = res
+            statevars_new = None
+        else:
+            S, statevars_new = res
+
+        # first Piola-Kirchhoff stress tensor
+        P = F @ S
+
+        if statevars_new is None:
+            return P
+        else:
+            return P, statevars_new
+
+    return first_piola_kirchhoff_stress

--- a/src/felupe/constitution/jax/_updated_lagrange.py
+++ b/src/felupe/constitution/jax/_updated_lagrange.py
@@ -1,0 +1,81 @@
+# -*- coding: utf-8 -*-
+"""
+This file is part of FElupe.
+
+FElupe is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+FElupe is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with FElupe.  If not, see <http://www.gnu.org/licenses/>.
+"""
+from functools import wraps
+
+
+def updated_lagrange(material):
+    r"""Decorate a Cauchy-stress Updated-Lagrange material formulation as a first Piola-
+    Kirchoff stress function.
+
+    Notes
+    -----
+    ..  math::
+
+        \delta \psi =  J \boldsymbol{\sigma} \boldsymbol{F}^{-T} : \delta \boldsymbol{F}
+
+    Examples
+    --------
+    >>> import felupe as fem
+    >>> import felupe.constitution.jax as mat
+    >>> import jax.numpy as jnp
+    >>>
+    >>> @fem.updated_lagrange
+    >>> def neo_hooke_updated_lagrange(F, mu=1):
+    >>>     J = jnp.linalg.det(F)
+    >>>     b = F @ F.T
+    >>>     dev = lambda b: b - jnp.trace(b) / 3 * jnp.eye(3)
+    >>>     τ = mu * dev(J**(-2/3) * b)
+    >>>     return τ / J
+    >>>
+    >>> umat = mat.Material(neo_hooke_updated_lagrange, mu=1)
+
+    See Also
+    --------
+    felupe.constitution.jax.Hyperelastic : A hyperelastic material definition with a
+        given function for the strain energy density function per unit undeformed volume
+        with Automatic Differentiation provided by jax.
+    felupe.constitution.jax.Material : A material definition with a given function for
+        the partial derivative of the strain energy function w.r.t. the deformation
+        gradient tensor with Automatic Differentiation provided by jax.
+    """
+    import jax.numpy as jnp
+    from jax import Array
+
+    @wraps(material)
+    def first_piola_kirchhoff_stress(F, *args, **kwargs):
+        # evaluate the Cauchy stress
+        res = material(F, *args, **kwargs)
+
+        # check if the material formulation returns state variables and extract
+        # the Cauchy stress tensor
+        if isinstance(res, Array):
+            σ = res
+            statevars_new = None
+        else:
+            σ, statevars_new = res
+
+        # first Piola-Kirchhoff stress tensor
+        J = jnp.linalg.det(F)
+        P = J * σ @ jnp.linalg.inv(F).T
+
+        if statevars_new is None:
+            return P
+        else:
+            return P, statevars_new
+
+    return first_piola_kirchhoff_stress

--- a/src/felupe/constitution/jax/models/hyperelastic/__init__.py
+++ b/src/felupe/constitution/jax/models/hyperelastic/__init__.py
@@ -1,5 +1,9 @@
 from ._mooney_rivlin import mooney_rivlin
+from ._third_order_deformation import third_order_deformation
+from ._yeoh import yeoh
 
 __all__ = [
     "mooney_rivlin",
+    "third_order_deformation",
+    "yeoh",
 ]

--- a/src/felupe/constitution/jax/models/hyperelastic/__init__.py
+++ b/src/felupe/constitution/jax/models/hyperelastic/__init__.py
@@ -1,0 +1,5 @@
+from ._mooney_rivlin import mooney_rivlin
+
+__all__ = [
+    "mooney_rivlin",
+]

--- a/src/felupe/constitution/jax/models/hyperelastic/_mooney_rivlin.py
+++ b/src/felupe/constitution/jax/models/hyperelastic/_mooney_rivlin.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+"""
+This file is part of FElupe.
+
+FElupe is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+FElupe is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with FElupe.  If not, see <http://www.gnu.org/licenses/>.
+"""
+from functools import wraps
+
+from ....tensortrax.models.hyperelastic import mooney_rivlin as mr
+
+
+@wraps(mr)
+def mooney_rivlin(C, C10, C01):
+    from jax.numpy import trace
+    from jax.numpy.linalg import det
+
+    J3 = det(C) ** (-1 / 3)
+    I1 = J3 * trace(C)
+    I2 = (I1**2 - J3**2 * trace(C @ C)) / 2
+    return C10 * (I1 - 3) + C01 * (I2 - 3)

--- a/src/felupe/constitution/jax/models/hyperelastic/_third_order_deformation.py
+++ b/src/felupe/constitution/jax/models/hyperelastic/_third_order_deformation.py
@@ -17,15 +17,21 @@ along with FElupe.  If not, see <http://www.gnu.org/licenses/>.
 """
 from functools import wraps
 
-from ....tensortrax.models.hyperelastic import mooney_rivlin as mooney_rivlin_docstring
+from ....tensortrax.models.hyperelastic import third_order_deformation as tod_docstring
 
 
-@wraps(mooney_rivlin_docstring)
-def mooney_rivlin(C, C10, C01):
+@wraps(tod_docstring)
+def third_order_deformation(C, C10, C01, C11, C20, C30):
     from jax.numpy import trace
     from jax.numpy.linalg import det
 
     J3 = det(C) ** (-1 / 3)
     I1 = J3 * trace(C)
     I2 = (I1**2 - J3**2 * trace(C @ C)) / 2
-    return C10 * (I1 - 3) + C01 * (I2 - 3)
+    return (
+        C10 * (I1 - 3)
+        + C01 * (I2 - 3)
+        + C11 * (I1 - 3) * (I2 - 3)
+        + C20 * (I1 - 3) ** 2
+        + C30 * (I1 - 3) ** 3
+    )

--- a/src/felupe/constitution/jax/models/hyperelastic/_yeoh.py
+++ b/src/felupe/constitution/jax/models/hyperelastic/_yeoh.py
@@ -17,15 +17,13 @@ along with FElupe.  If not, see <http://www.gnu.org/licenses/>.
 """
 from functools import wraps
 
-from ....tensortrax.models.hyperelastic import mooney_rivlin as mooney_rivlin_docstring
+from ....tensortrax.models.hyperelastic import yeoh as yeoh_docstring
 
 
-@wraps(mooney_rivlin_docstring)
-def mooney_rivlin(C, C10, C01):
+@wraps(yeoh_docstring)
+def yeoh(C, C10, C20, C30):
     from jax.numpy import trace
     from jax.numpy.linalg import det
 
-    J3 = det(C) ** (-1 / 3)
-    I1 = J3 * trace(C)
-    I2 = (I1**2 - J3**2 * trace(C @ C)) / 2
-    return C10 * (I1 - 3) + C01 * (I2 - 3)
+    I1 = det(C) ** (-1 / 3) * trace(C)
+    return C10 * (I1 - 3) + C20 * (I1 - 3) ** 2 + C30 * (I1 - 3) ** 3

--- a/src/felupe/constitution/jax/models/lagrange/_morph.py
+++ b/src/felupe/constitution/jax/models/lagrange/_morph.py
@@ -15,24 +15,26 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with FElupe.  If not, see <http://www.gnu.org/licenses/>.
 """
+from ..._total_lagrange import total_lagrange
 
 
+@total_lagrange
 def morph(F, statevars, p):
     r"""First Piola-Kirchhoff stress tensor of the
     `MORPH <https://doi.org/10.1016/s0749-6419(02)00091-8>`_ model formulation [1]_.
 
     Parameters
     ----------
-    F : jax.array
-        Right Cauchy-Green deformation tensor.
-    statevars : array
+    F : jax.Array
+        Deformation gradient tensor.
+    statevars : jax.Array
         Vector of stacked state variables (CTS, C, SA).
     p : list of float
         A list which contains the 8 material parameters.
 
     Notes
     -----
-    The MORPH material model is implemented as a first Piola-Kirchhoff stress-based
+    The MORPH material model is implemented as a second Piola-Kirchhoff stress-based
     formulation with automatic differentiation. The Tresca invariant of the distortional
     part of the right Cauchy-Green deformation tensor is used as internal state
     variable, see Eq. :eq:`morph-state`.
@@ -230,4 +232,4 @@ def morph(F, statevars, p):
     to_triu = lambda C: C[i, j]
     statevars_new = concatenate([array([CTS]), to_triu(C), to_triu(SA)])
 
-    return F @ S, statevars_new
+    return S, statevars_new

--- a/src/felupe/constitution/tensortrax/models/hyperelastic/_mooney_rivlin.py
+++ b/src/felupe/constitution/tensortrax/models/hyperelastic/_mooney_rivlin.py
@@ -80,8 +80,8 @@ def mooney_rivlin(C, C10, C01):
         :context:
 
         >>> umat = mat.Hyperelastic(
-        >>>     mat.models.hyperelastic.mooney_rivlin, C10=0.3, C01=0.8
-        >>> )
+        ...     mat.models.hyperelastic.mooney_rivlin, C10=0.3, C01=0.8
+        ... )
         >>> ax = umat.plot(incompressible=True)
 
     ..  pyvista-plot::

--- a/src/felupe/constitution/tensortrax/models/hyperelastic/_mooney_rivlin.py
+++ b/src/felupe/constitution/tensortrax/models/hyperelastic/_mooney_rivlin.py
@@ -27,7 +27,7 @@ def mooney_rivlin(C, C10, C01):
 
     Parameters
     ----------
-    C : tensortrax.Tensor
+    C : tensortrax.Tensor or jax.Array
         Right Cauchy-Green deformation tensor.
     C10 : float
         First material parameter associated to the first invariant.
@@ -66,13 +66,22 @@ def mooney_rivlin(C, C10, C01):
 
     Examples
     --------
+    First, choose the desired automatic differentiation backend
 
     ..  pyvista-plot::
         :context:
 
-        >>> import felupe as fem
-        >>>
-        >>> umat = fem.Hyperelastic(fem.mooney_rivlin, C10=0.3, C01=0.8)
+        >>> # import felupe.constitution.jax as mat
+        >>> import felupe.constitution.tensortrax as mat
+
+    and create the hyperelastic material.
+
+    ..  pyvista-plot::
+        :context:
+
+        >>> umat = mat.Hyperelastic(
+        >>>     mat.models.hyperelastic.mooney_rivlin, C10=0.3, C01=0.8
+        >>> )
         >>> ax = umat.plot(incompressible=True)
 
     ..  pyvista-plot::

--- a/src/felupe/constitution/tensortrax/models/hyperelastic/_third_order_deformation.py
+++ b/src/felupe/constitution/tensortrax/models/hyperelastic/_third_order_deformation.py
@@ -27,7 +27,7 @@ def third_order_deformation(C, C10, C01, C11, C20, C30):
 
     Parameters
     ----------
-    C : tensortrax.Tensor
+    C : tensortrax.Tensor or jax.Array
         Right Cauchy-Green deformation tensor.
     C10 : float
         Material parameter associated to the linear term of the first invariant.
@@ -78,14 +78,26 @@ def third_order_deformation(C, C10, C01, C11, C20, C30):
 
     Examples
     --------
+    First, choose the desired automatic differentiation backend
 
     ..  pyvista-plot::
         :context:
 
-        >>> import felupe as fem
-        >>>
-        >>> umat = fem.Hyperelastic(
-        ...     fem.third_order_deformation, C10=0.5, C01=0.1, C11=0.01, C20=-0.1, C30=0.02
+        >>> # import felupe.constitution.jax as mat
+        >>> import felupe.constitution.tensortrax as mat
+
+    and create the hyperelastic material.
+
+    ..  pyvista-plot::
+        :context:
+
+        >>> umat = mat.Hyperelastic(
+        ...     mat.models.hyperelastic.third_order_deformation,
+        ...     C10=0.5,
+        ...     C01=0.1,
+        ...     C11=0.01,
+        ...     C20=-0.1,
+        ...     C30=0.02,
         ... )
         >>> ax = umat.plot(incompressible=True)
 

--- a/src/felupe/constitution/tensortrax/models/hyperelastic/_yeoh.py
+++ b/src/felupe/constitution/tensortrax/models/hyperelastic/_yeoh.py
@@ -27,7 +27,7 @@ def yeoh(C, C10, C20, C30):
 
     Parameters
     ----------
-    C : tensortrax.Tensor
+    C : tensortrax.Tensor or jax.Array
         Right Cauchy-Green deformation tensor.
     C10 : float
         Material parameter associated to the linear term of the first invariant.
@@ -64,13 +64,22 @@ def yeoh(C, C10, C20, C30):
 
     Examples
     --------
+    First, choose the desired automatic differentiation backend
 
     ..  pyvista-plot::
         :context:
 
-        >>> import felupe as fem
-        >>>
-        >>> umat = fem.Hyperelastic(fem.yeoh, C10=0.5, C20=-0.1, C30=0.02)
+        >>> # import felupe.constitution.jax as mat
+        >>> import felupe.constitution.tensortrax as mat
+
+    and create the hyperelastic material.
+
+    ..  pyvista-plot::
+        :context:
+
+        >>> umat = mat.Hyperelastic(
+        ...     mat.models.hyperelastic.yeoh, C10=0.5, C20=-0.1, C30=0.02
+        ... )
         >>> ax = umat.plot(incompressible=True)
 
     ..  pyvista-plot::

--- a/src/felupe/constitution/tensortrax/models/lagrange/_morph.py
+++ b/src/felupe/constitution/tensortrax/models/lagrange/_morph.py
@@ -29,8 +29,8 @@ def morph(F, statevars, p):
 
     Parameters
     ----------
-    C : tensortrax.Tensor
-        Right Cauchy-Green deformation tensor.
+    F : tensortrax.Tensor
+        Deformation gradient tensor.
     statevars : array
         Vector of stacked state variables (CTS, C, SA).
     p : list of float

--- a/src/felupe/constitution/tensortrax/models/lagrange/_morph_representative_directions.py
+++ b/src/felupe/constitution/tensortrax/models/lagrange/_morph_representative_directions.py
@@ -28,8 +28,8 @@ def morph_representative_directions(F, statevars, p, ε=1e-8):
 
     Parameters
     ----------
-    C : tensortrax.Tensor
-        Right Cauchy-Green deformation tensor.
+    F : tensortrax.Tensor
+        Deformation gradient tensor.
     statevars : array
         Vector of stacked state variables (CTS, λ - 1, SA1, SA2).
     p : list of float
@@ -43,8 +43,9 @@ def morph_representative_directions(F, statevars, p, ε=1e-8):
         :context:
 
         >>> import felupe as fem
+        >>> import felupe.constitution.tensortrax as mat
         >>>
-        >>> umat = fem.MaterialAD(
+        >>> umat = mat.Material(
         ...     fem.morph_representative_directions,
         ...     p=[0.011, 0.408, 0.421, 6.85, 0.0056, 5.54, 5.84, 0.117],
         ...     nstatevars=84,

--- a/src/felupe/mesh/_discrete_geometry.py
+++ b/src/felupe/mesh/_discrete_geometry.py
@@ -102,7 +102,7 @@ class DiscreteGeometry:
             If the points of a mesh are modified and a region was already created with
             the mesh, it is important to re-evaluate (reload) the
             :class:`~felupe.Region`.
-        
+
         ..  pyvista-plot::
 
             >>> import felupe as fem

--- a/tests/test_constitution_jax.py
+++ b/tests/test_constitution_jax.py
@@ -102,14 +102,9 @@ def test_hyperelastic_jax_statevars():
         region = fem.RegionHexahedron(mesh)
         field = fem.FieldContainer([fem.Field(region, dim=3)])
 
-        boundaries, loadcase = fem.dof.uniaxial(field, clamped=True)
         solid = fem.SolidBody(umat=umat, field=field)
-
-        move = fem.math.linsteps([0, 1], num=3)
-        ramp = {boundaries["move"]: move}
-        step = fem.Step(items=[solid], ramp=ramp, boundaries=boundaries)
-        job = fem.Job(steps=[step])
-        job.evaluate(tol=1e-4)
+        solid.evaluate.gradient()
+        solid.evaluate.hessian()
 
     except ModuleNotFoundError:
         pass
@@ -134,14 +129,9 @@ def test_material_jax():
         region = fem.RegionHexahedron(mesh)
         field = fem.FieldContainer([fem.Field(region, dim=3)])
 
-        boundaries, loadcase = fem.dof.uniaxial(field, clamped=True)
         solid = fem.SolidBody(umat=umat, field=field)
-
-        move = fem.math.linsteps([0, 1], num=3)
-        ramp = {boundaries["move"]: move}
-        step = fem.Step(items=[solid], ramp=ramp, boundaries=boundaries)
-        job = fem.Job(steps=[step])
-        job.evaluate(tol=1e-4)
+        solid.evaluate.gradient()
+        solid.evaluate.hessian()
 
     except ModuleNotFoundError:
         pass
@@ -168,14 +158,9 @@ def test_material_jax_statevars():
         region = fem.RegionHexahedron(mesh)
         field = fem.FieldContainer([fem.Field(region, dim=3)])
 
-        boundaries, loadcase = fem.dof.uniaxial(field, clamped=True)
         solid = fem.SolidBody(umat=umat, field=field)
-
-        move = fem.math.linsteps([0, 1], num=3)
-        ramp = {boundaries["move"]: move}
-        step = fem.Step(items=[solid], ramp=ramp, boundaries=boundaries)
-        job = fem.Job(steps=[step])
-        job.evaluate(tol=1e-4)
+        solid.evaluate.gradient()
+        solid.evaluate.hessian()
 
     except ModuleNotFoundError:
         pass
@@ -192,14 +177,9 @@ def test_material_included_jax_statevars():
         region = fem.RegionHexahedron(mesh)
         field = fem.FieldContainer([fem.Field(region, dim=3)])
 
-        boundaries, loadcase = fem.dof.uniaxial(field, clamped=True)
         solid = fem.SolidBody(umat=umat, field=field)
-
-        move = fem.math.linsteps([0, 1], num=3)
-        ramp = {boundaries["move"]: move}
-        step = fem.Step(items=[solid], ramp=ramp, boundaries=boundaries)
-        job = fem.Job(steps=[step])
-        job.evaluate(tol=1e-4)
+        solid.evaluate.gradient()
+        solid.evaluate.hessian()
 
     except ModuleNotFoundError:
         pass

--- a/tests/test_constitution_jax.py
+++ b/tests/test_constitution_jax.py
@@ -62,15 +62,9 @@ def test_vmap():
 
 def test_hyperelastic_jax():
     try:
-        import jax.numpy as jnp
 
-        def W(C, C10, K):
-            I3 = jnp.linalg.det(C)
-            J = jnp.sqrt(I3)
-            I1 = I3 ** (-1 / 3) * jnp.trace(C)
-            return C10 * (I1 - 3) + K * (J - 1) ** 2 / 2
-
-        umat = fem.constitution.jax.Hyperelastic(W, C10=0.5, K=2.0, parallel=True)
+        W = mat.models.hyperelastic.mooney_rivlin
+        umat = mat.Hyperelastic(W, C10=0.4, C01=0.1, K=2.0, parallel=True)
         umat = mat.Hyperelastic(W, C10=0.5, K=2.0, jit=True)
         mesh = fem.Cube(n=2)
         region = fem.RegionHexahedron(mesh)

--- a/tests/test_constitution_jax.py
+++ b/tests/test_constitution_jax.py
@@ -125,13 +125,16 @@ def test_material_jax():
 
         umat = mat.Material(dWdF, C10=0.5, K=2.0, parallel=True)
         umat = mat.Material(dWdF, C10=0.5, K=2.0, jit=True)
-        mesh = fem.Cube(n=2)
-        region = fem.RegionHexahedron(mesh)
-        field = fem.FieldContainer([fem.Field(region, dim=3)])
 
-        solid = fem.SolidBody(umat=umat, field=field)
-        solid.evaluate.gradient()
-        solid.evaluate.hessian()
+        for fun in [dWdF, mat.updated_lagrange(dWdF), mat.total_lagrange(dWdF)]:
+            umat = mat.Material(dWdF, C10=0.5, K=2.0)
+            mesh = fem.Cube(n=2)
+            region = fem.RegionHexahedron(mesh)
+            field = fem.FieldContainer([fem.Field(region, dim=3)])
+
+            solid = fem.SolidBody(umat=umat, field=field)
+            solid.evaluate.gradient()
+            solid.evaluate.hessian()
 
     except ModuleNotFoundError:
         pass
@@ -153,14 +156,15 @@ def test_material_jax_statevars():
 
         dWdF.kwargs = {"C10": 0.5}
 
-        umat = mat.Material(dWdF, C10=0.5, K=2.0, nstatevars=1, jit=True)
-        mesh = fem.Cube(n=2)
-        region = fem.RegionHexahedron(mesh)
-        field = fem.FieldContainer([fem.Field(region, dim=3)])
+        for fun in [dWdF, mat.updated_lagrange(dWdF), mat.total_lagrange(dWdF)]:
+            umat = mat.Material(fun, C10=0.5, K=2.0, nstatevars=1, jit=True)
+            mesh = fem.Cube(n=2)
+            region = fem.RegionHexahedron(mesh)
+            field = fem.FieldContainer([fem.Field(region, dim=3)])
 
-        solid = fem.SolidBody(umat=umat, field=field)
-        solid.evaluate.gradient()
-        solid.evaluate.hessian()
+            solid = fem.SolidBody(umat=umat, field=field)
+            solid.evaluate.gradient()
+            solid.evaluate.hessian()
 
     except ModuleNotFoundError:
         pass

--- a/tests/test_constitution_jax.py
+++ b/tests/test_constitution_jax.py
@@ -62,22 +62,23 @@ def test_vmap():
 
 def test_hyperelastic_jax():
     try:
-
-        W = mat.models.hyperelastic.mooney_rivlin
-        umat = mat.Hyperelastic(W, C10=0.4, C01=0.1, K=2.0, parallel=True)
-        umat = mat.Hyperelastic(W, C10=0.5, K=2.0, jit=True)
         mesh = fem.Cube(n=2)
         region = fem.RegionHexahedron(mesh)
         field = fem.FieldContainer([fem.Field(region, dim=3)])
 
-        boundaries, loadcase = fem.dof.uniaxial(field, clamped=True)
-        solid = fem.SolidBody(umat=umat, field=field)
+        md = mat.models.hyperelastic
+        for W in [
+            md.mooney_rivlin,
+            md.yeoh,
+            md.third_order_deformation,
+        ]:
+            umat = mat.Hyperelastic(W, **W.kwargs)
+            solid = fem.SolidBody(umat=umat, field=field)
+            solid.evaluate.gradient()
+            solid.evaluate.hessian()
 
-        move = fem.math.linsteps([0, 1], num=3)
-        ramp = {boundaries["move"]: move}
-        step = fem.Step(items=[solid], ramp=ramp, boundaries=boundaries)
-        job = fem.Job(steps=[step])
-        job.evaluate(tol=1e-4)
+        umat = mat.Hyperelastic(W, **W.kwargs, parallel=True)
+        umat = mat.Hyperelastic(W, **W.kwargs, jit=True)
 
     except ModuleNotFoundError:
         pass
@@ -128,7 +129,7 @@ def test_material_jax():
             return P + K * (J - 1) * J * jnp.linalg.inv(C)
 
         umat = mat.Material(dWdF, C10=0.5, K=2.0, parallel=True)
-        umat = fem.constitution.jax.Material(dWdF, C10=0.5, K=2.0, jit=True)
+        umat = mat.Material(dWdF, C10=0.5, K=2.0, jit=True)
         mesh = fem.Cube(n=2)
         region = fem.RegionHexahedron(mesh)
         field = fem.FieldContainer([fem.Field(region, dim=3)])

--- a/tests/test_constitution_jax.py
+++ b/tests/test_constitution_jax.py
@@ -127,7 +127,7 @@ def test_material_jax():
         umat = mat.Material(dWdF, C10=0.5, K=2.0, jit=True)
 
         for fun in [dWdF, mat.updated_lagrange(dWdF), mat.total_lagrange(dWdF)]:
-            umat = mat.Material(dWdF, C10=0.5, K=2.0)
+            umat = mat.Material(fun, C10=0.5, K=2.0)
             mesh = fem.Cube(n=2)
             region = fem.RegionHexahedron(mesh)
             field = fem.FieldContainer([fem.Field(region, dim=3)])


### PR DESCRIPTION
- [x] Add the Mooney-Rivlin material for JAX (with a shared docstring from the tensortrax-version)
- [x] Add the Yeoh material for JAX (with a shared docstring from the tensortrax-version)
- [x] Add the Third-Order-Deformation material for JAX (with a shared docstring from the tensortrax-version)