### PR TITLE
Add `SolidBody(..., block=True, apply=None)`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file. The format 
 - Add a free-vibration modal analysis Step/Job `FreeVibration(items, boundaries)` with methods to evaluate `FreeVibration.evaluate()` and to extract `field, frequency = FreeVibration.extract(n)` its n-th result.
 - Add `Boundary.plot()` to plot the points and prescribed directions of a boundary.
 - Add `BoundaryDict` as a subclassed dict with methods to `plot()`, `screenshot()` and `imshow()`.
+- Add a new argument to apply a callable on the assembled vector/matrix of a solid body, `SolidBody(..., apply=None)`. This may be used to sum the list of sub-blocks instead of stacking them together, `SolidBody(..., block=False, apply=None)`. This is useful for mixed formulations where both the deformation gradient and the displacement values are required.
 
 ### Changed
 - The first Piola-Kirchhoff stress tensor is evaluated if `ViewSolid(stress_type=None)`.
@@ -17,6 +18,7 @@ All notable changes to this project will be documented in this file. The format 
 - Enhance `Boundary` with added support for multiaxial prescribed values.
 - Enhance `math.linsteps(..., values=0)` with default values except for the column `axis` if `axis` is not None.
 - Link all field-values to the values of the first field if no other field is given in `FieldContainer.link()`.
+- Change the default arguments from `block=True` to `block=None` in `SolidBody.assemble.vector(block=None)` and `SolidBody.assemble.matrix(block=None)` and define `block` on creation, `SolidBody(..., block=True)` instead.
 
 ### Fixed
 - Fix `Boundary(..., mode="and")` by ignoring any undefined axis.

--- a/src/felupe/assembly/_integral.py
+++ b/src/felupe/assembly/_integral.py
@@ -273,13 +273,12 @@ class IntegralForm:
                 if i != j:
                     K[j, i] = res[a].T
 
-            return bmat(K).tocsr()
+            res = bmat(K).tocsr()
 
         if block and self.mode == 1:
-            return vstack(res).tocsr()
+            res = vstack(res).tocsr()
 
-        else:
-            return res
+        return res
 
     def integrate(self, parallel=False, out=None):
         if out is None:

--- a/src/felupe/mechanics/_solidbody.py
+++ b/src/felupe/mechanics/_solidbody.py
@@ -169,6 +169,8 @@ class SolidBody(Solid):
         stacking sparse matrices vertically (row wise). Default is True.
     apply : callable or None, optional
         Apply a callable on the assembled vectors and sparse matrices. Default is None.
+    multiplier : float or None, optional
+        A scale factor for the assembled vector and matrix. Default is None.
 
     Notes
     -----
@@ -247,7 +249,14 @@ class SolidBody(Solid):
     """
 
     def __init__(
-        self, umat, field, statevars=None, density=None, block=True, apply=None
+        self,
+        umat,
+        field,
+        statevars=None,
+        density=None,
+        block=True,
+        apply=None,
+        multiplier=None,
     ):
         self.umat = umat
         self.field = field
@@ -273,7 +282,10 @@ class SolidBody(Solid):
             )
 
         self.assemble = Assemble(
-            vector=self._vector, matrix=self._matrix, mass=self._mass
+            vector=self._vector,
+            matrix=self._matrix,
+            mass=self._mass,
+            multiplier=multiplier,
         )
 
         self.evaluate = Evaluate(

--- a/tests/test_mechanics.py
+++ b/tests/test_mechanics.py
@@ -293,7 +293,7 @@ def test_solidbody_incompressible():
         assert np.allclose(t1, t2)
 
 
-def test_solidbody_axi():
+def test_solidbody_axi_incompressible():
     umat, u = pre_axi(bulk=None)
     b = fem.SolidBodyNearlyIncompressible(umat=umat, field=u, bulk=5000)
     b = fem.SolidBodyNearlyIncompressible(
@@ -338,7 +338,7 @@ def test_solidbody_axi():
         assert np.allclose(t1, t2)
 
 
-def test_solidbody_axi_incompressible():
+def test_solidbody_axi():
     umat, u = pre_axi()
     b = fem.SolidBody(umat=umat, field=u)
 
@@ -350,6 +350,9 @@ def test_solidbody_axi_incompressible():
 
         r2 = b.assemble.vector(**kwargs)
         assert np.allclose(r1.toarray(), r2.toarray())
+
+        r3 = b.assemble.vector(**kwargs, block=False, apply=sum)
+        assert np.allclose(r1.toarray(), r3.toarray())
 
         K1 = b.assemble.matrix(u, **kwargs)
         assert K1.shape == (18, 18)

--- a/tests/test_mechanics.py
+++ b/tests/test_mechanics.py
@@ -357,6 +357,9 @@ def test_solidbody_axi_incompressible():
         K2 = b.assemble.matrix(**kwargs)
         assert np.allclose(K1.toarray(), K2.toarray())
 
+        K3 = b.assemble.matrix(**kwargs, block=False, apply=sum)
+        assert np.allclose(K1.toarray(), K3.toarray())
+
         P1 = b.results.stress
         P2 = b.evaluate.gradient()
         P2 = b.evaluate.gradient(u)


### PR DESCRIPTION
to apply a final callable in `SolidBody.assemble.vector()` or `SolidBody.assemble.matrix()`.