### PR TITLE
Enhance `mesh.revolve()` and `mesh.expand()`: Add support for `quad9` to `hexahedron27`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file. The format 
 - Add `FieldContainer.revolve()`, `SolidBody.revolve()` and `SolidBodyNearlyIncompressible.revolve()` to convert a axisymmetric field / solid body to a 3d field / solid body. Only implemented for the conversion of axisymmetric quads to hexahedrons. For top-level fields, a vertex-mesh is also supported.
 - Add `fields, x0 = FieldContainer.merge()` to simplify the handling of multiple items (solid bodies). The top-level field container `x0` must be used for boundary conditions and in `Job.evaluate(x0=x0)`.
 - Add a warning if `FieldMixed()` is called with `axisymmetric=True` or `planestrain=True`, more than one field `n>1` and a given `dim`. This dimension is passed to the dual fields only.
+- Add support for the conversion of `quad9` to `hexahedron27` element types in `mesh.revolve()` and `mesh.expand()`.
 
 ### Changed
 - Allow field containers to be included in the list of `fields` in `FieldContainer(fields)`. If a field container is included, its sub-fields are unpacked.

--- a/src/felupe/mesh/_tools.py
+++ b/src/felupe/mesh/_tools.py
@@ -111,21 +111,21 @@ def expand(points, cells, cell_type, n=11, z=1, axis=-1, expand_dim=True):
         }[cell_type]
 
         if cell_type_new == "hexahedron27":
-            n = n + (n - 1)
+            n = 2 * n
 
         if np.isscalar(thickness):
             points_thickness = np.linspace(0, thickness, n)
         else:
 
+            points_thickness = np.array(thickness)
             if cell_type_new == "hexahedron27":
+
                 points_thickness = np.vstack(
                     [
                         points_thickness,
                         points_thickness + np.diff(points_thickness, append=np.nan) / 2,
                     ]
                 ).T.ravel()[:-1]
-
-            points_thickness = thickness
 
         n = len(points_thickness)
 
@@ -147,9 +147,9 @@ def expand(points, cells, cell_type, n=11, z=1, axis=-1, expand_dim=True):
             faces = [16, 14, 13, 15, 8, 26]
             volume = [17]
 
-            start = cells_new[:-2]
-            middle = cells_new[1:-1]
-            end = cells_new[2:]
+            start = cells_new[:-2:2]
+            middle = cells_new[1:-1:2]
+            end = cells_new[2::2]
 
             cells_new = np.concatenate([start, middle, end], axis=-1)[
                 ..., [*verts, *edges, *faces, *volume]
@@ -379,7 +379,7 @@ def revolve(points, cells, cell_type, n=11, phi=180, axis=0, expand_dim=True):
     }[cell_type]
 
     if cell_type_new == "hexahedron27":
-        n = n + (n - 1)
+        n = 2 * n
 
     if np.isscalar(phi):
         points_phi = np.linspace(0, phi, n)
@@ -416,7 +416,7 @@ def revolve(points, cells, cell_type, n=11, phi=180, axis=0, expand_dim=True):
         three = [9, 10, 11, 12, 16, 14, 13, 15, 8, 26, 17]
 
         cells_new = np.vstack(
-            [np.hstack((r, s, t)) for r, s, t in zip(c[:-2], c[1:-1], c[2:])]
+            [np.hstack((r, s, t)) for r, s, t in zip(c[:-2:2], c[1:-1:2], c[2::2])]
         )[:, [*one, *two, *three]]
 
     else:

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -573,8 +573,6 @@ def test_expand():
 def test_interpolate_line():
     from scipy.interpolate import CubicSpline
 
-    import felupe as fem
-
     mesh = fem.mesh.Line(n=5).expand(n=1).expand(n=1)
     t = mesh.x.copy()
     mesh.points[:, 0] = np.sin(np.pi / 2 * t)
@@ -601,6 +599,24 @@ def test_interpolate_line():
     assert len(mesh_new.points_derivative) == len(xi)
 
 
+def test_expand_revolve_quadratic():
+
+    mesh = (
+        fem.Rectangle(a=(0, 1), b=(1, 2), n=3)
+        .add_midpoints_edges()
+        .add_midpoints_faces()
+    )
+    
+    new_mesh = mesh.revolve(n=3, phi=45)
+    assert len(new_mesh.cells) == 8
+    
+    new_mesh = mesh.revolve(phi=[0, 20, 40])
+    assert len(new_mesh.cells) == 8
+    
+    new_mesh = mesh.expand(z=[0, 1, 2])
+    assert len(new_mesh.cells) == 8
+
+
 if __name__ == "__main__":
     test_meshes()
     test_mirror()
@@ -621,3 +637,4 @@ if __name__ == "__main__":
     test_modify_corners()
     test_expand()
     test_interpolate_line()
+    test_expand_revolve_quadratic()


### PR DESCRIPTION
<img width="718" height="626" alt="grafik" src="https://github.com/user-attachments/assets/8d075281-3263-45be-aa4c-99a9b1b96a07" />
