### PR TITLE
Add `SolidBody.revolve()` to convert axisymmetric models to 3d

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file. The format 
 - Add a method to checkpoint a current state of deformation, `state = SolidBody.checkpoint()` and a method to restore checkpoints, `SolidBody.restore(state)`. This is implemented for `SolidBody`, `SolidBodyNearlyIncompressible` and `FieldContainer`.
 - Add `math.revolve_points()`, to revolve only points instead of a Mesh. Previously, `mesh.revolve(points, cells=None, cell_type=None, **kwargs)[0]` had to be used.
 - Add `math.rotate_points()`, to rotate only points instead of a Mesh. Previously, `mesh.rotate(points, cells=None, cell_type=None, **kwargs)[0]` had to be used.
+- Add `SolidBody.revolve()` and `SolidBodyNearlyIncompressible.revolve()` to convert a axisymmetric solid body to a 3d solid body.
 
 ## [9.3.0] - 2025-06-29
 

--- a/src/felupe/mechanics/_solidbody_incompressible.py
+++ b/src/felupe/mechanics/_solidbody_incompressible.py
@@ -23,8 +23,9 @@ import numpy as np
 
 from ..assembly import IntegralForm
 from ..constitution import AreaChange
-from ..field import FieldAxisymmetric
-from ..math import ddot, det, dot, dya, transpose
+from ..field import Field, FieldAxisymmetric, FieldContainer
+from ..math import ddot, det, dot, dya, rotate_points, transpose
+from ..region import RegionHexahedron, RegionQuad, RegionTetra, RegionTriangle
 from ._helpers import Assemble, Evaluate, Results, StateNearlyIncompressible
 from ._solidbody import Solid
 
@@ -462,6 +463,89 @@ class SolidBodyNearlyIncompressible(Solid):
         # reset force and stiffness
         self.results.force = None
         self.results.stiffness = None
+
+    def revolve(self, n=11, phi=180):
+        """Return a revolved solid body.
+
+        Parameters
+        ----------
+        n : int, optional
+            Number of n-point revolutions (or (n-1) cell revolutions), default is 11.
+        phi : float or ndarray, optional
+            Revolution angle in degree (default is 180).
+
+        Returns
+        -------
+        SolidBody
+            The revolved solid body.
+
+        See Also
+        --------
+        SolidBody.revolve : Return a revolved solid body
+
+        """
+
+        # revolve the mesh around the x-axis and create new region and new field
+        new_mesh = self.field.region.mesh.revolve(n=n, phi=phi, axis=0, expand_dim=True)
+        new_region = {
+            RegionQuad: RegionHexahedron,
+            RegionTriangle: RegionTetra,
+        }[
+            type(self.field.region)
+        ](new_mesh)
+
+        if np.isscalar(phi):
+            rotation_angles = np.linspace(0, phi, n)
+        else:
+            rotation_angles = phi
+            n = len(rotation_angles)
+
+        new_values = []
+        for angle_deg in rotation_angles:
+            new_values.append(
+                rotate_points(
+                    points=np.pad(self.field[0].values, ((0, 0), (0, 1))),
+                    angle_deg=angle_deg,
+                    axis=0,
+                )
+            )
+
+        dim = new_values[-1].shape[1]
+        new_field = FieldContainer(
+            [Field(new_region, dim=3, values=np.array(new_values).reshape(-1, dim))]
+        )
+
+        # create a new solid body
+        new_solid = SolidBodyNearlyIncompressible(
+            umat=self.umat,
+            field=new_field,
+            density=self.density,
+            bulk=self.bulk,
+        )
+
+        # expand state variables (no rotation is applied here)
+        new_shape = np.array(new_solid.results.statevars.shape)
+        old_shape = np.array(self.results.statevars.shape)
+
+        # ratio of shape of new vs. old state variables
+        reps = np.zeros(len(new_shape), dtype=int)
+        reps[0] = new_shape[0]
+        reps[1:] = new_shape[1:] // old_shape[1:]
+
+        new_solid.results.statevars[:] = np.tile(self.results.statevars, reps)
+
+        # expand internal field variables (displacement)
+        new_shape_internal = np.array(new_solid.results.state.p.shape)
+        old_shape_internal = np.array(self.results.state.p.shape)
+
+        # ratio of shape of new vs. old internal field variables
+        reps_internal = new_shape_internal // old_shape_internal
+
+        new_solid.results.state.u[:] = new_field[0].values
+        new_solid.results.state.p[:] = np.tile(self.results.state.p, reps_internal)
+        new_solid.results.state.J[:] = np.tile(self.results.state.J, reps_internal)
+
+        return new_solid
 
     def _vector(
         self, field=None, parallel=False, items=None, args=(), kwargs=None, block=True

--- a/tests/test_mechanics.py
+++ b/tests/test_mechanics.py
@@ -699,6 +699,29 @@ def test_checkpoint_incompressible():
     fem.Job(steps=[step]).evaluate()
 
 
+def test_axi_to_3d():
+
+    import felupe as fem
+
+    mesh = fem.Rectangle(n=6)
+    field = fem.FieldContainer([fem.FieldAxisymmetric(fem.RegionQuad(mesh), dim=2)])
+
+    umat = fem.NeoHookeCompressible(mu=1, lmbda=2)
+    solid = fem.SolidBody(umat=umat, field=field)
+
+    boundaries, loadcase = fem.dof.uniaxial(solid.field, clamped=True, sym=False)
+    step = fem.Step(items=[solid], boundaries=boundaries)
+    fem.Job(steps=[step]).evaluate()
+
+    new_solid = solid.revolve(n=11, phi=180)
+    boundaries, loadcase = fem.dof.uniaxial(
+        new_solid.field, clamped=True, sym=(0, 0, 1)
+    )
+
+    step = fem.Step(items=[new_solid], boundaries=boundaries)
+    fem.Job(steps=[step]).evaluate()
+
+
 if __name__ == "__main__":
     test_simple()
     test_solidbody()
@@ -715,3 +738,4 @@ if __name__ == "__main__":
     test_truss
     test_checkpoint()
     test_checkpoint_incompressible()
+    test_axi_to_3d()

--- a/tests/test_mechanics.py
+++ b/tests/test_mechanics.py
@@ -714,6 +714,33 @@ def test_axi_to_3d():
     fem.Job(steps=[step]).evaluate()
 
     new_solid = solid.revolve(n=11, phi=180)
+    new_solid = solid.revolve(n=11, phi=fem.math.linsteps([0, 180], num=10))
+
+    boundaries, loadcase = fem.dof.uniaxial(
+        new_solid.field, clamped=True, sym=(0, 0, 1)
+    )
+
+    step = fem.Step(items=[new_solid], boundaries=boundaries)
+    fem.Job(steps=[step]).evaluate()
+
+
+def test_axi_to_3d_incompressible():
+
+    import felupe as fem
+
+    mesh = fem.Rectangle(n=6)
+    field = fem.FieldContainer([fem.FieldAxisymmetric(fem.RegionQuad(mesh), dim=2)])
+
+    umat = fem.NeoHooke(mu=1)
+    solid = fem.SolidBodyNearlyIncompressible(umat=umat, field=field, bulk=5000)
+
+    boundaries, loadcase = fem.dof.uniaxial(solid.field, clamped=True, sym=False)
+    step = fem.Step(items=[solid], boundaries=boundaries)
+    fem.Job(steps=[step]).evaluate()
+
+    new_solid = solid.revolve(n=11, phi=180)
+    new_solid = solid.revolve(n=11, phi=fem.math.linsteps([0, 180], num=10))
+
     boundaries, loadcase = fem.dof.uniaxial(
         new_solid.field, clamped=True, sym=(0, 0, 1)
     )
@@ -739,3 +766,4 @@ if __name__ == "__main__":
     test_checkpoint()
     test_checkpoint_incompressible()
     test_axi_to_3d()
+    test_axi_to_3d_incompressible()


### PR DESCRIPTION
This may be used to apply axisymmetric loads on an axisymmetric model and proceed with non-axisymmetric loads on a 3d-model. Only implemented for quads to hexahedrons.