### PR TITLE
Add `newtonrhapson(..., callback=None)`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file. The format 
 - Add `fields, x0 = FieldContainer.merge()` to simplify the handling of multiple items (solid bodies). The top-level field container `x0` must be used for boundary conditions and in `Job.evaluate(x0=x0)`.
 - Add a warning if `FieldMixed()` is called with `axisymmetric=True` or `planestrain=True`, more than one field `n>1` and a given `dim`. This dimension is passed to the dual fields only.
 - Add support for the conversion of `quad9` to `hexahedron27` element types in `mesh.revolve()` and `mesh.expand()`.
+- Add `newtonrhapson.callback(dx, x, iteration, xnorm, fnorm, success)` to provide a callback after each completed Newton iteration. This is available as `Job.evaluate(callback=newton_callback)`, whereas a callback after each completed substep has to be provided in `Job(callback=substep_callback)`.
 
 ### Changed
 - Allow field containers to be included in the list of `fields` in `FieldContainer(fields)`. If a field container is included, its sub-fields are unpacked.

--- a/src/felupe/field/_container.py
+++ b/src/felupe/field/_container.py
@@ -23,11 +23,11 @@ import numpy as np
 from ..math import rotate_points
 from ..mesh import MeshContainer
 from ..region import (
+    RegionBiQuadraticQuad,
     RegionHexahedron,
     RegionQuad,
-    RegionVertex,
     RegionTriQuadraticHexahedron,
-    RegionBiQuadraticQuad,
+    RegionVertex,
 )
 from ..view import ViewField
 from ._evaluate import EvaluateFieldContainer

--- a/src/felupe/tools/_newton.py
+++ b/src/felupe/tools/_newton.py
@@ -221,6 +221,8 @@ def newtonrhapson(
     ext0=None,
     solver=spsolve,
     verbose=None,
+    callback=None,
+    callback_kwargs=None,
 ):
     r"""Find a root of a real function using the Newton-Raphson method.
 
@@ -247,7 +249,8 @@ def newtonrhapson(
         Callable to update the unknowns. Function signature must be
         ``update = lambda x0, dx: x``.
     check : callable, optional
-        Callable to the check the result.
+        Callable to check the result with signature
+        ``check = lambda xnorm, fnorm, success: dx, x, **kwargs``.
     tol : float, optional
         Tolerance value to check if the function has converged (default is 1.490e-8).
     items : list or None, optional
@@ -270,6 +273,10 @@ def newtonrhapson(
         Default is None. If None, verbosity is set to True. If None and the
         environmental variable FELUPE_VERBOSE is set and its value is not ``true``,
         then logging is turned off.
+    callback : callable or None, optional
+        An optional callback function with function signature
+        ``callback = lambda dx, x, iteration, xnorm, fnorm, success: None``, which is
+        called after each completed iteration. Default is None.
 
     Returns
     -------
@@ -447,6 +454,12 @@ def newtonrhapson(
         )
         xnorms.append(xnorm)
         fnorms.append(fnorm)
+
+        if callback is not None:
+            if callback_kwargs is None:
+                callback_kwargs = {}
+
+            callback(dx, x, iteration, xnorm, fnorm, success)
 
         if verbose:
             print("|%2d | %1.3e | %1.3e |" % (1 + iteration, fnorm, xnorm))

--- a/tests/test_mechanics.py
+++ b/tests/test_mechanics.py
@@ -517,7 +517,10 @@ def test_load():
         bounds = {"fix": fem.Boundary(field[0], fx=lambda x: x == 0)}
         dof0, dof1 = fem.dof.partition(field, bounds)
 
-        res = fem.newtonrhapson(items=[body, load], dof0=dof0, dof1=dof1)
+        def cb(dx, x, iteration, xnorm, fnorm, success):
+            print("fnorm", fnorm)
+
+        res = fem.newtonrhapson(items=[body, load], dof0=dof0, dof1=dof1, callback=cb)
 
         assert res.success
 

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -606,16 +606,16 @@ def test_expand_revolve_quadratic():
         .add_midpoints_edges()
         .add_midpoints_faces()
     )
-    
+
     new_mesh = mesh.revolve(n=3, phi=45)
     assert len(new_mesh.cells) == 8
-    
+
     new_mesh = mesh.revolve(n=11, phi=360)
     assert len(new_mesh.cells) == 4 * 10
-    
+
     new_mesh = mesh.revolve(phi=[0, 20, 40])
     assert len(new_mesh.cells) == 8
-    
+
     new_mesh = mesh.expand(z=[0, 1, 2])
     assert len(new_mesh.cells) == 8
 


### PR DESCRIPTION
which is called after each completed iteration.

### Usage of Substep- and Newton-callbacks
`Job(..., callback=substep_callback).evaluate(..., callback=newton_callback)`.