### PR TITLE
Add `FreeVibration(items, boundaries)`

### DIFF
--- a/docs/felupe/mechanics.rst
+++ b/docs/felupe/mechanics.rst
@@ -22,6 +22,7 @@ Mechanics
    Step
    Job
    CharacteristicCurve
+   FreeVibration
 
 **Point Load and Multi-Point Constraints**
 
@@ -83,6 +84,11 @@ Mechanics
    :show-inheritance:
 
 .. autoclass:: felupe.CharacteristicCurve
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. autoclass:: felupe.FreeVibration
    :members:
    :undoc-members:
    :show-inheritance:

--- a/src/felupe/__init__.py
+++ b/src/felupe/__init__.py
@@ -70,6 +70,7 @@ from .field import (
 from .mechanics import (
     CharacteristicCurve,
     FormItem,
+    FreeVibration,
     Job,
     MultiPointConstraint,
     MultiPointContact,
@@ -133,6 +134,7 @@ __all__ = [
     "tools",
     "Form",
     "FormItem",
+    "FreeVibration",
     "IntegralForm",
     "Basis",
     "Field",

--- a/src/felupe/mechanics/__init__.py
+++ b/src/felupe/mechanics/__init__.py
@@ -1,4 +1,5 @@
 from ._curve import CharacteristicCurve
+from ._free_vibration import FreeVibration
 from ._helpers import Assemble, Evaluate, Results, StateNearlyIncompressible
 from ._item import FormItem
 from ._job import Job
@@ -16,6 +17,7 @@ __all__ = [
     "Assemble",
     "CharacteristicCurve",
     "Evaluate",
+    "FreeVibration",
     "FormItem",
     "StateNearlyIncompressible",
     "Job",

--- a/src/felupe/mechanics/_free_vibration.py
+++ b/src/felupe/mechanics/_free_vibration.py
@@ -19,6 +19,7 @@ along with FElupe.  If not, see <http://www.gnu.org/licenses/>.
 import numpy as np
 from scipy.sparse import csr_matrix
 from scipy.sparse.linalg import eigsh
+
 from ..dof import partition
 
 

--- a/src/felupe/mechanics/_free_vibration.py
+++ b/src/felupe/mechanics/_free_vibration.py
@@ -1,0 +1,118 @@
+# -*- coding: utf-8 -*-
+"""
+This file is part of FElupe.
+
+FElupe is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+FElupe is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with FElupe.  If not, see <http://www.gnu.org/licenses/>.
+"""
+
+import numpy as np
+from scipy.sparse import csr_matrix
+from scipy.sparse.linalg import eigsh
+from ..dof import partition
+
+
+class FreeVibration:
+    """A Free-Vibration Step.
+
+    Parameters
+    ----------
+    items : list of SolidBody or SolidBodyNearlyIncompressible
+        A list of items with methods for the assembly of sparse stiffness and mass
+        matrices.
+    boundaries : dict of Boundary, optional
+        A dict with :class:`~felupe.Boundary` conditions (default is None).
+
+    Examples
+    --------
+    ..  pyvista-plot::
+
+        >>> import felupe as fem
+        >>> import numpy as np
+        >>> from scipy.sparse.linalg import eigsh
+        >>>
+        >>> mesh = fem.Rectangle(b=(5, 1), n=(50, 10))
+        >>> region = fem.RegionQuad(mesh)
+        >>> field = fem.FieldContainer([fem.FieldPlaneStrain(region, dim=2)])
+        >>>
+        >>> boundaries = dict(left=fem.Boundary(field[0], fx=0))
+        >>> dof0, dof1 = fem.dof.partition(field, boundaries)
+        >>>
+        >>> solid = fem.SolidBody(umat=fem.LinearElastic(E=2.5, nu=0.25), field=field)
+    """
+
+    def __init__(self, items, boundaries=None):
+        self.items = items
+
+        if boundaries is None:
+            boundaries = {}
+
+        self.boundaries = boundaries
+        self.eigenvalues = None
+        self.eigenvectors = None
+
+    def evaluate(self, x0=None, k=6, solver=eigsh, tol=0, **kwargs):
+        if x0 is not None:
+            x = x0
+        else:
+            x = self.items[0].field
+
+        # link field of items with global field
+        [item.field.link(x) for item in self.items]
+
+        # init matrix with shape from global field
+        shape = (np.sum(x.fieldsizes), np.sum(x.fieldsizes))
+        stiffness = csr_matrix(shape)
+        mass = csr_matrix(shape)
+
+        # assemble matrices
+        for item in self.items:
+            K = item.assemble.matrix(**kwargs)
+            M = item.assemble.mass()
+
+            if item.assemble.multiplier is not None:
+                K *= item.assemble.multiplier
+
+            # check and reshape matrices
+            if K.shape != stiffness.shape:
+                K.resize(*shape)
+
+            if M.shape != mass.shape:
+                M.resize(*shape)
+
+            # add matrices
+            stiffness += K
+            mass += M
+
+        dof0, self.dof1 = partition(x, self.boundaries)
+
+        K = stiffness[self.dof1][:, self.dof1]
+        M = mass[self.dof1][:, self.dof1]
+
+        self.eigenvalues, self.eigenvectors = solver(A=K, k=k, M=M, sigma=0, tol=tol)
+
+        return self
+
+    def extract(self, n=0, x0=None, inplace=True):
+        if x0 is not None:
+            x = x0
+        else:
+            x = self.items[0].field
+
+        if not inplace:
+            x = x.copy()
+
+        frequency = np.sqrt(self.eigenvalues[n]) / (2 * np.pi)
+        x[0].values.ravel()[self.dof1] = self.eigenvectors[:, n]
+
+        return x, frequency

--- a/src/felupe/mechanics/_free_vibration.py
+++ b/src/felupe/mechanics/_free_vibration.py
@@ -24,7 +24,7 @@ from ..dof import partition
 
 
 class FreeVibration:
-    """A Free-Vibration Step.
+    """A Free-Vibration Step/Job.
 
     Parameters
     ----------
@@ -33,6 +33,12 @@ class FreeVibration:
         matrices.
     boundaries : dict of Boundary, optional
         A dict with :class:`~felupe.Boundary` conditions (default is None).
+    
+    Notes
+    -----
+    ..  note::
+        
+        Boundary conditions with non-zero values are not supported.
 
     Examples
     --------
@@ -40,16 +46,17 @@ class FreeVibration:
 
         >>> import felupe as fem
         >>> import numpy as np
-        >>> from scipy.sparse.linalg import eigsh
         >>>
         >>> mesh = fem.Rectangle(b=(5, 1), n=(50, 10))
         >>> region = fem.RegionQuad(mesh)
         >>> field = fem.FieldContainer([fem.FieldPlaneStrain(region, dim=2)])
         >>>
         >>> boundaries = dict(left=fem.Boundary(field[0], fx=0))
-        >>> dof0, dof1 = fem.dof.partition(field, boundaries)
-        >>>
-        >>> solid = fem.SolidBody(umat=fem.LinearElastic(E=2.5, nu=0.25), field=field)
+        >>> solid = fem.SolidBody(fem.LinearElastic(E=2.5, nu=0.25), field, density=1.0)
+        >>> modal = fem.FreeVibration(items=[solid], boundaries=boundaries).evaluate()
+        >>> 
+        >>> eigenvector, frequency = modal.extract(n=4, inplace=True)
+        >>> solid.plot("Stress", component=0).show()
     """
 
     def __init__(self, items, boundaries=None):

--- a/src/felupe/mechanics/_solidbody.py
+++ b/src/felupe/mechanics/_solidbody.py
@@ -398,13 +398,13 @@ class SolidBody(Solid):
         return dot(P, transpose(F)) / J
 
     def _mass(self, density=None):
-        
+
         if density is None:
             density = self.density
-        
+
         field = self.field[0].as_container()
         dim = field[0].dim
-        
+
         form = self._form(
             fun=[density * np.eye(dim).reshape(dim, dim, 1, 1)],
             v=field,
@@ -413,5 +413,5 @@ class SolidBody(Solid):
             grad_v=[False],
             grad_u=[False],
         )
-        
+
         return form.assemble()

--- a/src/felupe/mechanics/_solidbody.py
+++ b/src/felupe/mechanics/_solidbody.py
@@ -132,6 +132,8 @@ class SolidBody(Solid):
         A field container with one or more fields.
     statevars : ndarray or None, optional
         Array of initial internal state variables (default is None).
+    density : float or None, optional
+        The density of the solid body.
 
     Notes
     -----
@@ -209,9 +211,10 @@ class SolidBody(Solid):
         methods for the assembly of sparse vectors/matrices.
     """
 
-    def __init__(self, umat, field, statevars=None):
+    def __init__(self, umat, field, statevars=None, density=None):
         self.umat = umat
         self.field = field
+        self.density = density
 
         self.results = Results(stress=True, elasticity=True)
         self.results.kinematics = self._extract(self.field)
@@ -364,9 +367,14 @@ class SolidBody(Solid):
 
         return dot(P, transpose(F)) / J
 
-    def _mass(self, density=1.0):
+    def _mass(self, density=None):
+        
+        if density is None:
+            density = self.density
+        
         field = self.field[0].as_container()
         dim = field[0].dim
+        
         form = self._form(
             fun=[density * np.eye(dim).reshape(dim, dim, 1, 1)],
             v=field,
@@ -375,4 +383,5 @@ class SolidBody(Solid):
             grad_v=[False],
             grad_u=[False],
         )
+        
         return form.assemble()

--- a/src/felupe/mechanics/_solidbody_incompressible.py
+++ b/src/felupe/mechanics/_solidbody_incompressible.py
@@ -56,6 +56,8 @@ class SolidBodyNearlyIncompressible(Solid):
         A valid initial state for a (nearly) incompressible solid (default is None).
     statevars : ndarray or None, optional
         Array of initial internal state variables (default is None).
+    density : float or None, optional
+        The density of the solid body.
 
     Notes
     -----
@@ -315,10 +317,11 @@ class SolidBodyNearlyIncompressible(Solid):
         for (nearly) incompressible solid bodies.
     """
 
-    def __init__(self, umat, field, bulk, state=None, statevars=None):
+    def __init__(self, umat, field, bulk, state=None, statevars=None, density=None):
         self.umat = umat
         self.field = field
         self.bulk = bulk
+        self.density = density
 
         self._area_change = AreaChange()
         self._form = IntegralForm
@@ -540,9 +543,13 @@ class SolidBodyNearlyIncompressible(Solid):
 
         return dot(P, transpose(F)) / J
 
-    def _mass(self, density=1.0):
+    def _mass(self, density=None):
+        if density is None:
+            density = self.density
+
         field = self.field[0].as_container()
         dim = field[0].dim
+
         form = self._form(
             fun=[density * np.eye(dim).reshape(dim, dim, 1, 1)],
             v=field,
@@ -551,4 +558,5 @@ class SolidBodyNearlyIncompressible(Solid):
             grad_v=[False],
             grad_u=[False],
         )
+
         return form.assemble()

--- a/tests/test_free_vibration.py
+++ b/tests/test_free_vibration.py
@@ -1,0 +1,40 @@
+import numpy as np
+import felupe as fem
+
+
+def test_free_vibration():
+    meshes = [
+        fem.Cube(a=(0, 0, 30), b=(50, 100, 35), n=(3, 6, 2)),
+        fem.Cube(a=(0, 0, 5), b=(50, 100, 30), n=(3, 6, 4)),
+        fem.Cube(a=(0, 0, 0), b=(50, 100, 5), n=(3, 6, 2)),
+    ]
+    container = fem.MeshContainer(meshes, merge=True)
+    mesh = container.stack()
+
+    regions = [fem.RegionHexahedron(m) for m in container.meshes]
+    fields = [
+        fem.FieldsMixed(regions[0], n=1),
+        fem.FieldsMixed(regions[1], n=3),
+        fem.FieldsMixed(regions[2], n=1),
+    ]
+
+    region = fem.RegionHexahedron(mesh)
+    field = fem.FieldContainer([fem.Field(region, dim=3), *fields[1][1:]])
+
+    boundaries = dict(left=fem.Boundary(field[0], fx=0))
+    rubber = fem.ThreeFieldVariation(fem.NeoHooke(mu=1, bulk=5000))
+    steel = fem.LinearElasticLargeStrain(2.1e5, 0.3)
+    solids = [
+        fem.SolidBody(umat=steel, field=fields[0], density=7.85e-9),
+        fem.SolidBody(umat=rubber, field=fields[1], density=1.5e-9),
+        fem.SolidBody(umat=steel, field=fields[2], density=7.85e-9),
+    ]
+
+    job = fem.FreeVibration(solids, boundaries).evaluate(x0=field)
+    new_field, frequency = job.extract(x0=field, n=-1, inplace=False)
+
+    assert np.isclose(new_field[0].values.max(), 358.08157)
+
+
+if __name__ == "__main__":
+    test_free_vibration()

--- a/tests/test_free_vibration.py
+++ b/tests/test_free_vibration.py
@@ -1,3 +1,30 @@
+# -*- coding: utf-8 -*-
+"""
+ _______  _______  ___      __   __  _______  _______ 
+|       ||       ||   |    |  | |  ||       ||       |
+|    ___||    ___||   |    |  | |  ||    _  ||    ___|
+|   |___ |   |___ |   |    |  |_|  ||   |_| ||   |___ 
+|    ___||    ___||   |___ |       ||    ___||    ___|
+|   |    |   |___ |       ||       ||   |    |   |___ 
+|___|    |_______||_______||_______||___|    |_______|
+
+This file is part of felupe.
+
+Felupe is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Felupe is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Felupe.  If not, see <http://www.gnu.org/licenses/>.
+
+"""
+
 import numpy as np
 
 import felupe as fem

--- a/tests/test_free_vibration.py
+++ b/tests/test_free_vibration.py
@@ -4,6 +4,20 @@ import felupe as fem
 
 
 def test_free_vibration():
+
+    mesh = fem.Cube(a=(0, 0, 5), b=(50, 100, 30), n=(3, 6, 4))
+    region = fem.RegionHexahedron(mesh)
+    field = fem.FieldContainer([fem.Field(region, dim=3)])
+
+    umat = fem.NeoHooke(mu=1, bulk=2)
+    solid = fem.SolidBody(umat=umat, field=field, density=1.5e-9)
+
+    job = fem.FreeVibration([solid]).evaluate(x0=field)
+    new_field, frequency = job.extract(x0=field, n=-1, inplace=False)
+
+
+def test_free_vibration_mixed():
+
     meshes = [
         fem.Cube(a=(0, 0, 30), b=(50, 100, 35), n=(3, 6, 2)),
         fem.Cube(a=(0, 0, 5), b=(50, 100, 30), n=(3, 6, 4)),
@@ -34,8 +48,7 @@ def test_free_vibration():
     job = fem.FreeVibration(solids, boundaries).evaluate(x0=field)
     new_field, frequency = job.extract(x0=field, n=-1, inplace=False)
 
-    assert np.isclose(new_field[0].values.max(), 358.08157)
-
 
 if __name__ == "__main__":
     test_free_vibration()
+    test_free_vibration_mixed()

--- a/tests/test_free_vibration.py
+++ b/tests/test_free_vibration.py
@@ -39,8 +39,8 @@ def test_free_vibration():
     umat = fem.NeoHooke(mu=1, bulk=2)
     solid = fem.SolidBody(umat=umat, field=field, density=1.5e-9)
 
-    job = fem.FreeVibration([solid]).evaluate(x0=field)
-    new_field, frequency = job.extract(x0=field, n=-1, inplace=False)
+    job = fem.FreeVibration([solid]).evaluate()
+    new_field, frequency = job.extract(n=-1, inplace=False)
 
 
 def test_free_vibration_mixed():

--- a/tests/test_free_vibration.py
+++ b/tests/test_free_vibration.py
@@ -1,4 +1,5 @@
 import numpy as np
+
 import felupe as fem
 
 

--- a/tests/test_mechanics.py
+++ b/tests/test_mechanics.py
@@ -235,7 +235,7 @@ def test_solidbody_incompressible():
 
     umat = fem.OgdenRoxburgh(fem.NeoHooke(mu=1), r=3, m=1, beta=0)
     b = fem.SolidBodyNearlyIncompressible(
-        umat=umat, field=u, bulk=5000, state=fem.StateNearlyIncompressible(u)
+        umat=umat, field=u, bulk=5000, state=fem.StateNearlyIncompressible(u), density=1.0
     )
 
     M = b.assemble.mass()

--- a/tests/test_mechanics.py
+++ b/tests/test_mechanics.py
@@ -39,7 +39,7 @@ def test_simple():
     r = fem.RegionHexahedron(m, uniform=True)
     u = fem.FieldContainer([fem.Field(r, dim=3)])
 
-    b = fem.SolidBody(umat, u)
+    b = fem.SolidBody(umat, u, density=1.0)
     r = b.assemble.vector()
 
     K = b.assemble.matrix()

--- a/tests/test_mechanics.py
+++ b/tests/test_mechanics.py
@@ -235,7 +235,11 @@ def test_solidbody_incompressible():
 
     umat = fem.OgdenRoxburgh(fem.NeoHooke(mu=1), r=3, m=1, beta=0)
     b = fem.SolidBodyNearlyIncompressible(
-        umat=umat, field=u, bulk=5000, state=fem.StateNearlyIncompressible(u), density=1.0
+        umat=umat,
+        field=u,
+        bulk=5000,
+        state=fem.StateNearlyIncompressible(u),
+        density=1.0,
     )
 
     M = b.assemble.mass()


### PR DESCRIPTION
with methods to `evaluate()` and `extract()` the n-th eigenvector to a field.

### Tasks
- [x] check for mixed-field solid bodies
- [x] test the performance for typical (10^5) degrees-of-freedom models

### Example
```python
import felupe as fem

mesh = fem.Rectangle(b=(5, 1), n=(50, 10))
region = fem.RegionQuad(mesh)
field = fem.FieldContainer([fem.FieldPlaneStrain(region, dim=2)])

boundaries = dict(left=fem.Boundary(field[0], fx=0))
solid = fem.SolidBody(umat=fem.LinearElastic(E=2.5, nu=0.25), field=field, density=1.0)

res = fem.FreeVibration(items=[solid], boundaries=boundaries).evaluate()
field, frequency = res.extract(n=4, inplace=True)

ax = solid.imshow("Stress", component=0)
ax.set_title(rf"Frequency $f_5$ = {frequency:.2} Hz")
```

![image](https://github.com/user-attachments/assets/fe4df36d-9d17-4a54-b453-e2431219d5a1)
