### PR TITLE
Enhance `MultiPointConstraint.plot(..., deformed=True)`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ All notable changes to this project will be documented in this file. The format 
 - Add a warning if `FieldMixed()` is called with `axisymmetric=True` or `planestrain=True`, more than one field `n>1` and a given `dim`. This dimension is passed to the dual fields only.
 - Add support for the conversion of `quad9` to `hexahedron27` element types in `mesh.revolve()` and `mesh.expand()`.
 - Add `newtonrhapson.callback(dx, x, iteration, xnorm, fnorm, success)` to provide a callback after each completed Newton iteration. This is available as `Job.evaluate(callback=newton_callback)`, whereas a callback after each completed substep has to be provided in `Job(callback=substep_callback)`.
-- Add `MultiPointConstraint.plot(deformed=True)`.
+- Add a flag to plot MPC and point load either on the deformed (default) or undeformed mesh-points, `MultiPointConstraint.plot(..., deformed=True)`, `MultiPointContact.plot(..., deformed=True)`, `PointLoad.plot(..., deformed=True)`.
 
 ### Changed
 - Allow field containers to be included in the list of `fields` in `FieldContainer(fields)`. If a field container is included, its sub-fields are unpacked.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file. The format 
 - Add a warning if `FieldMixed()` is called with `axisymmetric=True` or `planestrain=True`, more than one field `n>1` and a given `dim`. This dimension is passed to the dual fields only.
 - Add support for the conversion of `quad9` to `hexahedron27` element types in `mesh.revolve()` and `mesh.expand()`.
 - Add `newtonrhapson.callback(dx, x, iteration, xnorm, fnorm, success)` to provide a callback after each completed Newton iteration. This is available as `Job.evaluate(callback=newton_callback)`, whereas a callback after each completed substep has to be provided in `Job(callback=substep_callback)`.
+- Add `MultiPointConstraint.plot(deformed=True)`.
 
 ### Changed
 - Allow field containers to be included in the list of `fields` in `FieldContainer(fields)`. If a field container is included, its sub-fields are unpacked.

--- a/src/felupe/mechanics/_multipoint.py
+++ b/src/felupe/mechanics/_multipoint.py
@@ -169,14 +169,18 @@ class MultiPointConstraint:
         self.results = Results(stress=False, elasticity=False)
         self.assemble = Assemble(vector=self._vector, matrix=self._matrix)
 
-    def plot(self, plotter=None, color="black", **kwargs):
+    def plot(self, plotter=None, color="black", deformed=True, **kwargs):
         import pyvista as pv
 
         if plotter is None:
             plotter = pv.Plotter()
 
-        # get deformed points
-        x = self.mesh.points + self.field[0].values
+        # get undeformed points
+        x = self.mesh.points
+        
+        if deformed:  # get deformed points
+            x += self.field[0].values
+            
         x = np.pad(x, ((0, 0), (0, 3 - x.shape[1])))
         pointa = x[self.centerpoint]
 

--- a/src/felupe/mechanics/_multipoint.py
+++ b/src/felupe/mechanics/_multipoint.py
@@ -177,10 +177,10 @@ class MultiPointConstraint:
 
         # get undeformed points
         x = self.mesh.points
-        
+
         if deformed:  # get deformed points
-            x += self.field[0].values
-            
+            x = x + self.field[0].values
+
         x = np.pad(x, ((0, 0), (0, 3 - x.shape[1])))
         pointa = x[self.centerpoint]
 
@@ -385,6 +385,7 @@ class MultiPointContact:
         show_edges=True,
         color="black",
         opacity=0.5,
+        deformed=True,
         **kwargs,
     ):
         import pyvista as pv
@@ -392,8 +393,12 @@ class MultiPointContact:
         if plotter is None:
             plotter = pv.Plotter()
 
-        # get edge lengths of deformed enclosing box
-        x = self.mesh.points + self.field[0].values
+        # get edge lengths of undeformed enclosing box
+        x = self.mesh.points
+
+        if deformed:  # get deformed points
+            x = x + self.field[0].values
+
         edges = np.diag((x.max(axis=0) - x.min(axis=0))) + x.min(axis=0)
 
         # plot a line or a rectangle for each active contact plane

--- a/src/felupe/mechanics/_pointload.py
+++ b/src/felupe/mechanics/_pointload.py
@@ -115,6 +115,7 @@ class PointLoad:
         plotter=None,
         color="red",
         scale=0.125,
+        deformed=True,
         **kwargs,
     ):
         "Plot the point load."
@@ -125,8 +126,14 @@ class PointLoad:
             plotter = mesh.plot()
 
         if len(self.points) > 0:
-            points = np.pad(mesh.points, ((0, 0), (0, 3 - mesh.dim)))
-            magnitude = min(mesh.points.max(axis=0) - mesh.points.min(axis=0)) * scale
+
+            x = mesh.points
+
+            if deformed:
+                x = x + self.field[0].values
+
+            points = np.pad(x, ((0, 0), (0, 3 - mesh.dim)))
+            magnitude = min(points.max(axis=0) - points.min(axis=0)) * scale
 
             values = np.atleast_2d(self.values)
 


### PR DESCRIPTION
Add a flag to plot MPC and point load either on the deformed (default) or undeformed mesh-points, `MultiPointConstraint.plot(..., deformed=True)`, `MultiPointContact.plot(..., deformed=True)`, `PointLoad.plot(..., deformed=True)`.