### PR TITLE
Add `ConstitutiveMaterial.is_stable()` and fix `CompositeMaterial`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file. The format 
 - Add `Mesh.add_points(points)` to update the mesh with additional points.
 - Add `Mesh.clear_points_without_cells()` to clear the list of points without cells (useful for center-points of multi-point constraints).
 - Release FElupe on conda-forge, starting with v9.2.0.
+- Add `ConstitutiveMaterial.is_stable()` which returns a boolean mask of stability for isotropic material model formulations. Note that this will require an additional volumetric part of the strain energy density function for hyperelastic material model formulations without a volumetric part.
 
 ### Changed
 - Change the required setuptools-version in the build-system table of `pyproject.toml` to match PEP639 (setuptools>=77.0.3).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file. The format 
 ### Changed
 - Change the required setuptools-version in the build-system table of `pyproject.toml` to match PEP639 (setuptools>=77.0.3).
 - Change the labels to well-known labels for the URLs in `pyproject.toml`.
+- Change the first return value of `ViewMaterial.uniaxial()`, `ViewMaterial.planar()`, `ViewMaterial.biaxial()`, `ViewMaterialIncompressible.uniaxial()`, `ViewMaterialIncompressible.planar()`, `ViewMaterialIncompressible.biaxial()` from the stretch to a list of all three principal stretches.
 
 ### Fixed
 - Fix the declaration of the (spdx identifier) license and license-file in `pyproject.toml`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be documented in this file. The format 
 - Fix missing import of `TriQuadraticHexahedron` in the top-level namespace.
 - Fix the path to `docs/_static/logo_without_text.svg` in `docs/conf.py`.
 - Fix a typo in the docstring of `MeshContainer.from_unstructured_grid()`.
+- Fix `CompositeMaterial` for input lists of length 1.
 
 ## [9.2.0] - 2025-03-04
 

--- a/src/felupe/constitution/_base.py
+++ b/src/felupe/constitution/_base.py
@@ -467,7 +467,7 @@ class ConstitutiveMaterial:
             ...     C01=0.25,
             ... ) & fem.Volumetric(bulk=5000)
             >>> umat.is_stable([F])
-            array([[ True]])
+            array([[False]])
 
         """
         N = eigh(dot(transpose(x[0]), x[0]))[1]

--- a/src/felupe/constitution/_base.py
+++ b/src/felupe/constitution/_base.py
@@ -446,11 +446,17 @@ class ConstitutiveMaterial:
             >>> import numpy as np
             >>> import felupe as fem
             >>>
-            >>> F = np.diag([2.0, 2.0, 0.25]).reshape(3, 3, 1, 1)
-            >>>
             >>> umat = fem.NeoHooke(mu=1.0, bulk=2.0)
+            >>> view = umat.view()
+            >>> λ = view.biaxial()[0]
+            >>>
+            >>> F = np.zeros((3, 3, 1, λ[0].size))
+            >>> for a in range(3):
+            ...     F[a, a] = λ[a]
+            >>>
             >>> umat.is_stable([F])
-            array([[ True]])
+            array([[ True,  True,  True,  True,  True,  True,  True,  True,  True,
+                     True,  True,  True,  True,  True,  True,  True]])
 
 
         ..  plot::
@@ -459,15 +465,21 @@ class ConstitutiveMaterial:
             >>> import felupe as fem
             >>> import felupe.constitution.tensortrax as mat
             >>>
-            >>> F = np.diag([2.0, 2.0, 0.25]).reshape(3, 3, 1, 1)
-            >>>
             >>> umat = fem.Hyperelastic(
             ...     mat.models.hyperelastic.mooney_rivlin,
             ...     C10=0.25,
             ...     C01=0.25,
             ... ) & fem.Volumetric(bulk=5000)
+            >>> view = umat.view()
+            >>> λ = view.biaxial()[0]
+            >>>
+            >>> F = np.zeros((3, 3, 1, λ[0].size))
+            >>> for a in range(3):
+            ...     F[a, a] = λ[a]
+            >>>
             >>> umat.is_stable([F])
-            array([[False]])
+            array([[ True,  True,  True,  True,  True,  True,  True,  True, False,
+                    False, False, False, False, False, False, False]])
 
         """
         N = eigh(dot(transpose(x[0]), x[0]))[1]

--- a/src/felupe/constitution/_base.py
+++ b/src/felupe/constitution/_base.py
@@ -440,6 +440,9 @@ class ConstitutiveMaterial:
 
         Examples
         --------
+        First, let's check the stability of the Neo-Hookean material model formulation.
+        The stability is evaluated on (valid) principal stretches of a biaxial
+        deformation. All deformations are stable.
 
         ..  plot::
 
@@ -458,6 +461,10 @@ class ConstitutiveMaterial:
             array([[ True,  True,  True,  True,  True,  True,  True,  True,  True,
                      True,  True,  True,  True,  True,  True,  True]])
 
+        Now, let's check the stability of the Mooney-Rivlin material model formulation.
+        The stability is evaluated on (valid) principal stretches of a biaxial
+        deformation. Biaxial deformations are only stable up to a longitudinal stretch
+        of 1.35.
 
         ..  plot::
 

--- a/src/felupe/constitution/_base.py
+++ b/src/felupe/constitution/_base.py
@@ -20,6 +20,7 @@ from copy import deepcopy as copy
 
 import numpy as np
 
+from ..math import dot, eigh, transpose
 from ._view import ViewMaterial, ViewMaterialIncompressible
 
 
@@ -407,6 +408,88 @@ class ConstitutiveMaterial:
 
         return umat, res
 
+    def is_stable(self, x, hessian=None):
+        """Return a boolean mask for stability of isotropic material model formulations.
+
+        At a given deformation gradient, a normal force is applied on each principal
+        stretch direction. If the resulting incremental stretches are positive, the
+        material model formulation is considered to be stable at the given deformation
+        gradient.
+
+        Parameters
+        ----------
+        x : list of ndarray
+            The list with input arguments. These contain the extracted fields of a
+            :class:`~felupe.FieldContainer`.
+        hessian : ndarray or None, optional
+            Second partial derivative of the strain energy density function w.r.t. the
+            deformation gradient. Default is None.
+
+        Returns
+        -------
+        ndarray
+            Boolean mask of stability.
+
+        Notes
+        -----
+
+        ..  warning::
+
+            This stability check will lead to a singular matrix for isotropic
+            (hyperelastic) material model formulations without a volumetric part.
+
+        Examples
+        --------
+
+        ..  plot::
+
+            >>> import numpy as np
+            >>> import felupe as fem
+            >>>
+            >>> F = np.diag([2.0, 2.0, 0.25]).reshape(3, 3, 1, 1)
+            >>>
+            >>> umat = fem.NeoHooke(mu=1.0, bulk=2.0)
+            >>> umat.is_stable([F])
+            array([[ True]])
+
+
+        ..  plot::
+
+            >>> import numpy as np
+            >>> import felupe as fem
+            >>> import felupe.constitution.tensortrax as mat
+            >>>
+            >>> F = np.diag([2.0, 2.0, 0.25]).reshape(3, 3, 1, 1)
+            >>>
+            >>> umat = fem.Hyperelastic(
+            ...     mat.models.hyperelastic.mooney_rivlin,
+            ...     C10=0.25,
+            ...     C01=0.25,
+            ... ) & fem.Volumetric(bulk=5000)
+            >>> umat.is_stable([F])
+            array([[ True]])
+
+        """
+        N = eigh(dot(transpose(x[0]), x[0]))[1]
+        n = eigh(dot(x[0], transpose(x[0])))[1]
+
+        if hessian is None:
+            hessian = self.hessian(x)[0]
+
+        A = np.einsum(
+            "iJkL...,ia...,Ja...,kb...,Lb...->ab...",
+            hessian,
+            n,
+            N,
+            n,
+            N,
+            optimize=True,
+        )
+
+        stretch_change = np.diagonal(np.linalg.inv(A.T).T, axis1=0, axis2=1)
+
+        return np.all(stretch_change > 0, axis=-1)
+
     def __and__(self, other_material):
         return CompositeMaterial(self, other_material)
 
@@ -512,12 +595,12 @@ class CompositeMaterial(ConstitutiveMaterial):
 
     def gradient(self, x, **kwargs):
         gradients = [material.gradient(x, **kwargs) for material in self.materials]
-        nfields = len(x) - 1
+        nfields = max(1, len(x) - 1)
         P = [np.sum([grad[i] for grad in gradients], axis=0) for i in range(nfields)]
         statevars_new = gradients[0][-1]
         return [*P, statevars_new]
 
     def hessian(self, x, **kwargs):
         hessians = [material.hessian(x, **kwargs) for material in self.materials]
-        nfields = len(x) - 1
+        nfields = max(1, len(x) - 1)
         return [np.sum([hess[i] for hess in hessians], axis=0) for i in range(nfields)]

--- a/src/felupe/constitution/_view.py
+++ b/src/felupe/constitution/_view.py
@@ -72,14 +72,14 @@ class PlotMaterial:
         shear and biaxial tension."""
 
         import matplotlib.pyplot as plt
-        
+
         data = self.evaluate()
 
         if ax is None:
             fig, ax = plt.subplots()
 
-        for stretch, force, label in data:
-            ax.plot(stretch, force, label=label, **kwargs)
+        for stretches, force, label in data:
+            ax.plot(stretches[0], force, label=label, **kwargs)
 
         ax.set_xlabel(r"Stretch $l/L$ $\rightarrow$")
         ax.set_ylabel("Normal force per undeformed area" + r" $N/A$ $\rightarrow$")
@@ -254,7 +254,7 @@ class ViewMaterial(PlotMaterial):
             warnings.warn("Uniaxial data with volume ratio det(F) <= 0 included.")
             P[0, 0][~valid] = np.nan
 
-        return λ1, P[0, 0].ravel(), "Uniaxial"
+        return (λ1, λ2, λ3), P[0, 0].ravel(), "Uniaxial"
 
     def planar(self, stretches=None, **kwargs):
         """Normal force per undeformed area vs stretch curve for a planar shear
@@ -327,7 +327,7 @@ class ViewMaterial(PlotMaterial):
             warnings.warn("Planar Shear data with volume ratio det(F) <= 0 included.")
             P[0, 0][~valid] = np.nan
 
-        return λ1, P[0, 0].ravel(), "Planar Shear"
+        return (λ1, λ2, λ3), P[0, 0].ravel(), "Planar Shear"
 
     def biaxial(self, stretches=None, **kwargs):
         """Normal force per undeformed area vs stretch curve for a equi-biaxial
@@ -399,7 +399,7 @@ class ViewMaterial(PlotMaterial):
             warnings.warn("Biaxial data with volume ratio det(F) <= 0 included.")
             P[0, 0][~valid] = np.nan
 
-        return λ1, P[0, 0].ravel(), "Biaxial"
+        return (λ1, λ2, λ3), P[0, 0].ravel(), "Biaxial"
 
 
 class ViewMaterialIncompressible(PlotMaterial):
@@ -503,7 +503,11 @@ class ViewMaterialIncompressible(PlotMaterial):
         else:
             P, self.statevars = self.umat.gradient([F, None])
 
-        return λ1, (P[0, 0] - λ3 / λ1 * P[2, 2]).ravel(), "Uniaxial (Incompressible)"
+        return (
+            (λ1, λ2, λ3),
+            (P[0, 0] - λ3 / λ1 * P[2, 2]).ravel(),
+            "Uniaxial (Incompressible)",
+        )
 
     def planar(self, stretches=None):
         """Normal force per undeformed area vs stretch curve for a planar shear
@@ -544,7 +548,7 @@ class ViewMaterialIncompressible(PlotMaterial):
             P, self.statevars = self.umat.gradient([F, None])
 
         return (
-            λ1,
+            (λ1, λ2, λ3),
             (P[0, 0] - λ3 / λ1 * P[2, 2]).ravel(),
             "Planar Shear (Incompressible)",
         )
@@ -586,4 +590,8 @@ class ViewMaterialIncompressible(PlotMaterial):
         else:
             P, self.statevars = self.umat.gradient([F, None])
 
-        return λ1, (P[0, 0] - λ3 / λ1 * P[2, 2]).ravel(), "Biaxial (Incompressible)"
+        return (
+            (λ1, λ2, λ3),
+            (P[0, 0] - λ3 / λ1 * P[2, 2]).ravel(),
+            "Biaxial (Incompressible)",
+        )

--- a/tests/test_constitution.py
+++ b/tests/test_constitution.py
@@ -101,6 +101,8 @@ def test_nh():
             assert P[0].shape == (3, 3, *F[0].shape[-2:])
             assert A[0].shape == (3, 3, 3, 3, *F[0].shape[-2:])
 
+    assert np.all(nh.is_stable(F))
+
 
 def test_linear():
     r, F = pre(sym=False, add_identity=True)


### PR DESCRIPTION
- [x] Add `ConstitutiveMaterial.is_stable()` which returns a boolean mask of stability for isotropic material model formulations. Note that this will require an additional volumetric part of the strain energy density function for hyperelastic material model formulations without a volumetric part.
- [x] Fix `CompositeMaterial` for input lists of length 1.

fixes #964 

### Example
Let's check the stability of the Mooney-Rivlin material model formulation. The stability is evaluated on (valid) principal stretches of a biaxial deformation. Biaxial deformations are only stable up to a longitudinal stretch of 1.35. Similar results are also shown here: https://bentleysystems.service-now.com/community?id=kb_article_view&sysparm_article=KB0115733 but with different material parameters and load cases.

```python
>>> import numpy as np
>>> import felupe as fem
>>> import felupe.constitution.tensortrax as mat
>>>
>>> umat = fem.Hyperelastic(
...     mat.models.hyperelastic.mooney_rivlin,
...     C10=0.25,
...     C01=0.25,
... ) & fem.Volumetric(bulk=5000)
>>> view = umat.view()
>>> λ = view.biaxial()[0]
>>>
>>> F = np.zeros((3, 3, 1, λ[0].size))
>>> for a in range(3):
...     F[a, a] = λ[a]
>>>
>>> umat.is_stable([F])
array([[ True,  True,  True,  True,  True,  True,  True,  True, False,
        False, False, False, False, False, False, False]])
```