### PR TITLE
Enhance `Boundary`: Add support for multiaxial prescribed `value`-argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file. The format 
 - The first Piola-Kirchhoff stress tensor is evaluated if `ViewSolid(stress_type=None)`.
 - Autodetect the stress-type in `SolidBody.plot(name)` from `name`.
 - Enhance the `hello_world(axisymmetric=False, planestrain=False, curve=False, xdmf=False, container=False)` function with new arguments to customize the generated template script.
+- Enhance `Boundary` with added support for multiaxial prescribed values.
 
 ## [9.1.0] - 2024-11-23
 

--- a/src/felupe/dof/_tools.py
+++ b/src/felupe/dof/_tools.py
@@ -235,8 +235,21 @@ def apply(field, bounds, dof0=None):
         # get offset for field-dof of current boundary
         offset = offsets[[b.field == f for f in field.fields]]
 
+        if isinstance(b.value, np.ndarray):
+            # get size and broadcast the values if necessary
+            value = b.value
+            if b.dof.size != value.size:
+                if len(value.shape) == 1:
+                    value = value.reshape(1, -1)
+
+                value = np.broadcast_to(value, (b.points.size, b.value.shape[-1]))
+
+            value = value.ravel()
+        else:
+            value = b.value
+
         # set prescribed values
-        u.ravel()[b.dof + offset] = b.value
+        u.ravel()[b.dof + offset] = value
 
     if dof0 is None:
         return u

--- a/src/felupe/mechanics/_free_vibration.py
+++ b/src/felupe/mechanics/_free_vibration.py
@@ -33,11 +33,11 @@ class FreeVibration:
         matrices.
     boundaries : dict of Boundary, optional
         A dict with :class:`~felupe.Boundary` conditions (default is None).
-    
+
     Notes
     -----
     ..  note::
-        
+
         Boundary conditions with non-zero values are not supported.
 
     Examples
@@ -54,7 +54,7 @@ class FreeVibration:
         >>> boundaries = dict(left=fem.Boundary(field[0], fx=0))
         >>> solid = fem.SolidBody(fem.LinearElastic(E=2.5, nu=0.25), field, density=1.0)
         >>> modal = fem.FreeVibration(items=[solid], boundaries=boundaries).evaluate()
-        >>> 
+        >>>
         >>> eigenvector, frequency = modal.extract(n=4, inplace=True)
         >>> solid.plot("Stress", component=0).show()
     """

--- a/src/felupe/mechanics/_solidbody.py
+++ b/src/felupe/mechanics/_solidbody.py
@@ -398,7 +398,6 @@ class SolidBody(Solid):
         return dot(P, transpose(F)) / J
 
     def _mass(self, density=None):
-
         if density is None:
             density = self.density
 

--- a/src/felupe/tools/_hello_world.py
+++ b/src/felupe/tools/_hello_world.py
@@ -101,7 +101,6 @@ def hello_world(
     plot = "\n".join(plot)
 
     if not container:
-
         kwargs = ", ".join(kwargs)
 
         # fmt: off
@@ -126,7 +125,6 @@ def hello_world(
         # fmt: on
 
     else:
-
         kwargs.insert(0, "x0=field")
         kwargs = ", ".join(kwargs)
 

--- a/tests/test_dof.py
+++ b/tests/test_dof.py
@@ -145,6 +145,24 @@ def test_loadcase():
         assert "top" in sh[0]
 
 
+def test_boundary_multiaxial():
+    mesh = fem.Rectangle(n=3)
+    region = fem.RegionQuad(mesh)
+    field = fem.FieldContainer([fem.FieldPlaneStrain(region, dim=2)])
+
+    for value in [1.0, np.arange(1, 3), np.arange(1, 3).reshape(1, 2)]:
+        boundaries = dict(
+            left=fem.Boundary(field[0], fx=0),
+            right=fem.Boundary(field[0], fx=1, value=value),
+        )
+
+        dof0, dof1 = fem.dof.partition(field, boundaries)
+        ext0 = fem.dof.apply(field, boundaries, dof0)
+
+        assert ext0.shape == dof0.shape
+
+
 if __name__ == "__main__":
     test_boundary()
+    test_boundary_multiaxial()
     test_loadcase()

--- a/tests/test_free_vibration.py
+++ b/tests/test_free_vibration.py
@@ -31,7 +31,6 @@ import felupe as fem
 
 
 def test_free_vibration():
-
     mesh = fem.Cube(a=(0, 0, 5), b=(50, 100, 30), n=(3, 6, 4))
     region = fem.RegionHexahedron(mesh)
     field = fem.FieldContainer([fem.Field(region, dim=3)])
@@ -44,7 +43,6 @@ def test_free_vibration():
 
 
 def test_free_vibration_mixed():
-
     meshes = [
         fem.Cube(a=(0, 0, 30), b=(50, 100, 35), n=(3, 6, 2)),
         fem.Cube(a=(0, 0, 5), b=(50, 100, 30), n=(3, 6, 4)),


### PR DESCRIPTION
This PR closes #911.

Now it's possible to prescribe multiaxial values without manual broadcast+ravel required:

```python
import felupe as fem
import numpy as np

mesh = fem.Cube(n=6)
region = fem.RegionHexahedron(mesh)
field = fem.FieldContainer([fem.Field(region, dim=3)])

value = np.array([1.0, 2.0, 3.0])
boundaries = dict(
    left=fem.Boundary(field[0], fx=0),
    right=fem.Boundary(field[0], fx=1, value=value),
)

dof0, dof1 = fem.dof.partition(field, boundaries)
ext0 = fem.dof.apply(field, boundaries, dof0)
```