### PR TITLE
Make license-files more explicit in `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ authors = [
 ]
 requires-python = ">=3.9"
 license = "GPL-3.0-or-later"
-license-files = ["LICEN[CS]E.*"]
+license-files = ["LICENSE"]
 keywords = [
   "computational-mechanics",
   "fea",


### PR DESCRIPTION
Fix the license-files entry. Fixes #952. See #953.