### PR TITLE
`pyproject.toml` ensure PEP639 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file. The format 
 - Add `Mesh.clear_points_without_cells()` to clear the list of points without cells (useful for center-points of multi-point constraints).
 - Release FElupe on conda-forge, starting with v9.2.0.
 
+### Changed
+- Change the required setuptools-version in the build-system table of `pyproject.toml` to match PEP639 (setuptools>=77.0.3).
+- Change the labels to well-known labels for the URLs in `pyproject.toml`.
+
 ### Fixed
 - Fix the declaration of the (spdx identifier) license and license-file in `pyproject.toml`.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=61"]
+requires = ["setuptools>=77.0.3"]
 build-backend = "setuptools.build_meta"
 
 [tool.isort]
@@ -10,9 +10,7 @@ name = "felupe"
 description = "Finite Element Analysis"
 readme = "README.md"
 authors = [
-  {name = "Andreas Dutzler"},
-  {email = "a.dutzler@gmail.com"},
-  
+  {name = "Andreas Dutzler", email = "a.dutzler@gmail.com"},
 ]
 requires-python = ">=3.9"
 license = "GPL-3.0-or-later"
@@ -86,5 +84,7 @@ version = {attr = "felupe.__about__.__version__"}
 
 [project.urls]
 Homepage = "https://felupe.readthedocs.io/en/latest"
-Code = "https://github.com/adtzlr/felupe"
+Documentation = "https://felupe.readthedocs.io/en/latest"
+Repository = "https://github.com/adtzlr/felupe"
 Issues = "https://github.com/adtzlr/felupe/issues"
+Changelog = "https://github.com/adtzlr/felupe/blob/main/CHANGELOG.md"


### PR DESCRIPTION
by enforcing `setuptools>=77.0.3` for [PEP639](https://peps.python.org/pep-0639/).

This PR also changes the labels of the project-urls to [well-known labels](https://packaging.python.org/en/latest/specifications/well-known-project-urls/#well-known-labels).

Now, `pyproject.toml` follows this [guideline](https://packaging.python.org/en/latest/guides/writing-pyproject-toml/).

See also #953.