### PR TITLE
Add `RegionTruss`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file. The format 
 - Release FElupe on conda-forge, starting with v9.2.0.
 - Add `ConstitutiveMaterial.is_stable()` which returns a boolean mask of stability for isotropic material model formulations. Note that this will require an additional volumetric part of the strain energy density function for hyperelastic material model formulations without a volumetric part.
 - Add the linear-elastic material formulation `constitution.LinearElastic1D()` and a truss-body `mechanics.TrussBody()`.
+- Add `RegionTruss` with a truss element. This is a line element with a `GaussLobatto(order=0)` quadrature, i.e. with two quadrature points located at the boundaries.
 
 ### Changed
 - Change the required setuptools-version in the build-system table of `pyproject.toml` to match PEP639 (setuptools>=77.0.3).

--- a/docs/felupe/region.rst
+++ b/docs/felupe/region.rst
@@ -34,6 +34,7 @@ This module contains the definition of a region as well as a boundary region alo
    RegionQuadBoundary
    RegionHexahedronBoundary
    RegionVertex
+   RegionTruss
 
 **Detailed API Reference**
 
@@ -133,6 +134,11 @@ This module contains the definition of a region as well as a boundary region alo
    :show-inheritance:
 
 .. autoclass:: felupe.RegionVertex
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. autoclass:: felupe.RegionTruss
    :members:
    :undoc-members:
    :show-inheritance:

--- a/src/felupe/__init__.py
+++ b/src/felupe/__init__.py
@@ -122,6 +122,7 @@ from .region import (
     RegionTriangleMINI,
     RegionTriQuadraticHexahedron,
     RegionTriQuadraticHexahedronBoundary,
+    RegionTruss,
     RegionVertex,
 )
 from .tools import hello_world, newtonrhapson, project, runs_on, save, topoints
@@ -250,6 +251,7 @@ __all__ = [
     "RegionTriangleMINI",
     "RegionTriQuadraticHexahedron",
     "RegionTriQuadraticHexahedronBoundary",
+    "RegionTruss",
     "RegionVertex",
     "newtonrhapson",
     "project",

--- a/src/felupe/mechanics/_truss.py
+++ b/src/felupe/mechanics/_truss.py
@@ -50,31 +50,34 @@ class TrussBody(Solid):
     Examples
     --------
     ..  pyvista-plot::
+        :context:
         :force_static:
 
         >>> import felupe as fem
         >>>
         >>> mesh = fem.Mesh(
-        ...     points=[[0, 0], [1, 1], [2.0, 0]], cells=[[0, 1], [1, 2]], cell_type="line"
+        ...     points=[[0, 0], [1, 1], [2.0, 0]],
+        ...     cells=[[0, 1], [1, 2]],
+        ...     cell_type="line",
         ... )
-        >>> region = fem.Region(mesh, fem.Line(), fem.GaussLobatto(order=0, dim=1), grad=False)
+        >>> region = fem.RegionTruss(mesh)
         >>> field = fem.Field(region, dim=2).as_container()
         >>> boundaries = fem.BoundaryDict(fixed=fem.Boundary(field[0], fy=0))
         >>>
         >>> umat = fem.LinearElastic1D(E=[1, 1])
         >>> truss = fem.TrussBody(umat, field, area=[1, 1])
-        >>> load = fem.PointLoad(field, [1])
+        >>> load = fem.PointLoad(field, points=[1])
         >>>
-        >>> mesh.plot(plotter=load.plot(plotter=boundaries.plot()), line_width=5).show()
-        >>>
-        >>> move = fem.math.linsteps([0, -0.1], num=5, axis=1, axes=2)
-        >>> step = fem.Step(items=[truss, load], ramp={load: move}, boundaries=boundaries)
+        >>> table = fem.math.linsteps([0, 1], num=5, axis=1, axes=2)
+        >>> ramp = {load: table * -0.1}
+        >>> step = fem.Step(items=[truss, load], ramp=ramp, boundaries=boundaries)
         >>> job = fem.Job(steps=[step]).evaluate()
+        >>>
+        >>> mesh.plot(
+        ...     plotter=load.plot(plotter=boundaries.plot(), scale=0.5),
+        ...     line_width=5
+        ... ).show()
 
-    See Also
-    --------
-    felupe.SolidBodyNearlyIncompressible : A (nearly) incompressible solid body with
-        methods for the assembly of sparse vectors/matrices.
     """
 
     def __init__(self, umat, field, area, statevars=None):

--- a/src/felupe/region/__init__.py
+++ b/src/felupe/region/__init__.py
@@ -22,6 +22,7 @@ from ._templates import (
     RegionTriangleMINI,
     RegionTriQuadraticHexahedron,
     RegionTriQuadraticHexahedronBoundary,
+    RegionTruss,
     RegionVertex,
 )
 
@@ -49,5 +50,6 @@ __all__ = [
     "RegionTriangleMINI",
     "RegionTriQuadraticHexahedron",
     "RegionTriQuadraticHexahedronBoundary",
+    "RegionTruss",
     "RegionVertex",
 ]

--- a/src/felupe/region/_templates.py
+++ b/src/felupe/region/_templates.py
@@ -22,6 +22,7 @@ from ..element import (
     ConstantHexahedron,
     ConstantQuad,
     Hexahedron,
+    Line,
     Quad,
     QuadraticHexahedron,
     QuadraticQuad,
@@ -35,7 +36,7 @@ from ..element import (
     Vertex,
 )
 from ..mesh import Mesh
-from ..quadrature import GaussLegendre, GaussLegendreBoundary
+from ..quadrature import GaussLegendre, GaussLegendreBoundary, GaussLobatto
 from ..quadrature import Tetrahedron as TetraQuadrature
 from ..quadrature import Triangle as TriangleQuadrature
 from ._boundary import RegionBoundary
@@ -862,4 +863,14 @@ class RegionVertex(Region):
         self, mesh, quadrature=GaussLegendre(order=0, dim=1), grad=False, **kwargs
     ):
         element = Vertex()
+        super().__init__(mesh, element, quadrature, grad=grad, **kwargs)
+
+
+class RegionTruss(Region):
+    "A region with a truss element."
+
+    def __init__(
+        self, mesh, quadrature=GaussLobatto(order=0, dim=1), grad=False, **kwargs
+    ):
+        element = Line()
         super().__init__(mesh, element, quadrature, grad=grad, **kwargs)

--- a/tests/test_mechanics.py
+++ b/tests/test_mechanics.py
@@ -609,7 +609,7 @@ def test_truss():
     mesh = fem.Mesh(
         points=[[0, 0], [1, 1], [2.0, 0]], cells=[[0, 1], [1, 2]], cell_type="line"
     )
-    region = fem.Region(mesh, fem.Line(), fem.GaussLobatto(order=0, dim=1), grad=False)
+    region = fem.RegionTruss(mesh)
     field = fem.Field(region, dim=2).as_container()
     boundaries = fem.BoundaryDict(fixed=fem.Boundary(field[0], fy=0))
 


### PR DESCRIPTION
This is an addon for #966 

### Example

```python
import felupe as fem
import numpy as np

mesh = fem.Mesh(
    points=[[0, 0], [1, 1], [2.0, 0]], cells=[[0, 1], [1, 2]], cell_type="line"
)
region = fem.RegionTruss(mesh)
field = fem.Field(region, dim=2).as_container()
boundaries = fem.BoundaryDict(fixed=fem.Boundary(field[0], fy=0))

umat = fem.LinearElastic1D(E=np.ones(2))
truss = fem.Truss(umat, field, area=[2, 2])
load = fem.PointLoad(field, [1])

move = fem.math.linsteps([0, -0.1], num=5, axis=1, axes=2)
step = fem.Step(items=[truss, load], ramp={load: move}, boundaries=boundaries)
job = fem.Job(steps=[step]).evaluate(verbose=2)

mesh.plot(plotter=load.plot(plotter=boundaries.plot()), line_width=5).show()
```