### PR TITLE
Switch to default tqdm-backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@ All notable changes to this project will be documented in this file. The format 
 ## [Unreleased]
 
 ### Added
-- Add JOSS badge to README.md and change CITATION.cff to JOSS.
-- Add the keyword `Job.evaluate(tqdm="auto")` and `newtonrhapson(tqdm="auto")` with additional options `None` and `"notebook"`. In a Jupyter console, a progress bar from `tqdm.auto` does not update. The `tqdm`-keyword allows to switch the tqdm-backend manually.
+- Add a JOSS badge to README.md and change CITATION.cff to JOSS.
+- Add the keyword `Job.evaluate(tqdm="tqdm")` and `newtonrhapson(tqdm="tqdm")` with additional options `"auto"` and `"notebook"`. The `tqdm`-keyword allows to switch the tqdm-backend manually. Note that in a Jupyter console, a progress bar from `tqdm.auto` does not update. 
 
 ### Changed
 - Change the recommended citation from Zenodo to JOSS in README.md.

--- a/src/felupe/mechanics/_job.py
+++ b/src/felupe/mechanics/_job.py
@@ -153,7 +153,7 @@ class Job:
         cell_data_default=True,
         verbose=None,
         parallel=False,
-        tqdm="auto",
+        tqdm="tqdm",
         **kwargs,
     ):
         """Evaluate the steps.
@@ -191,10 +191,9 @@ class Job:
             Flag to use a threaded version of :func:`numpy.einsum` during assembly.
             Requires ``einsumt``. This may add additional overhead to small-sized
             problems. Default is False.
-        tqdm : str or None, optional
-            If verbose is True, choose a backend for ``tqdm`` (None, ``"auto"`` or
-            ``"notebook"``. Default is ``"auto"``. Note that ``tqdm.auto`` does not
-            update the progress bar in a Jupyter console, which is used in Spyder IDE.
+        tqdm : str, optional
+            If verbose is True, choose a backend for ``tqdm`` ("tqdm", ``"auto"`` or
+            ``"notebook"``. Default is ``"tqdm"``.
         **kwargs : dict
             Optional keyword arguments for :meth:`~felupe.Step.generate`. If
             ``parallel=True``, it is added as ``kwargs["parallel"] = True`` to the dict
@@ -232,14 +231,14 @@ class Job:
             try:
                 backend = str(tqdm).lower()
 
-                if backend == "none":
+                if backend == "tqdm":
                     from tqdm import tqdm
                 elif backend == "auto":
                     from tqdm.auto import tqdm
                 elif backend == "notebook":
                     from tqdm.notebook import tqdm
                 else:
-                    raise ValueError('tqdm must be None, "auto" or "notebook".')
+                    raise ValueError('tqdm must be "tqdm", "auto" or "notebook".')
 
             except ModuleNotFoundError:  # pragma: no cover
                 verbose = 2  # pragma: no cover

--- a/src/felupe/tools/_newton.py
+++ b/src/felupe/tools/_newton.py
@@ -224,7 +224,7 @@ def newtonrhapson(
     callback=None,
     callback_kwargs=None,
     progress_bar=None,
-    tqdm="auto",
+    tqdm="tqdm",
 ):
     r"""Find a root of a real function using the Newton-Raphson method.
 
@@ -282,10 +282,9 @@ def newtonrhapson(
     progress_bar : tqdm or None, optional
         Use an existing instance of a progress bar if verbose is True. If None and
         verbose is True, a new bar is created. Default is None.
-    tqdm : str or None, optional
-        If verbose is True, choose a backend for ``tqdm`` (None, ``"auto"`` or
-        ``"notebook"``. Default is ``"auto"``. Note that ``tqdm.auto`` does not
-        update the progress bar in a Jupyter console, which is used in Spyder IDE.
+    tqdm : str, optional
+        If verbose is True, choose a backend for ``tqdm`` ("tqdm", ``"auto"`` or
+        ``"notebook"``. Default is ``"tqdm"``.
 
     Returns
     -------
@@ -403,14 +402,14 @@ def newtonrhapson(
         try:
             backend = str(tqdm).lower()
 
-            if backend == "none":
+            if backend == "tqdm":
                 from tqdm import tqdm
             elif backend == "auto":
                 from tqdm.auto import tqdm
             elif backend == "notebook":
                 from tqdm.notebook import tqdm
             else:
-                raise ValueError('tqdm must be None, "auto" or "notebook".')
+                raise ValueError('tqdm must be "tqdm", "auto" or "notebook".')
 
             decades = None
 

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -99,7 +99,7 @@ def test_job_xdmf_global_field():
 
     field, step = pre()
     job = fem.Job(steps=[step])
-    job.evaluate(filename="result.xdmf", x0=field, tqdm=None)
+    job.evaluate(filename="result.xdmf", x0=field, tqdm="auto")
 
 
 def test_job_xdmf_vertex():

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -223,7 +223,7 @@ def test_newton_plane():
         field,
         verbose=True,
         kwargs=dict(umat=umat),
-        tqdm=None,
+        tqdm="auto",
         **loadcase,
     )
 


### PR DESCRIPTION
because the auto-backend has problems with Jupyter consoles (not Notebooks!). Also, in auto-mode, the background is white in apps like VSCode with a dark background. The text-based progress bars are prettier here.

Also, the tqdm-options now include tqdm, auto and notebook. All options are strings now, even the default one.