### PR TITLE
Add `checkpoint()` and `restore()` methods for solid bodies and field containers

### DIFF
--- a/src/felupe/field/_container.py
+++ b/src/felupe/field/_container.py
@@ -219,6 +219,37 @@ class FieldContainer:
             for field, newfield in zip(self.fields, other_field.fields):  # link 1-to-1
                 field.values = newfield.values
 
+    def checkpoint(self):
+        """Return a checkpoint of the field container.
+
+        Returns
+        -------
+        dict
+            A dict with the checkpoint array.
+
+        See Also
+        --------
+        felupe.FieldContainer.restore : Restore a checkpoint of a field container
+            inplace.
+        """
+        return {"field": self.copy()}
+
+    def restore(self, checkpoint):
+        """Restore a checkpoint inplace.
+
+        Parameters
+        ----------
+        checkpoint : dict
+            A dict with checkpoint arrays / objects.
+
+        See Also
+        --------
+        felupe.FieldContainer.checkpoint : Return a checkpoint of the field container.
+        """
+
+        for field, newfield in zip(self.fields, checkpoint["field"].fields):
+            field.values[:] = newfield.values
+
     def view(self, point_data=None, cell_data=None, cell_type=None, project=None):
         """View the field with optional given dicts of point- and cell-data items.
 

--- a/src/felupe/mechanics/__init__.py
+++ b/src/felupe/mechanics/__init__.py
@@ -7,6 +7,7 @@ from ._multipoint import MultiPointConstraint, MultiPointContact
 from ._pointload import PointLoad
 from ._solidbody import SolidBody
 from ._solidbody_cauchy_stress import SolidBodyCauchyStress
+from ._solidbody_contact import SolidBodyContact
 from ._solidbody_force import SolidBodyForce
 from ._solidbody_gravity import SolidBodyGravity
 from ._solidbody_incompressible import SolidBodyNearlyIncompressible
@@ -26,6 +27,7 @@ __all__ = [
     "Results",
     "SolidBody",
     "SolidBodyCauchyStress",
+    "SolidBodyContact",
     "SolidBodyGravity",
     "SolidBodyForce",
     "SolidBodyNearlyIncompressible",

--- a/src/felupe/mechanics/__init__.py
+++ b/src/felupe/mechanics/__init__.py
@@ -7,7 +7,6 @@ from ._multipoint import MultiPointConstraint, MultiPointContact
 from ._pointload import PointLoad
 from ._solidbody import SolidBody
 from ._solidbody_cauchy_stress import SolidBodyCauchyStress
-from ._solidbody_contact import SolidBodyContact
 from ._solidbody_force import SolidBodyForce
 from ._solidbody_gravity import SolidBodyGravity
 from ._solidbody_incompressible import SolidBodyNearlyIncompressible
@@ -27,7 +26,6 @@ __all__ = [
     "Results",
     "SolidBody",
     "SolidBodyCauchyStress",
-    "SolidBodyContact",
     "SolidBodyGravity",
     "SolidBodyForce",
     "SolidBodyNearlyIncompressible",

--- a/src/felupe/mechanics/_solidbody.py
+++ b/src/felupe/mechanics/_solidbody.py
@@ -355,7 +355,7 @@ class SolidBody(Solid):
         """
 
         return {
-            "field": self.field.copy(),
+            **self.field.checkpoint(),
             "results.statevars": self.results.statevars.copy(),
         }
 

--- a/src/felupe/mechanics/_solidbody_incompressible.py
+++ b/src/felupe/mechanics/_solidbody_incompressible.py
@@ -370,6 +370,90 @@ class SolidBodyNearlyIncompressible(Solid):
             kirchhoff_stress=self._kirchhoff_stress,
         )
 
+    def checkpoint(self):
+        """Return a checkpoint of the nearly-incompressible solid body.
+
+        Returns
+        -------
+        dict
+            A dict with checkpoint arrays / objects.
+
+        Examples
+        --------
+        ..  pyvista-plot::
+            :force_static:
+
+            import felupe as fem
+
+            mesh = fem.Rectangle(b=(3, 1), n=(7, 3))
+            region = fem.RegionQuad(mesh)
+            field = fem.FieldContainer([fem.FieldPlaneStrain(region, dim=2)])
+
+            umat = fem.NeoHooke(mu=1)
+            solid = fem.SolidBodyNearlyIncompressible(umat=umat, field=field, bulk=5000)
+
+            # 1. vertical compression
+            boundaries, loadcase = fem.dof.uniaxial(field, clamped=True, sym=False, axis=1)
+            ramp = {boundaries["move"]: fem.math.linsteps([0, -0.2], num=2)}
+            step = fem.Step(items=[solid], ramp=ramp, boundaries=boundaries)
+            job = fem.Job(steps=[step]).evaluate()
+
+            # checkpoint the current state of deformation
+            checkpoint = solid.checkpoint()
+
+            # 2a. horizontal shear (right)
+            boundaries, loadcase = fem.dof.shear(field, sym=False, moves=(0, 0, -0.2))
+            ramp = {boundaries["move"]: fem.math.linsteps([0, 1], num=2)}
+            step = fem.Step(items=[solid], ramp=ramp, boundaries=boundaries)
+            job = fem.Job(steps=[step]).evaluate()
+
+            # (1.) restore compression without shear
+            solid.restore(checkpoint)
+
+            # 2b. horizontal shear (left)
+            boundaries, loadcase = fem.dof.shear(field, sym=False, moves=(0, 0, -0.2))
+            ramp = {boundaries["move"]: fem.math.linsteps([0, -1], num=2)}
+            step = fem.Step(items=[solid], ramp=ramp, boundaries=boundaries)
+            job = fem.Job(steps=[step]).evaluate()
+
+        See Also
+        --------
+        felupe.SolidBody.restore : Restore a checkpoint of a nearly-incompressible solid
+            body inplace.
+        """
+
+        return {
+            "field": self.field.copy(),
+            "results.state.u": self.results.state.u.copy(),
+            "results.state.p": self.results.state.p.copy(),
+            "results.state.J": self.results.state.J.copy(),
+            "results.statevars": self.results.statevars.copy(),
+        }
+
+    def restore(self, checkpoint):
+        """Restore a checkpoint inplace.
+
+        Parameters
+        ----------
+        checkpoint : dict
+            A dict with checkpoint arrays / objects.
+
+        See Also
+        --------
+        felupe.SolidBodyNearlyIncompressible.checkpoint : Return a checkpoint of the
+            nearly-incompressible solid body.
+        """
+
+        self.field.restore(checkpoint)
+        self.results.state.u[:] = checkpoint["results.state.u"]
+        self.results.state.p[:] = checkpoint["results.state.p"]
+        self.results.state.J[:] = checkpoint["results.state.J"]
+        self.results.statevars[:] = checkpoint["results.statevars"]
+
+        # results must be re-evaluated
+        self.evaluate.gradient(self.field)
+        self.evaluate.hessian(self.field)
+
     def _vector(
         self, field=None, parallel=False, items=None, args=(), kwargs=None, block=True
     ):

--- a/src/felupe/mechanics/_solidbody_incompressible.py
+++ b/src/felupe/mechanics/_solidbody_incompressible.py
@@ -423,7 +423,7 @@ class SolidBodyNearlyIncompressible(Solid):
         """
 
         return {
-            "field": self.field.copy(),
+            **self.field.checkpoint(),
             "results.state.u": self.results.state.u.copy(),
             "results.state.p": self.results.state.p.copy(),
             "results.state.J": self.results.state.J.copy(),


### PR DESCRIPTION
This implementation is based on the idea of #971. The `results`-keyword is not yet implemented - results are always re-evaluated after a checkpoint is restored.

closes #971