### PR TITLE
Tests: Enforce `matplotlib.use("Agg")` to avoid tcl-related errors

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -91,6 +91,12 @@ or clone the repository and install the package in editable mode.
    cd felupe
    pip install --editable .
 
+Optional dependencies may also be installed by replacing the last line.
+
+.. code-block:: shell
+
+   pip install --editable ".[all]"
+
 Extension Packages
 ------------------
 

--- a/tests/test_constitution.py
+++ b/tests/test_constitution.py
@@ -24,6 +24,10 @@ You should have received a copy of the GNU General Public License
 along with Felupe.  If not, see <http://www.gnu.org/licenses/>.
 
 """
+import matplotlib
+
+matplotlib.use("Agg")
+
 import matplotlib.pyplot as plt
 import numpy as np
 import pytest


### PR DESCRIPTION
fixes #991 

When running the tests locally in a new virtual environment, matplotlib tries to import tcl/tk and raises an error because tcl can't be found. This PR enforces matplotlib to use a non-GUI backend in `test_constitution.py`.

Also add a note to the docs on how to install all optional dependencies in editable mode.