### PR TITLE
Fix missing import of `TriQuadraticHexahedron`

### DIFF
--- a/src/felupe/__init__.py
+++ b/src/felupe/__init__.py
@@ -58,6 +58,7 @@ from .element import (
     TetraMINI,
     Triangle,
     TriangleMINI,
+    TriQuadraticHexahedron,
     Vertex,
 )
 from .field import (

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -571,8 +571,9 @@ def test_expand():
 
 
 def test_interpolate_line():
-    import felupe as fem
     from scipy.interpolate import CubicSpline
+
+    import felupe as fem
 
     mesh = fem.mesh.Line(n=5).expand(n=1).expand(n=1)
     t = mesh.x.copy()


### PR DESCRIPTION
which causes the docs not to build because `TriQuadraticHexahedron` is not available in the top-level namespace of felupe. Thanks @tkoyama010! 🎉 

fixes #957 

- [x] Add `TriQuadraticHexahedron` to the top-level namesapce

This is the error of RTD, but this can't be reproduced locally.

```
WARNING: autodoc: failed to import class 'TriQuadraticHexahedron' from module 'felupe'; the following exception was raised:
--
383 | Traceback (most recent call last):
384 | File "/home/docs/checkouts/readthedocs.org/user_builds/felupe/envs/latest/lib/python3.12/site-packages/sphinx/util/inspect.py", line 461, in safe_getattr
385 | return getattr(obj, name, *defargs)
386 | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
387 | AttributeError: module 'felupe' has no attribute 'TriQuadraticHexahedron'. Did you mean: 'QuadraticHexahedron'?
```

There's also another error in `MultiPointConstraint`:
```
felupe/mechanics/_multipoint.py:docstring of felupe.mechanics._multipoint.MultiPointConstraint:107: WARNING: Exception occurred in plotting mechanics-14
--
421 | from /home/docs/checkouts/readthedocs.org/user_builds/felupe/checkouts/latest/docs/felupe/mechanics.rst:
422 | Traceback (most recent call last):
423 | File "/home/docs/checkouts/readthedocs.org/user_builds/felupe/envs/latest/lib/python3.12/site-packages/pyvista/ext/plot_directive.py", line 436, in _run_code
424 | exec(code, ns)
425 | File "<string>", line 12
426 | field.plot(
427 | ^
428 | SyntaxError: '(' was never closed [docutils]
429 | Path to light image logo does not exist: logo_without_text.svg
430 | Path to dark image logo does not exist: logo_without_text.svg
```

Also, there seems to be one more problem, but this could be related to the first two errors.

`AssertionError: Directive "pyvista-plot" returned non-Node object (index 0): [<system_message: <paragraph...>>]`