### PR TITLE
Enhance `MaterialStrain(..., symmetry=True)`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file. The format 
 
 ### Added
 - Add `MaterialStrain(..., framework="small-strain")` to select a framework. Default is `"small-strain"` (unchanged) but now `"total-lagrange"` is also supported. Note that `framework="total-lagrange"` will change the linear-elastic material model formulation to the Saint-Venant Kirchhoff material model formulation.
-- Add `MaterialStrain(..., enforce_symmetry=True)` to enforce the returned stress and elasticity tensors to be (minor) symmetric. Default is True. `enforce_symmetry=False` will improve performance if the `material` already returns symmetric tensors.
+- Add `MaterialStrain(..., symmetry=True)` to enforce the returned stress and elasticity tensors to be (minor) symmetric. Default is True. `symmetry=False` will improve performance if the provided `material` returns symmetric tensors.
 
 ### Changed
 - Don't enforce the returned elasticity tensor in `MaterialStrain` to be major-symmetric.

--- a/src/felupe/constitution/strain/models/_linear_elastic.py
+++ b/src/felupe/constitution/strain/models/_linear_elastic.py
@@ -16,7 +16,7 @@ You should have received a copy of the GNU General Public License
 along with FElupe.  If not, see <http://www.gnu.org/licenses/>.
 """
 
-from ....math import cdya, dya, identity, trace
+from ....math import cdya_ik, dya, identity, trace
 
 
 def linear_elastic(dε, εn, σn, ζn, λ, μ, **kwargs):
@@ -91,7 +91,7 @@ def linear_elastic(dε, εn, σn, ζn, λ, μ, **kwargs):
 
     # evaluate elasticity tensor
     if kwargs["tangent"]:
-        dσdε = 2 * μ * cdya(eye, eye) + λ * dya(eye, eye)
+        dσdε = 2 * μ * cdya_ik(eye, eye) + λ * dya(eye, eye)
     else:
         dσdε = None
 

--- a/src/felupe/constitution/strain/models/_linear_elastic_plastic_isotropic.py
+++ b/src/felupe/constitution/strain/models/_linear_elastic_plastic_isotropic.py
@@ -18,7 +18,7 @@ along with FElupe.  If not, see <http://www.gnu.org/licenses/>.
 
 import numpy as np
 
-from ....math import cdya, ddot, dya, identity, sqrt, trace
+from ....math import cdya_ik, ddot, dya, identity, sqrt, trace
 from ...linear_elasticity import lame_converter
 from .._material_strain import MaterialStrain
 
@@ -147,7 +147,7 @@ def linear_elastic_plastic_isotropic_hardening(dε, εn, σn, ζn, λ, μ, σy, 
     # elasticity tensor
     if kwargs["tangent"]:
         dσdε = np.zeros((3, 3, 3, 3, *dε.shape[2:]))
-        dσdε[:] = λ * dya(eye, eye) + 2 * μ * cdya(eye, eye)
+        dσdε[:] = λ * dya(eye, eye) + 2 * μ * cdya_ik(eye, eye)
     else:
         dσdε = None
 
@@ -187,7 +187,10 @@ def linear_elastic_plastic_isotropic_hardening(dε, εn, σn, ζn, λ, μ, σy, 
                 * μ
                 * dγ
                 / norm_s
-                * (2 * μ * (cdya(eye, eye) - 1 / 3 * dya(eye, eye)) - 2 * μ * dya(n, n))
+                * (
+                    2 * μ * (cdya_ik(eye, eye) - 1 / 3 * dya(eye, eye))
+                    - 2 * μ * dya(n, n)
+                )
             )[..., mask]
 
         # update list of state variables


### PR DESCRIPTION
by making the returned stress and elasticity tensors optionally symmetric. This is True by default and considered to be the safe version. For performance reasons, this can be turned off.