### PR TITLE
Don't create a figure if error in `umat.plot()`

### DIFF
--- a/src/felupe/constitution/_view.py
+++ b/src/felupe/constitution/_view.py
@@ -72,11 +72,12 @@ class PlotMaterial:
         shear and biaxial tension."""
 
         import matplotlib.pyplot as plt
+        
+        data = self.evaluate()
 
         if ax is None:
             fig, ax = plt.subplots()
 
-        data = self.evaluate()
         for stretch, force, label in data:
             ax.plot(stretch, force, label=label, **kwargs)
 


### PR DESCRIPTION
See also #931 - this avoids unnecessary figures created in the tests. If non-physical stretches are present, no (empty) figure is created.