### PR TITLE
Enhance `FieldContainer.merge()` for `FieldsMixed()`

### DIFF
--- a/src/felupe/field/_axi.py
+++ b/src/felupe/field/_axi.py
@@ -78,6 +78,7 @@ class FieldAxisymmetric(Field):
     """
 
     def __init__(self, region, dim=2, values=0.0, dtype=None):
+
         # init base Field
         super().__init__(region, dim=dim, values=values, dtype=dtype)
 

--- a/src/felupe/field/_base.py
+++ b/src/felupe/field/_base.py
@@ -126,6 +126,8 @@ class Field:
 
         eai, ai = self._indices_per_cell(self.region.mesh.cells, dim)
         self.indices = Indices(eai, ai, region, dim)
+        
+        self.__field__ = Field
 
     def _indices_per_cell(self, cells, dim):
         "Calculate pre-defined indices for sparse matrices."

--- a/src/felupe/field/_dual.py
+++ b/src/felupe/field/_dual.py
@@ -107,6 +107,12 @@ class FieldDual(Field):
         disconnect=None,
         **kwargs,
     ):
+
+        # store original function args and kwargs for re-creating the dual field in
+        # FieldContainer.merge()
+        self.__args__ = (region, dim, values, offset, npoints, mesh, disconnect)
+        self.__kwargs__ = kwargs
+
         # create dual regions
         region_dual_dict = {
             RegionHexahedron: RegionConstantHexahedron,

--- a/src/felupe/field/_fields.py
+++ b/src/felupe/field/_fields.py
@@ -16,6 +16,8 @@ You should have received a copy of the GNU General Public License
 along with FElupe.  If not, see <http://www.gnu.org/licenses/>.
 """
 
+import warnings
+
 from ._axi import FieldAxisymmetric
 from ._base import Field
 from ._container import FieldContainer
@@ -94,6 +96,18 @@ class FieldsMixed(FieldContainer):
         else:
             raise ValueError(
                 "Choose between ``axisymmetric=True`` or ``planestrain=True``."
+            )
+
+        if (axisymmetric or planestrain) and "dim" in kwargs.keys() and n > 1:
+            warnings.warn(
+                " ".join(
+                    [
+                        f'"dim={kwargs["dim"]}" will be used for the dual fields only.',
+                        'For NearlyIncompressible and "ThreeFieldVariation"',
+                        '"dim" must not be passed (dual fields have to be scalars).',
+                    ]
+                ),
+                stacklevel=2,
             )
 
         fields = [F(region, dim=region.mesh.dim, values=values[0])]

--- a/tests/test_field.py
+++ b/tests/test_field.py
@@ -108,6 +108,9 @@ def pre_axi_mixed():
     with pytest.raises(ValueError):
         fem.FieldsMixed(region, axisymmetric=True, planestrain=True)
 
+    with pytest.warns(UserWarning):
+        fem.FieldsMixed(region, axisymmetric=True, n=3, dim=2)
+
     u.values[0] = np.ones(2)
     assert np.all(f.values()[0][0] == 1)
 
@@ -294,7 +297,7 @@ def test_toplevel():
 def test_toplevel_merge():
 
     mesh1 = fem.Rectangle(n=3)
-    field1 = fem.FieldAxisymmetric(fem.RegionQuad(mesh1), dim=2)
+    field1 = fem.FieldsMixed(fem.RegionQuad(mesh1), n=3, axisymmetric=True)
 
     mesh2 = fem.Rectangle(a=(1, 0), b=(2, 1), n=3)
     field2 = fem.FieldAxisymmetric(fem.RegionQuad(mesh2), dim=2)
@@ -302,7 +305,7 @@ def test_toplevel_merge():
     fields, x0 = (field1 & field2).merge()
 
     umat = fem.NeoHookeCompressible(mu=1, lmbda=2)
-    solid1 = fem.SolidBody(umat, fields[0])
+    solid1 = fem.SolidBody(fem.ThreeFieldVariation(umat), fields[0])
     solid2 = fem.SolidBody(umat, fields[1])
 
     boundaries, loadcase = fem.dof.uniaxial(x0, clamped=True)


### PR DESCRIPTION
but only mixed-fields which were created with `FieldsMixed()` are supported. This is because only template regions are supported by `FieldDual`.