### PR TITLE
Make restoring state variables optional

### DIFF
--- a/src/felupe/mechanics/_solidbody.py
+++ b/src/felupe/mechanics/_solidbody.py
@@ -359,13 +359,16 @@ class SolidBody(Solid):
             "results.statevars": self.results.statevars.copy(),
         }
 
-    def restore(self, checkpoint):
+    def restore(self, checkpoint, restore_statevars=True):
         """Restore a checkpoint inplace.
 
         Parameters
         ----------
         checkpoint : dict
             A dict with checkpoint arrays / objects.
+        restore_statevars : bool, optional
+            Flag to restore state variables. This is a power feature and must be used
+            with caution! Default is True.
 
         See Also
         --------
@@ -373,7 +376,8 @@ class SolidBody(Solid):
         """
 
         self.field.restore(checkpoint)
-        self.results.statevars[:] = checkpoint["results.statevars"]
+        if restore_statevars:
+            self.results.statevars[:] = checkpoint["results.statevars"]
 
         # results must be re-evaluated
         self.evaluate.gradient(self.field)

--- a/src/felupe/mechanics/_solidbody_incompressible.py
+++ b/src/felupe/mechanics/_solidbody_incompressible.py
@@ -430,13 +430,16 @@ class SolidBodyNearlyIncompressible(Solid):
             "results.statevars": self.results.statevars.copy(),
         }
 
-    def restore(self, checkpoint):
+    def restore(self, checkpoint, restore_statevars=True):
         """Restore a checkpoint inplace.
 
         Parameters
         ----------
         checkpoint : dict
             A dict with checkpoint arrays / objects.
+        restore_statevars : bool, optional
+            Flag to restore state variables. This is a power feature and must be used
+            with caution! Default is True.
 
         See Also
         --------
@@ -448,7 +451,9 @@ class SolidBodyNearlyIncompressible(Solid):
         self.results.state.u[:] = checkpoint["results.state.u"]
         self.results.state.p[:] = checkpoint["results.state.p"]
         self.results.state.J[:] = checkpoint["results.state.J"]
-        self.results.statevars[:] = checkpoint["results.statevars"]
+
+        if restore_statevars:
+            self.results.statevars[:] = checkpoint["results.statevars"]
 
         # results must be re-evaluated
         self.evaluate.gradient(self.field)


### PR DESCRIPTION
this PR adds the function argument `SolidBody.restore(checkpoint, restore_statevars=True)`. Also for `SolidBodyNearlyIncompressible`.

This is a super-handy power feature which must be used with caution. A possible use case is the Ogden-Roxburgh model, where only once a max. deformation is evaluated. Then, snapshots of prior deformations may be restored while keeping the state variables. Convergence is not guaranteed because the displacements to reach equilibrium  will still change.