### PR TITLE
Enhance `mesh.interpolate_line(axis=None)`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ All notable changes to this project will be documented in this file. The format 
 - Change supported Python versions to 3.9 - 3.12.
 - Change the `dtype`-argument in `Region.astype(dtype)` from an optional to a required argument.
 - Make `tensortrax` an optional dependency (again). Now FElupe does only depend on NumPy and SciPy, all other extras are optional.
+- Enhance `mesh.interpolate_line(mesh, xi, axis=None, ...)` which by default uses a curve-progress variable when `axis=None`. The curve progress evaluation points `xi` must be within `0 <= xi <= 1`.
 
 ### Fixed
 - Fix the number of points for non-disconnected dual meshes. This reduces the assembled (sparse) vector- and matrix-shapes, which are defined on mixed-fields.

--- a/src/felupe/mesh/_interpolate.py
+++ b/src/felupe/mesh/_interpolate.py
@@ -19,7 +19,7 @@ along with FElupe.  If not, see <http://www.gnu.org/licenses/>.
 import numpy as np
 
 
-def interpolate_line(mesh, xi, axis, Interpolator=None, **kwargs):
+def interpolate_line(mesh, xi, axis=None, Interpolator=None, **kwargs):
     r"""Return an interpolated line mesh from an existing line mesh with provided
     interpolation points on a given axis.
 
@@ -28,13 +28,15 @@ def interpolate_line(mesh, xi, axis, Interpolator=None, **kwargs):
     mesh : Mesh
         A :class:`~felupe.Mesh` with cell-type ``line``.
     xi : ndarray
-        Points at which to interpolate data.
-    axis : int
-        The axis of the points at which the data will be interpolated.
+        Points at which to interpolate data. If axis is None, a normalized curve-
+        progress must be provided (:math:`0 \le \xi \le 1`).
+    axis : int or None, optional
+        The axis of the points at which the data will be interpolated. If None, a
+        normalized curve-progress is used. Default is None.
     Interpolator : callable or None, optional
         An interpolator class (default is :class:`scipy.interpolate.PchipInterpolator`).
     **kwargs : dict, optional
-        Optional keyword arguments are passed to the interpolator.
+        Optional keyword arguments are passed to the Interpolator.
 
     Returns
     -------
@@ -51,53 +53,70 @@ def interpolate_line(mesh, xi, axis, Interpolator=None, **kwargs):
 
         >>> import felupe as fem
         >>> import numpy as np
+        >>> from scipy.interpolate import CubicSpline
         >>>
-        >>> mesh = fem.mesh.Line(n=5).expand(n=1)
+        >>> mesh = fem.mesh.Line(b=1.0, n=5).expand(n=1)
         >>> t = mesh.x.copy()
-        >>> mesh.points[:, 0] = np.sin(np.pi / 2 * t)
-        >>> mesh.points[:, 1] = np.cos(np.pi / 2 * t)
+        >>> mesh.points[:, 0] = np.sin(2 * np.pi * t)
+        >>> mesh.points[:, 1] = np.cos(2 * np.pi * t)
         >>>
-        >>> mesh.plot(style="points", color="black").show()
+        >>> mesh_new = fem.mesh.interpolate_line(
+        ...     mesh, xi=np.linspace(0, 1), Interpolator=CubicSpline, bc_type="periodic"
+        ... )
+        >>>
+        >>> mesh_new.plot(
+        ...     plotter=mesh.plot(style="points", color="red", point_size=15),
+        ...     color="black",
+        ... ).show()
 
-    ..  pyvista-plot::
-        :context:
-        :force_static:
-
-        >>> mesh_new = fem.mesh.interpolate_line(mesh, xi=np.linspace(0, 1), axis=1)
-        >>> mesh_new.plot(style="points", color="black").show()
     """
 
-    # line connectivity
-    # concatenate the first point of each cell and the last point of the last cell
-    line = np.concatenate([mesh.cells[:, :-1].ravel(), mesh.cells[-1, -1:]])
-
-    # independent spline variable
-    points = mesh.points[line, axis]
-    ascending = np.argsort(points)
-
-    # dependent spline variable(s)
-    mask = np.ones(mesh.dim, dtype=bool)
-    mask[axis] = False
-
-    axes = np.arange(mesh.dim)
-    values = mesh.points[line.reshape(-1, 1), axes[mask]]
-
-    # spline interpolator
     if Interpolator is None:
         from scipy.interpolate import PchipInterpolator as Interpolator
 
-    # create a spline
-    spline = Interpolator(points[ascending], values[ascending], **kwargs)
+    if axis is None:  # progress-based interpolation
 
-    # evaluation points for the independent spline variable
-    points_new = np.zeros((len(xi), mesh.dim))
-    points_new[:, axis] = xi
-    points_new[:, axes[mask]] = spline(xi)
+        distances = np.linalg.norm(np.diff(mesh.points, axis=0), axis=1)
+        progress = np.insert(np.cumsum(distances), 0, 0)
+        progress /= progress.max()
 
-    cells_new = np.repeat(np.arange(len(xi)), 2)[1:-1].reshape(-1, 2)
+        spline = Interpolator(progress, mesh.points, **kwargs)
 
-    mesh_new = type(mesh)(points_new, cells_new, cell_type="line")
-    mesh_new.points_derivative = np.zeros_like(mesh_new.points)
-    mesh_new.points_derivative[:, axes[mask]] = spline.derivative()(xi)
+        points_new = spline(xi)
+        cells_new = np.repeat(np.arange(len(xi)), 2)[1:-1].reshape(-1, 2)
+
+        mesh_new = type(mesh)(points_new, cells_new, cell_type="line")
+        mesh_new.points_derivative = spline.derivative()(xi)
+
+    else:  # independent- and dependent-variables
+
+        # line connectivity
+        # concatenate the first point of each cell and the last point of the last cell
+        line = np.concatenate([mesh.cells[:, :-1].ravel(), mesh.cells[-1, -1:]])
+
+        # independent spline variable
+        points = mesh.points[line, axis]
+        ascending = np.argsort(points)
+
+        # dependent spline variable(s)
+        mask = np.ones(mesh.dim, dtype=bool)
+        mask[axis] = False
+
+        axes = np.arange(mesh.dim)
+        values = mesh.points[line.reshape(-1, 1), axes[mask]]
+
+        # create a spline
+        spline = Interpolator(points[ascending], values[ascending], **kwargs)
+
+        # evaluation points for the independent spline variable
+        points_new = np.zeros((len(xi), mesh.dim))
+        points_new[:, axis] = xi
+        points_new[:, axes[mask]] = spline(xi)
+
+        cells_new = np.repeat(np.arange(len(xi)), 2)[1:-1].reshape(-1, 2)
+
+        mesh_new = type(mesh)(points_new, cells_new, cell_type="line")
+        mesh_new.points_derivative = np.zeros_like(mesh_new.points)
+        mesh_new.points_derivative[:, axes[mask]] = spline.derivative()(xi)
 
     return mesh_new

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
 """
- _______  _______  ___      __   __  _______  _______ 
+ _______  _______  ___      __   __  _______  _______
 |       ||       ||   |    |  | |  ||       ||       |
 |    ___||    ___||   |    |  | |  ||    _  ||    ___|
-|   |___ |   |___ |   |    |  |_|  ||   |_| ||   |___ 
+|   |___ |   |___ |   |    |  |_|  ||   |_| ||   |___
 |    ___||    ___||   |___ |       ||    ___||    ___|
-|   |    |   |___ |       ||       ||   |    |   |___ 
+|   |    |   |___ |       ||       ||   |    |   |___
 |___|    |_______||_______||_______||___|    |_______|
 
 This file is part of felupe.
@@ -568,6 +568,7 @@ def test_expand():
 
 def test_interpolate_line():
     import felupe as fem
+    from scipy.interpolate import CubicSpline
 
     mesh = fem.mesh.Line(n=5).expand(n=1).expand(n=1)
     t = mesh.x.copy()
@@ -580,6 +581,19 @@ def test_interpolate_line():
     assert mesh_new.npoints == len(xi)
     assert len(mesh_new.points_derivative) == len(xi)
     assert np.allclose(mesh_new.points_derivative[:, 1], 0)
+
+    mesh = fem.mesh.Line(n=5).expand(n=1).expand(n=1)
+    t = mesh.x.copy()
+    mesh.points[:, 0] = np.sin(2 * np.pi * t)
+    mesh.points[:, 1] = np.cos(2 * np.pi * t)
+
+    xi = np.linspace(0, 1, 101)
+    mesh_new = fem.mesh.interpolate_line(
+        mesh, xi=xi, Interpolator=CubicSpline, bc_type="periodic"
+    )
+
+    assert mesh_new.npoints == len(xi)
+    assert len(mesh_new.points_derivative) == len(xi)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
use a curve-progress variable if `axis=None` by default.

```python
>>> import felupe as fem
>>> import numpy as np
>>> from scipy.interpolate import CubicSpline
>>>
>>> mesh = fem.mesh.Line(b=1.0, n=5).expand(n=1)
>>> t = mesh.x.copy()
>>> mesh.points[:, 0] = np.sin(2 * np.pi * t)
>>> mesh.points[:, 1] = np.cos(2 * np.pi * t)
>>>
>>> mesh_new = fem.mesh.interpolate_line(
...     mesh, xi=np.linspace(0, 1), Interpolator=CubicSpline, bc_type="periodic"
... )
>>>
>>> mesh_new.plot(
...     plotter=mesh.plot(style="points", color="red", point_size=15),
...     color="black",
... ).show()
```