### PR TITLE
Clear force and stiffness results in `SolidBody.restore()`

### DIFF
--- a/src/felupe/mechanics/_solidbody.py
+++ b/src/felupe/mechanics/_solidbody.py
@@ -379,6 +379,10 @@ class SolidBody(Solid):
         self.evaluate.gradient(self.field)
         self.evaluate.hessian(self.field)
 
+        # reset force and stiffness
+        self.results.force = None
+        self.results.stiffness = None
+
     def _vector(
         self,
         field=None,

--- a/src/felupe/mechanics/_solidbody_incompressible.py
+++ b/src/felupe/mechanics/_solidbody_incompressible.py
@@ -453,6 +453,10 @@ class SolidBodyNearlyIncompressible(Solid):
         # results must be re-evaluated
         self.evaluate.gradient(self.field)
         self.evaluate.hessian(self.field)
+        
+        # reset force and stiffness
+        self.results.force = None
+        self.results.stiffness = None
 
     def _vector(
         self, field=None, parallel=False, items=None, args=(), kwargs=None, block=True


### PR DESCRIPTION
Just to be on the safe side, clear the force and stiffness results on restore.