### PR TITLE
Run tests on Python 3.9 and 3.14

### DIFF
--- a/.github/workflows/upload-codecov.yml
+++ b/.github/workflows/upload-codecov.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.13"]
+        python-version: ["3.9", "3.14"]
     steps:
     - uses: actions/setup-python@v5
       with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Topic :: Scientific/Engineering",
   "Topic :: Scientific/Engineering :: Mathematics",
   "Topic :: Utilities"


### PR DESCRIPTION
add Python 3.14 but keep 3.9 until the end of October.