### PR TITLE
Enable `jax.Hyperelastic(..., parallel=True)` with `jax.pmap` on quadrature-points axis

### DIFF
--- a/docs/felupe/constitution/autodiff.rst
+++ b/docs/felupe/constitution/autodiff.rst
@@ -15,12 +15,6 @@ automatic differentiation. The default backend is based on :mod:`tensortrax` whi
 with FElupe. For more computationally expensive material formulations, :mod:`jax` may
 be the preferred option.
 
-..  note::
-    JAX uses single-precision (32bit) data types by default. This requires to relax the
-    tolerance of :func:`~felupe.newtonrhapson` to ``tol=1e-4``. If required, JAX may be
-    enforced to use double-precision at startup with
-    ``jax.config.update("jax_enable_x64", True)``.
-
 It is straightforward to switch between these backends.
 
 ..  tab:: tensortrax (default)

--- a/docs/felupe/constitution/autodiff/jax.rst
+++ b/docs/felupe/constitution/autodiff/jax.rst
@@ -3,7 +3,30 @@
 Materials with Automatic Differentiation (JAX)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-This page contains material model formulations with automatic differentiation using :mod:`jax`.
+This page contains material model formulations with automatic differentiation using
+:mod:`jax`.
+
+..  note::
+
+    JAX uses single-precision (32bit) data types by default. This requires to relax the
+    tolerance of :func:`~felupe.newtonrhapson` to ``tol=1e-4``. If required, JAX may be
+    enforced to use double-precision at startup with
+    ``jax.config.update("jax_enable_x64", True)``.
+
+..  note::
+
+    The number of local XLA devices available must be greater or equal the number of the
+    parallel-mapped axis, i.e. the number of quadrature points per cell when used in
+    :class:`~felupe.constitution.jax.Material` and
+    :class:`~felupe.constitution.jax.Hyperelastic` along with ``parallel=True``. To use
+    the multiple cores of a CPU device as multiple local XLA devices, the XLA device
+    count must be defined at startup.
+    
+    ..  code-block:: python
+        
+        import os
+
+        os.environ["XLA_FLAGS"] = "--xla_force_host_platform_device_count=4"
 
 **Frameworks**
 

--- a/src/felupe/constitution/jax/_helpers.py
+++ b/src/felupe/constitution/jax/_helpers.py
@@ -23,7 +23,7 @@ import jax.numpy as jnp
 from jax.numpy.linalg import det
 
 
-def vmap(fun, in_axes=0, out_axes=0, **kwargs):
+def vmap(fun, in_axes=0, out_axes=0, method=jax.vmap, **kwargs):
     """Vectorizing map. Creates a function which maps ``fun`` over argument axes. This
     decorator treats all non-specified arguments and keyword-arguments as static.
 
@@ -74,19 +74,22 @@ def vmap(fun, in_axes=0, out_axes=0, **kwargs):
         static_argnums = len(args) + len(keyword_args) - len(in_axes_tuple)
         in_axes_new = (*in_axes_tuple, *([None] * static_argnums))
 
-        vfun = jax.vmap(fun, in_axes=in_axes_new, out_axes=out_axes, **kwargs)
+        vfun = method(fun, in_axes=in_axes_new, out_axes=out_axes, **kwargs)
 
         return vfun(*args, *keyword_args)
 
     return vmap_with_static_kwargs
 
 
-def vmap2(fun, in_axes=0, out_axes=0, **kwargs):
+def vmap2(fun, in_axes=[0, 0], out_axes=[0, 0], methods=[jax.vmap, jax.vmap], **kwargs):
     "Nested vectorizing map."
     return vmap(
-        vmap(fun, in_axes=in_axes, out_axes=out_axes, **kwargs),
-        in_axes=in_axes,
-        out_axes=out_axes,
+        vmap(
+            fun, in_axes=in_axes[0], out_axes=out_axes[0], method=methods[0], **kwargs
+        ),
+        in_axes=in_axes[1],
+        out_axes=out_axes[1],
+        method=methods[1],
         **kwargs,
     )
 

--- a/src/felupe/constitution/jax/_hyperelastic.py
+++ b/src/felupe/constitution/jax/_hyperelastic.py
@@ -44,8 +44,9 @@ class Hyperelastic(Material):
     jit : bool, optional
         A flag to invoke just-in-time compilation (default is True).
     parallel : bool, optional
-        A flag to invoke threaded strain energy density function evaluations (default
-        is False). Not implemented.
+        A flag to invoke parallel strain energy density function evaluations (default
+        is False). If True, the quadrature points are executed in parallel. The number
+        of devices must be greater or equal the number of quadrature points per cell.
     **kwargs : dict, optional
         Optional keyword-arguments for the strain energy density function.
 
@@ -170,7 +171,8 @@ class Hyperelastic(Material):
 
         methods = [jax.vmap, jax.vmap]
         if parallel:
-            methods[0] = jax.pmap
+            methods[0] = jax.pmap  # apply on quadrature-points
+            jit = False  # pmap uses jit
 
         self._grad = vmap2(
             jax.grad(self.fun, has_aux=has_aux),

--- a/tests/test_constitution_jax.py
+++ b/tests/test_constitution_jax.py
@@ -83,9 +83,7 @@ def test_hyperelastic_jax_statevars():
         I3 = jnp.linalg.det(C)
         J = jnp.sqrt(I3)
         I1 = I3 ** (-1 / 3) * jnp.trace(C)
-        statevars_new = I1.reshape(
-            1,
-        )
+        statevars_new = statevars.at[0].set(I1)
         return C10 * (I1 - 3) + K * (J - 1) ** 2 / 2, statevars_new
 
     W.kwargs = {"C10": 0.5}
@@ -134,9 +132,7 @@ def test_material_jax_statevars():
         dev = lambda C: C - jnp.trace(C) / 3 * jnp.eye(3)
 
         P = 2 * C10 * F @ dev(Cu) @ jnp.linalg.inv(C)
-        statevars_new = J.reshape(
-            1,
-        )
+        statevars_new = statevars.at[0].set(J)
         return P + K * (J - 1) * J * jnp.linalg.inv(C), statevars_new
 
     dWdF.kwargs = {"C10": 0.5}

--- a/tests/test_constitution_jax.py
+++ b/tests/test_constitution_jax.py
@@ -42,7 +42,7 @@ def test_vmap():
     vf = fem.constitution.jax.vmap(f)
     vg = fem.constitution.jax.vmap(g)
 
-    x = np.eye(3).reshape(1, 3, 3) * np.ones((10, 1, 1))
+    x = (np.eye(3).reshape(1, 1, 3, 3) * np.ones((10, 2, 1, 1))).T
 
     z = vf(x, a=1.0)
 
@@ -83,7 +83,9 @@ def test_hyperelastic_jax_statevars():
         I3 = jnp.linalg.det(C)
         J = jnp.sqrt(I3)
         I1 = I3 ** (-1 / 3) * jnp.trace(C)
-        statevars_new = I1
+        statevars_new = I1.reshape(
+            1,
+        )
         return C10 * (I1 - 3) + K * (J - 1) ** 2 / 2, statevars_new
 
     W.kwargs = {"C10": 0.5}
@@ -132,7 +134,9 @@ def test_material_jax_statevars():
         dev = lambda C: C - jnp.trace(C) / 3 * jnp.eye(3)
 
         P = 2 * C10 * F @ dev(Cu) @ jnp.linalg.inv(C)
-        statevars_new = J
+        statevars_new = J.reshape(
+            1,
+        )
         return P + K * (J - 1) * J * jnp.linalg.inv(C), statevars_new
 
     dWdF.kwargs = {"C10": 0.5}


### PR DESCRIPTION
This makes the Hyperelastic/Material JAX-classes with state variables a bit more unflexible: `-1`-batch axes are not allowed in `pmap` and hence, explicit axes (>0) must be specified. That means scalar-valued state variables must be converted to a length-1 array.

To use multiple cores of a CPU device as local XLA devices:

```python
import os

os.environ["XLA_FLAGS"] = "--xla_force_host_platform_device_count=4"
```