### PR TITLE
Enhance `FieldContainer.link()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file. The format 
 - Enhance the `hello_world(axisymmetric=False, planestrain=False, curve=False, xdmf=False, container=False)` function with new arguments to customize the generated template script.
 - Enhance `Boundary` with added support for multiaxial prescribed values.
 - Enhance `math.linsteps(..., values=0)` with default values except for the column `axis` if `axis` is not None.
+- Link all field-values to the values of the first field if no other field is given in `FieldContainer.link()`.
 
 ### Fixed
 - Fix `Boundary(..., mode="and")` by ignoring any undefined axis.

--- a/src/felupe/field/_container.py
+++ b/src/felupe/field/_container.py
@@ -210,10 +210,14 @@ class FieldContainer:
         "Return a copy of the field."
         return deepcopy(self)
 
-    def link(self, other_field):
+    def link(self, other_field=None):
         "Link value array of other field."
-        for field, newfield in zip(self.fields, other_field.fields):
-            field.values = newfield.values
+        if other_field is None:
+            for u in self.fields[1:]:  # link n-to-1 (all-to-first)
+                u.values = self.fields[0].values
+        else:
+            for field, newfield in zip(self.fields, other_field.fields):  # link 1-to-1
+                field.values = newfield.values
 
     def view(self, point_data=None, cell_data=None, cell_type=None, project=None):
         """View the field with optional given dicts of point- and cell-data items.

--- a/tests/test_field.py
+++ b/tests/test_field.py
@@ -247,9 +247,26 @@ def test_view():
     # ax = mesh.imshow()
 
 
+def test_link():
+    mesh = fem.Cube(n=2)
+    region = fem.RegionHexahedron(mesh)
+    field = fem.Field(region, dim=3) & fem.Field(region, dim=1)
+    field.link()
+
+    assert field[0].values is field[1].values
+
+    field1 = fem.Field(region, dim=3) & fem.Field(region, dim=1)
+    field2 = fem.Field(region, dim=3) & fem.Field(region, dim=1)
+    field1.link(field2)
+
+    assert field1[0].values is field2[0].values
+    assert field1[1].values is field2[1].values
+
+
 if __name__ == "__main__":
     test_axi()
     test_3d()
     test_3d_mixed()
     test_mixed_lagrange()
     test_view()
+    test_link()


### PR DESCRIPTION
This PR enhances `FieldContainer.link()`. If no other field is given, all field values of the container are linked to the values of the first field.