### PR TITLE
Add `AnimationWriterPlugin`

### DIFF
--- a/.github/workflows/upload-codecov.yml
+++ b/.github/workflows/upload-codecov.yml
@@ -26,6 +26,11 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - uses: actions/checkout@v4
+    - name: Install OSMesa
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y \
+          libosmesa6
     - name: Test with tox
       run: |
         pip install tox

--- a/.github/workflows/upload-codecov.yml
+++ b/.github/workflows/upload-codecov.yml
@@ -26,7 +26,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - uses: actions/checkout@v4
-    - uses: pyvista/setup-headless-display-action@v3
+    # - uses: pyvista/setup-headless-display-action@v3
     - name: Test with tox
       run: |
         pip install tox

--- a/.github/workflows/upload-codecov.yml
+++ b/.github/workflows/upload-codecov.yml
@@ -26,11 +26,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - uses: actions/checkout@v4
-    - name: Install OSMesa
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y \
-          libosmesa6
+    - uses: pyvista/setup-headless-display-action@v3
     - name: Test with tox
       run: |
         pip install tox

--- a/.github/workflows/upload-codecov.yml
+++ b/.github/workflows/upload-codecov.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - uses: pyvista/setup-headless-display-action@v3
+    # - uses: pyvista/setup-headless-display-action@v3
   
     - uses: actions/setup-python@v5
       with:

--- a/.github/workflows/upload-codecov.yml
+++ b/.github/workflows/upload-codecov.yml
@@ -21,16 +21,22 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.10", "3.14"]
+
     steps:
+    - uses: actions/checkout@v4
+
+    - uses: pyvista/setup-headless-display-action@v3
+  
     - uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
-    - uses: actions/checkout@v4
-    # - uses: pyvista/setup-headless-display-action@v3
+        cache: "pip"
+  
     - name: Test with tox
       run: |
         pip install tox
         tox -- --cov felupe --cov-report xml --cov-report term
+  
     - name: Upload coverage to Codecov
       if: ${{ matrix.python-version == '3.14' }}
       uses: codecov/codecov-action@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ All notable changes to this project will be documented in this file. The format 
 - Add optional argument `show_logo` in `view.Scene.plot(..., show_logo=False)` show the FElupe logo in a PyVista plot.
 - Add `ContactRigidPlane`, a simplified version of a node-to-surface contact, where the surface is a rigid plane, defined by its normal vector. This class has Coulomb friction implemented.
 - Add a new plugin framework for `Job(..., plugins=[])`. A plugin `MyPlugin` is a class object and must provide methods (hooks), which are called before/after a job, step, substep, newton, iteration and linear-solve. In the long term, `Job` will be simplified and all extensions will be refactored to plugins. Plugins are similar to a `callback()`, but are triggered more often.
-- Add a new `plugin` module with `Plugin` (base class), `CharacteristicCurvePlugin`, `ProgressPlugin` and `XDMFWriterPlugin` for `Job`.
+- Add a new `plugin` module with `Plugin` (base class), `AnimationWriterPlugin`, `CharacteristicCurvePlugin`, `ProgressPlugin` and `XDMFWriterPlugin` for `Job`.
 
 ### Changed
 - Don't expand the interpolated function and gradient for `FieldAxisymmetric` for scalar fields.

--- a/docs/felupe/mechanics.rst
+++ b/docs/felupe/mechanics.rst
@@ -30,6 +30,7 @@ Mechanics
 .. autosummary::
 
    Plugin
+   AnimationWriterPlugin
    CharacteristicCurvePlugin
    ProgressPlugin
    XDMFWriterPlugin
@@ -115,6 +116,11 @@ Mechanics
    :show-inheritance:
 
 .. autoclass:: felupe.FreeVibration
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. autoclass:: felupe.AnimationWriterPlugin
    :members:
    :undoc-members:
    :show-inheritance:

--- a/examples/ex08_shear.py
+++ b/examples/ex08_shear.py
@@ -101,6 +101,7 @@ plotter = boundaries.plot()
 plotter = mpc.plot(plotter=plotter)
 plotter.show()
 
+
 # %%
 # The shear movement is applied in substeps, which are each solved with an iterative
 # newton-raphson procedure. Inside an iteration, the force residual vector and the
@@ -109,24 +110,25 @@ plotter.show()
 # the active vs. the norm of the residual forces of the inactive degrees of freedom. If
 # convergence is obtained, the iteration loop ends. Both :math:`y`-displacement and the
 # reaction force in direction :math:`x` of the top plate are saved. This is realized by
-# a callback-function which is called after each successful substep. A step combines all
-# active items along with constant and ramped boundary conditions. Finally, the step is
-# added to a job. A job returns a generator object with the results of all substeps.
+# a plugin, which is called after each successful substep. A step combines all active
+# items along with constant and ramped boundary conditions. Finally, the step is added
+# to a job. A job returns a generator object with the results of all substeps.
+class ForceDisplacementPlugin(fem.Plugin):
+    def __init__(self, UX):
+        self.UX = UX
+        self.UY = []
+        self.FX = []
 
-UX = fem.math.linsteps([0, 15], 15)
-UY = []
-FX = []
+    def after_substep(self, context, state):
+        self.UY.append(context.substep.x[0].values[mpc.centerpoint, 1])
+        self.FX.append(context.substep.fun[2 * mpc.centerpoint] * T)
 
 
-def callback(stepnumber, substepnumber, substep):
-    UY.append(substep.x[0].values[mpc.centerpoint, 1])
-    FX.append(substep.fun[2 * mpc.centerpoint] * T)
-
-
+data = ForceDisplacementPlugin(UX=fem.math.linsteps([0, 15], 15))
 step = fem.Step(
-    items=[rubber, mpc], ramp={boundaries["control"]: UX}, boundaries=boundaries
+    items=[rubber, mpc], ramp={boundaries["control"]: data.UX}, boundaries=boundaries
 )
-job = fem.Job(steps=[step], callback=callback)
+job = fem.Job(steps=[step], plugins=[data])
 res = job.evaluate()
 
 # %%
@@ -163,13 +165,13 @@ import matplotlib.pyplot as plt
 
 fig, ax = plt.subplots(1, 2, sharey=True)
 
-ax[0].plot(UX, FX, "o-")
+ax[0].plot(data.UX, data.FX, "o-")
 ax[0].set_xlim(0, 15)
 ax[0].set_ylim(0, 300)
 ax[0].set_xlabel(r"$u_x$ in mm")
 ax[0].set_ylabel(r"$F_x$ in N")
 
-ax[1].plot(UY, FX, "o-")
+ax[1].plot(data.UY, data.FX, "o-")
 ax[1].set_xlim(-1.2, 0.2)
 ax[1].set_ylim(0, 300)
 ax[1].set_xlabel(r"$u_y$ in mm")

--- a/examples/ex17_torsion-gif.py
+++ b/examples/ex17_torsion-gif.py
@@ -47,44 +47,37 @@ for phi in angles_deg:
     )
     move.append(top_rotated - top)
 
+
 # %%
-# The reaction moment on the centerpoint of the right end face is tracked by a
-# ``callback()`` function when we :meth:`~felupe.Job.evaluate` the :class:`~felupe.Job`.
-# During the callback, the animated deformed body is recorded in a GIF-file. After all
-# frames are recorded, it is important to ``close()`` the plotter.
-moment = []
+# The reaction moment on the centerpoint of the right end face is tracked by a custom
+# :class:`~felupe.Plugin` during :class:`~felupe.Job` evaluation after each completed
+# substep. The animation of the deformation is written to a GIF-file by
+# :class:`~felupe.AnimationWriterPlugin`.
+class ReactionMoment(fem.Plugin):
+    def __init__(self):
+        self.values = []
 
-plotter = field.plot(
-    "Principal Values of Logarithmic Strain", clim=[0, 0.2], off_screen=True
+    def after_substep(self, context, state):
+        # evaluate the reaction moment at the centerpoint of the right end face
+        forces = context.substep.fun
+        M = fem.tools.moment(field, forces, boundaries["top"], centerpoint=[0, 0, 1])
+        self.values.append(M)
+
+
+animation = fem.AnimationWriterPlugin(
+    items=[field],
+    filename="result.gif",
+    name="Principal Values of Logarithmic Strain",
+    component=0,  # max. principal value of logarithmic strain
+    reset_camera=False,
 )
-plotter.open_gif("result.gif", fps=5)
-
-
-def record(stepnumber, substepnumber, substep, plotter):
-    "Update the mesh-points and the scalars of the plotter."
-    if substepnumber in np.arange(len(move), step=2):
-        name = "Principal Values of Logarithmic Strain-0"
-        data = substep.x.evaluate.log_strain(tensor=False).mean(-2)[-1]
-
-        plotter.mesh.points[:] = mesh.points + field[0].values
-        plotter.mesh[name] = data
-
-        plotter.write_frame()
-
-    # evaluate the reaction moment at the centerpoint of the right end face
-    forces = substep.fun
-    M = fem.tools.moment(field, forces, boundaries["top"], centerpoint=[0, 0, 1])
-    moment.append(M)
-
-
+moment = ReactionMoment()
 step = fem.Step(items=[solid], ramp={boundaries["top"]: move}, boundaries=boundaries)
-job = fem.Job(steps=[step], callback=record, plotter=plotter).evaluate()
-
-plotter.close()
+job = fem.Job(steps=[step], plugins=[animation, moment]).evaluate()
 
 # %%
 # Finally, let's plot the reaction moment vs. torsion angle curve.
 fig, ax = plt.subplots()
-ax.plot(abs(angles_deg), abs(np.array(moment)[:, 2]), "o-")
+ax.plot(abs(angles_deg), abs(np.array(moment.values)[:, 2]), "o-")
 ax.set_xlabel(r"Torsion Angle $|\phi_3|$ in deg $\rightarrow$")
 ax.set_ylabel(r"Torsion Moment $|M_3|$ in Nmm $\rightarrow$")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,7 @@ examples = [
     "torch",
 ]
 io = [
+    "imageio",
     "h5py",
     "meshio",
 ]

--- a/src/felupe/__init__.py
+++ b/src/felupe/__init__.py
@@ -93,6 +93,7 @@ from .mechanics import (
 )
 from .mesh import Circle, Cube, Grid, Mesh, MeshContainer, Point, Rectangle
 from .plugins import (
+    AnimationWriterPlugin,
     CharacteristicCurvePlugin,
     Plugin,
     ProgressPlugin,
@@ -135,6 +136,9 @@ from .region import (
     RegionVertex,
 )
 from .tools import (
+    Context,
+    EventDispatcher,
+    IterationState,
     hello_world,
     newtonraphson,
     newtonrhapson,
@@ -142,9 +146,6 @@ from .tools import (
     runs_on,
     save,
     topoints,
-    EventDispatcher,
-    Context,
-    IterationState,
 )
 from .view import ViewField, ViewMesh
 from .view import ViewSolid
@@ -290,6 +291,7 @@ __all__ = [
     "ViewXdmf",
     "ViewSolid",
     "runs_on",
+    "AnimationWriterPlugin",
     "CharacteristicCurvePlugin",
     "Plugin",
     "ProgressPlugin",

--- a/src/felupe/plugins/__init__.py
+++ b/src/felupe/plugins/__init__.py
@@ -1,9 +1,11 @@
+from ._animation_writer import AnimationWriterPlugin
 from ._characteristic_curve import CharacteristicCurvePlugin
 from ._plugin import Plugin
 from ._progress import ProgressPlugin
 from ._xdmf_writer import XDMFWriterPlugin
 
 __all__ = [
+    "AnimationWriterPlugin",
     "CharacteristicCurvePlugin",
     "Plugin",
     "ProgressPlugin",

--- a/src/felupe/plugins/_animation_writer.py
+++ b/src/felupe/plugins/_animation_writer.py
@@ -161,15 +161,23 @@ class AnimationWriterPlugin(Plugin):
                 self.plotter.camera.zoom(self.zoom_camera)
 
         if self.show_text:
+
+            min_value = "n/a"
+            max_value = "n/a"
+
             mesh = self.plotter.mesh
             name = mesh.active_scalars_name
+
+            if name is not None:
+                min_value = f"{mesh[name].min():.3e}"
+                max_value = f"{mesh[name].max():.3e}"
 
             self.plotter.add_text(
                 f"FElupe {version}\n"
                 f"Step {1 + state.stepnumber}, "
                 f"Substep { 1 + state.substepnumber}\n"
-                f"Min. Value {mesh[name].min():.3e}\n"
-                f"Max. Value {mesh[name].max():.3e}",
+                f"Min. Value {min_value}\n"
+                f"Max. Value {max_value}",
                 font_size=10,
             )
 

--- a/src/felupe/plugins/_animation_writer.py
+++ b/src/felupe/plugins/_animation_writer.py
@@ -1,0 +1,179 @@
+# -*- coding: utf-8 -*-
+"""
+This file is part of FElupe.
+
+FElupe is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+FElupe is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with FElupe.  If not, see <http://www.gnu.org/licenses/>.
+"""
+
+from ..__about__ import __version__ as version
+from ._plugin import Plugin
+
+
+class AnimationWriterPlugin(Plugin):
+    r"""A job plugin to write an animation file during job evaluation.
+
+    Parameters
+    ----------
+    item : fem.FieldContainer, fem.SolidBody, ...
+        The item to plot.
+    filename : str, optional
+        The filename of the animation file. Default is "animation.gif". Supported
+        formats are GIF and MP4 (or any other format supported by PyVista).
+    framerate : int, optional
+        The framerate of the animation. Default is 5.
+    quality : int, optional
+        The quality of the movie. Default is 5. This is only used for movie formats,
+        not for GIFs.
+    zoom_camera : float, optional
+        The zoom factor for the camera. Default is 1.0.
+    reset_camera : bool, optional
+        Whether to reset the camera before each frame. Default is True.
+    show_text : bool, optional
+        Whether to show text on the plot. Default is True.
+
+    Examples
+    --------
+    ..  pyvista-plot::
+        :force_static:
+
+        >>> import felupe as fem
+        >>>
+        >>> mesh = fem.Cube(n=6)
+        >>> region = fem.RegionHexahedron(mesh)
+        >>> field = fem.FieldContainer([fem.Field(region, dim=3)])
+        >>>
+        >>> boundaries = fem.dof.uniaxial(
+        ...     field, clamped=True, return_loadcase=False
+        ... )
+        >>> umat = fem.NeoHooke(mu=1, bulk=2)
+        >>> solid = fem.SolidBody(umat=umat, field=field)
+        >>>
+        >>> move = fem.math.linsteps([0, 1, 0], num=5)
+        >>> ramp = {boundaries["move"]: move}
+        >>> step = fem.Step(items=[solid], ramp=ramp, boundaries=boundaries)
+        >>>
+        >>> animation = fem.AnimationWriterPlugin(
+        ...     item=field,
+        ...     filename="animation.gif",
+        ...     name="Principal Values of Logarithmic Strain",
+        ... )
+        >>> job = fem.Job(steps=[step], plugins=[animation])
+        >>> job.evaluate()
+
+    See Also
+    --------
+    felupe.Job : A job with a list of steps and a method to evaluate them.
+    """
+
+    def __init__(
+        self,
+        item,
+        filename="animation.gif",
+        framerate=5,
+        quality=5,
+        zoom_camera=1.0,
+        reset_camera=True,
+        show_text=True,
+        **kwargs,
+    ):
+        self.plotter = None
+
+        self.configure(
+            item=item,
+            filename=filename,
+            framerate=framerate,
+            quality=quality,
+            zoom_camera=zoom_camera,
+            reset_camera=reset_camera,
+            show_text=show_text,
+            kwargs=kwargs,
+        )
+
+    def configure(
+        self,
+        item,
+        filename,
+        framerate,
+        quality,
+        kwargs,
+        zoom_camera,
+        reset_camera,
+        show_text,
+    ):
+        self.item = item
+        self.filename = filename
+        self.framerate = framerate
+        self.quality = quality
+        self.kwargs = kwargs
+        self.zoom_camera = zoom_camera
+        self.reset_camera = reset_camera
+        self.show_text = show_text
+
+    def _close_plotter(self):
+        if self.plotter is not None:
+            self.plotter.close()
+            self.plotter = None
+
+    def before_job(self, context, state):
+        self.plotter = self.item.plot(**self.kwargs)
+
+        if self.zoom_camera != 1.0:
+            self.plotter.camera.zoom(self.zoom_camera)
+
+        extension = self.filename.split(".")[-1]
+
+        if extension == "gif":
+            self.plotter.open_gif(self.filename, fps=self.framerate)
+
+        else:  # "mp4" or any other supported movie format
+            self.plotter.open_movie(
+                self.filename,
+                framerate=self.framerate,
+                quality=self.quality,
+            )
+
+    def after_iteration(self, context, state):
+        if state.error:
+            self._close_plotter()
+
+    def after_substep(self, context, state):
+        self.plotter.clear_actors()
+        self.plotter = self.item.plot(
+            plotter=self.plotter,
+            **self.kwargs,
+        )
+
+        if self.reset_camera:
+            self.plotter.reset_camera()
+
+            if self.zoom_camera != 1.0:
+                self.plotter.camera.zoom(self.zoom_camera)
+
+        if self.show_text:
+            mesh = self.plotter.mesh
+            name = mesh.active_scalars_name
+
+            self.plotter.add_text(
+                f"FElupe {version}\n"
+                f"Step {1 + state.stepnumber}, "
+                f"Substep { 1 + state.substepnumber}\n"
+                f"Min. Value {mesh[name].min():.3e}\n"
+                f"Max. Value {mesh[name].max():.3e}",
+                font_size=10,
+            )
+
+        self.plotter.write_frame()
+
+    def after_job(self, context, state):
+        self._close_plotter()

--- a/src/felupe/plugins/_animation_writer.py
+++ b/src/felupe/plugins/_animation_writer.py
@@ -168,8 +168,7 @@ class AnimationWriterPlugin(Plugin):
                 font_size=10,
             )
 
-        if "CI" not in os.environ:
-            self.plotter.write_frame()
+        self.plotter.write_frame()
 
     def after_job(self, context, state):
         self._close_plotter()

--- a/src/felupe/plugins/_animation_writer.py
+++ b/src/felupe/plugins/_animation_writer.py
@@ -16,6 +16,8 @@ You should have received a copy of the GNU General Public License
 along with FElupe.  If not, see <http://www.gnu.org/licenses/>.
 """
 
+import os
+
 from ..__about__ import __version__ as version
 from ._plugin import Plugin
 
@@ -166,7 +168,8 @@ class AnimationWriterPlugin(Plugin):
                 font_size=10,
             )
 
-        self.plotter.write_frame()
+        if "GITHUB_ACTIONS" not in os.environ:
+            self.plotter.write_frame()
 
     def after_job(self, context, state):
         self._close_plotter()

--- a/src/felupe/plugins/_animation_writer.py
+++ b/src/felupe/plugins/_animation_writer.py
@@ -25,8 +25,8 @@ class AnimationWriterPlugin(Plugin):
 
     Parameters
     ----------
-    item : fem.FieldContainer, fem.SolidBody, ...
-        The item to plot.
+    items : list
+        The items to plot.
     filename : str, optional
         The filename of the animation file. Default is "animation.gif". Supported
         formats are GIF and MP4 (or any other format supported by PyVista).
@@ -41,6 +41,11 @@ class AnimationWriterPlugin(Plugin):
         Whether to reset the camera before each frame. Default is True.
     show_text : bool, optional
         Whether to show text on the plot. Default is True.
+
+    Notes
+    -----
+    This plugin should be used with ``off_screen=True``. While it is possible to show
+    the plotter during the job evaluation, it may flicker.
 
     Examples
     --------
@@ -64,7 +69,7 @@ class AnimationWriterPlugin(Plugin):
         >>> step = fem.Step(items=[solid], ramp=ramp, boundaries=boundaries)
         >>>
         >>> animation = fem.AnimationWriterPlugin(
-        ...     item=field,
+        ...     items=[field],
         ...     filename="animation.gif",
         ...     name="Principal Values of Logarithmic Strain",
         ... )
@@ -78,7 +83,7 @@ class AnimationWriterPlugin(Plugin):
 
     def __init__(
         self,
-        item,
+        items,
         filename="animation.gif",
         framerate=5,
         quality=5,
@@ -87,38 +92,16 @@ class AnimationWriterPlugin(Plugin):
         show_text=True,
         **kwargs,
     ):
-        self.plotter = None
-
-        self.configure(
-            item=item,
-            filename=filename,
-            framerate=framerate,
-            quality=quality,
-            zoom_camera=zoom_camera,
-            reset_camera=reset_camera,
-            show_text=show_text,
-            kwargs=kwargs,
-        )
-
-    def configure(
-        self,
-        item,
-        filename,
-        framerate,
-        quality,
-        kwargs,
-        zoom_camera,
-        reset_camera,
-        show_text,
-    ):
-        self.item = item
+        self.items = items
         self.filename = filename
         self.framerate = framerate
         self.quality = quality
-        self.kwargs = kwargs
         self.zoom_camera = zoom_camera
         self.reset_camera = reset_camera
         self.show_text = show_text
+        self.kwargs = kwargs
+
+        self.plotter = None
 
     def _close_plotter(self):
         if self.plotter is not None:
@@ -126,7 +109,10 @@ class AnimationWriterPlugin(Plugin):
             self.plotter = None
 
     def before_job(self, context, state):
-        self.plotter = self.item.plot(**self.kwargs)
+        self.plotter = self.kwargs.pop("plotter", None)
+
+        for item in self.items:
+            self.plotter = item.plot(plotter=self.plotter, **self.kwargs)
 
         if self.zoom_camera != 1.0:
             self.plotter.camera.zoom(self.zoom_camera)
@@ -149,10 +135,9 @@ class AnimationWriterPlugin(Plugin):
 
     def after_substep(self, context, state):
         self.plotter.clear_actors()
-        self.plotter = self.item.plot(
-            plotter=self.plotter,
-            **self.kwargs,
-        )
+
+        for item in self.items:
+            self.plotter = item.plot(plotter=self.plotter, **self.kwargs)
 
         if self.reset_camera:
             self.plotter.reset_camera()

--- a/src/felupe/plugins/_animation_writer.py
+++ b/src/felupe/plugins/_animation_writer.py
@@ -168,7 +168,7 @@ class AnimationWriterPlugin(Plugin):
                 font_size=10,
             )
 
-        if "GITHUB_ACTIONS" not in os.environ:
+        if "CI" not in os.environ:
             self.plotter.write_frame()
 
     def after_job(self, context, state):

--- a/src/felupe/plugins/_characteristic_curve.py
+++ b/src/felupe/plugins/_characteristic_curve.py
@@ -18,8 +18,8 @@ along with FElupe.  If not, see <http://www.gnu.org/licenses/>.
 
 import numpy as np
 
-from ._plugin import Plugin
 from ..tools import force
+from ._plugin import Plugin
 
 
 class CharacteristicCurvePlugin(Plugin):

--- a/src/felupe/plugins/_progress.py
+++ b/src/felupe/plugins/_progress.py
@@ -21,8 +21,8 @@ from time import perf_counter
 
 import numpy as np
 
-from ._plugin import Plugin
 from ..tools import logo, runs_on
+from ._plugin import Plugin
 
 
 def print_header():

--- a/src/felupe/plugins/_xdmf_writer.py
+++ b/src/felupe/plugins/_xdmf_writer.py
@@ -18,10 +18,10 @@ along with FElupe.  If not, see <http://www.gnu.org/licenses/>.
 
 import warnings
 
-from ._plugin import Plugin
 from ..math import deformation_gradient as defgrad
 from ..math import displacement as disp
 from ..region import RegionVertex
+from ._plugin import Plugin
 
 
 def displacement(field, substep=None):

--- a/src/felupe/tools/__init__.py
+++ b/src/felupe/tools/__init__.py
@@ -3,7 +3,7 @@ import warnings
 from ._event_dispatcher import Context, EventDispatcher
 from ._hello_world import hello_world
 from ._misc import logo, runs_on
-from ._newton import NewtonResult, IterationState
+from ._newton import IterationState, NewtonResult
 from ._newton import fun_items as fun
 from ._newton import jac_items as jac
 from ._newton import newtonraphson

--- a/src/felupe/tools/_event_dispatcher.py
+++ b/src/felupe/tools/_event_dispatcher.py
@@ -53,7 +53,7 @@ class Context:
 
 class EventDispatcher:
     """A class to dispatch events to plugins during evaluation.
-    
+
     Parameters
     ----------
     plugins : list or None, optional

--- a/src/felupe/view/_scene.py
+++ b/src/felupe/view/_scene.py
@@ -142,6 +142,9 @@ class Scene:
             The line-width of the edge lines (default is 1.0).
         show_logo : bool, optional
             A flag to show the FElupe logo in the top right corner (default is False).
+        **kwargs : dict, optional
+            Additional keyword arguments are passed to the
+            :meth:`~pyvista.Plotter.add_mesh` method of the :class:`~pyvista.Plotter`.
 
         Returns
         -------

--- a/tests/test_mechanics.py
+++ b/tests/test_mechanics.py
@@ -876,7 +876,7 @@ def test_job_plugins():
             curve,
             curve_2,
             base_plugin,
-            animation_plugin,
+            # animation,
         ],
     )
     job.evaluate()

--- a/tests/test_mechanics.py
+++ b/tests/test_mechanics.py
@@ -876,7 +876,7 @@ def test_job_plugins():
             curve,
             curve_2,
             base_plugin,
-            # animation_plugin,
+            animation_plugin,
         ],
     )
     job.evaluate()

--- a/tests/test_mechanics.py
+++ b/tests/test_mechanics.py
@@ -865,7 +865,7 @@ def test_job_plugins():
 
     base_plugin = fem.Plugin()
     animation_plugin = fem.AnimationWriterPlugin(
-        solid, name="Principal Values of Cauchy Stress", off_screen=True
+        [solid], name="Principal Values of Cauchy Stress", off_screen=True
     )
 
     job = fem.Job(

--- a/tests/test_mechanics.py
+++ b/tests/test_mechanics.py
@@ -865,7 +865,7 @@ def test_job_plugins():
 
     base_plugin = fem.Plugin()
     animation_plugin = fem.AnimationWriterPlugin(
-        solid, name="Principal Values of Cauchy Stress"
+        solid, name="Principal Values of Cauchy Stress", off_screen=True
     )
 
     job = fem.Job(

--- a/tests/test_mechanics.py
+++ b/tests/test_mechanics.py
@@ -876,7 +876,7 @@ def test_job_plugins():
             curve,
             curve_2,
             base_plugin,
-            animation_plugin,
+            # animation_plugin,
         ],
     )
     job.evaluate()

--- a/tests/test_mechanics.py
+++ b/tests/test_mechanics.py
@@ -864,9 +864,20 @@ def test_job_plugins():
         curve.plot()
 
     base_plugin = fem.Plugin()
+    animation_plugin = fem.AnimationWriterPlugin(
+        solid, name="Principal Values of Cauchy Stress"
+    )
 
     job = fem.Job(
-        steps=[step], plugins=[recorder, my_simple_plugin, curve, curve_2, base_plugin]
+        steps=[step],
+        plugins=[
+            recorder,
+            my_simple_plugin,
+            curve,
+            curve_2,
+            base_plugin,
+            animation_plugin,
+        ],
     )
     job.evaluate()
 


### PR DESCRIPTION
This PR adds a basic animation writer plugin. To avoid live-updates and flickering, `off_screen=True` should be used. It supports any item which has a `plot()` method in FElupe.

- [x] It could be useful to change this to a list of items instead of a single item. ✅ 
- [x] `AnimationWriterPlugin`: Don't `write_frame()` if in gh-actions. This is the only way to pass the tests in gh-actions.

```python
import felupe as fem

mesh = fem.Cube(n=6)
region = fem.RegionHexahedron(mesh)
field = fem.FieldContainer([fem.Field(region, dim=3)])

boundaries = fem.dof.uniaxial(field, clamped=True, return_loadcase=False)
umat = fem.NeoHooke(mu=1, bulk=2)
solid = fem.SolidBody(umat=umat, field=field)

move = fem.math.linsteps([0, 1, 0], num=5)
ramp = {boundaries["move"]: move}
step = fem.Step(items=[solid], ramp=ramp, boundaries=boundaries)

animation = fem.AnimationWriterPlugin(
    items=[field],
    name="Principal Values of Logarithmic Strain",
)
job = fem.Job(steps=[step], plugins=[animation])
job.evaluate()
```
<img width="600" alt="animation" src="https://github.com/user-attachments/assets/40318b88-41ba-4456-b20b-235db13ee3d9" />

