### PR TITLE
Fix the path to the logo in `docs/conf.py`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ All notable changes to this project will be documented in this file. The format 
 
 ### Fixed
 - Fix the declaration of the (spdx identifier) license and license-file in `pyproject.toml`.
+- Fix missing import of `TriQuadraticHexahedron` in the top-level namespace.
+- Fix the path to `docs/_static/logo_without_text.svg` in `docs/conf.py`.
 
 ## [9.2.0] - 2025-03-04
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -143,8 +143,8 @@ html_theme_options = {
     ],
     "logo": {
         "text": "FElupe",
-        "image_light": "logo_without_text.svg",
-        "image_dark": "logo_without_text.svg",
+        "image_light": "_static/logo_without_text.svg",
+        "image_dark": "_static/logo_without_text.svg",
     },
     "use_edit_page_button": True,
 }


### PR DESCRIPTION
I think it works without the path, but let's change it according to the offical docs of the PyData theme.

see #957 