### PR TITLE
Clear the centerpoint of `MultiPointContact` from `mesh.points_without_cells`, support mask-based `points`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ All notable changes to this project will be documented in this file. The format 
 - Change default dimension of an axisymmetric field from 2 to 1, i.e. `FieldAxisymmetric(..., dim=1)`. This fixes errors regarding wrong shapes with `SolidBodyThermal.heat_flux_boundary()`.
 - Change `FieldContainer.plot()`: Add general `"Field"` name for plotting field values of non-vector valued fields, like the temperature in thermal problems. Only activate `warp_by_vector`, if the field is a vector-valued field with the same dimension as the mesh.
 - Clear the centerpoint of `MultiPointContact`, `MultiPointConstraint`, `PointLoad` and `ContactRigidPlane` from `mesh.points_without_cells`. Previously, this had to be done manually and is now checked when creating one of the above objects.
-- Allow mask-based `points` `MultiPointContact`, `MultiPointConstraint`, `PointLoad` and `ContactRigidPlane` in addition to point indices.
+- Allow mask-based `points` in `MultiPointContact`, `MultiPointConstraint`, `PointLoad` and `ContactRigidPlane` in addition to point indices.
 
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ All notable changes to this project will be documented in this file. The format 
 - Change `FieldContainer.plot()`: Add general `"Field"` name for plotting field values of non-vector valued fields, like the temperature in thermal problems. Only activate `warp_by_vector`, if the field is a vector-valued field with the same dimension as the mesh.
 - Clear the centerpoint of `MultiPointContact`, `MultiPointConstraint`, `PointLoad` and `ContactRigidPlane` from `mesh.points_without_cells`. Previously, this had to be done manually and is now checked when creating one of the above objects.
 - Allow mask-based `points` in `MultiPointContact`, `MultiPointConstraint`, `PointLoad` and `ContactRigidPlane` in addition to point indices.
-
+- Allow empty list for `points` in `MultiPointContact`, `MultiPointConstraint`, `PointLoad` and `ContactRigidPlane` in addition to point indices.
 
 ### Fixed
 - Fix the typo `Rhapson` and change it to `Raphson`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ All notable changes to this project will be documented in this file. The format 
 - Set the `algorithm` in `pyvista.UnstructuredGrid.extract_surface(algorithm=None)` to prevent future errors with `nonlinear_subdivision`.
 - Change default dimension of an axisymmetric field from 2 to 1, i.e. `FieldAxisymmetric(..., dim=1)`. This fixes errors regarding wrong shapes with `SolidBodyThermal.heat_flux_boundary()`.
 - Change `FieldContainer.plot()`: Add general `"Field"` name for plotting field values of non-vector valued fields, like the temperature in thermal problems. Only activate `warp_by_vector`, if the field is a vector-valued field with the same dimension as the mesh.
+- Clear the centerpoint of `MultiPointContact`, `MultiPointConstraint`, `PointLoad` and `ContactRigidPlane` from `mesh.points_without_cells`. Previously, this had to be done manually and is now checked when creating one of the above objects.
+- Allow mask-based `points` `MultiPointContact`, `MultiPointConstraint`, `PointLoad` and `ContactRigidPlane` in addition to point indices.
 
 
 ### Fixed

--- a/examples/ex06_rubber-metal-spring.py
+++ b/examples/ex06_rubber-metal-spring.py
@@ -33,7 +33,6 @@ import felupe as fem
 
 mesh = fem.mesh.read("ex06_rubber-metal-spring_mesh.vtk")[0]
 mesh.add_points([[0, 0, mesh.z.min()], [0, 0, mesh.z.max() + 1]])
-mesh.clear_points_without_cells()  # used for contact center-points
 
 mesh.plot().show()
 
@@ -68,8 +67,7 @@ solid = fem.SolidBody(umat, field)
 # the solid body are determined. Then, the center (control) point is defined by one of
 # the mesh points on the end faces in direction :math:`z`.
 surface = np.unique(fem.RegionHexahedronBoundary(mesh).mesh_faces().cells)
-mask = np.isin(np.arange(mesh.npoints), surface)
-points = np.where(mask)[0]
+points = np.isin(np.arange(mesh.npoints), surface)
 
 bottom = fem.ContactRigidPlane(
     field,

--- a/examples/ex08_shear.py
+++ b/examples/ex08_shear.py
@@ -10,7 +10,7 @@ Non-homogeneous shear
 
    * assign a micro-sphere material formulation
 
-   * define a step and a job along with a callback-function
+   * define a step and a job along with a plugin to record force-displacement data
 
    * export and visualize principal stretches
 
@@ -26,9 +26,7 @@ with a compressive normal force :math:`F`.
 
 
 Let's create the mesh. An additional center-point is created for a multi-point
-constraint (MPC). By default, FElupe stores points not connected to any cells in
-:attr:`Mesh.points_without_cells` and adds them to the list of inactive
-degrees of freedom. Hence, we have to drop our MPC-centerpoint from that list.
+constraint (MPC).
 """
 
 # sphinx_gallery_thumbnail_number = -2
@@ -45,7 +43,6 @@ a = min(L / n, H / n)
 
 mesh = fem.Rectangle((0, 0), (L, H), n=(round(L / a), round(H / a)))
 mesh.add_points([L / 2, 1.3 * H])
-mesh.clear_points_without_cells()
 
 # %%
 # A numeric quad-region created on the mesh in combination with a vector-valued
@@ -54,7 +51,6 @@ mesh.clear_points_without_cells()
 # load case is applied on the displacement field. This involves setting up a y-symmetry
 # plane as well as the absolute value of the prescribed shear movement in direction
 # :math:`x` at the MPC-centerpoint.
-
 region = fem.RegionQuad(mesh)
 field = fem.FieldsMixed(region, n=3, planestrain=True)
 
@@ -70,7 +66,6 @@ dof0, dof1 = fem.dof.partition(field, boundaries)
 # as a :class:`~felupe.Hyperelastic` material. The material
 # formulation is finally applied on the plane-strain field, resulting in a hyperelastic
 # solid body.
-
 import felupe.constitution.tensortrax as mat
 
 # import felupe.constitution.jax as mat
@@ -90,11 +85,10 @@ rubber = fem.SolidBody(umat=fem.NearlyIncompressible(umat, bulk=5000), field=fie
 # At the centerpoint of a multi-point constraint (MPC) the external shear
 # movement is prescribed. It also ensures a force-free top plate in direction
 # :math:`y`.
-
 mpc = fem.MultiPointConstraint(
     field=field,
-    points=np.arange(mesh.npoints)[mesh.points[:, 1] == H],
-    centerpoint=mesh.npoints - 1,
+    points=mesh.points[:, 1] == H,
+    centerpoint=-1,
 )
 
 plotter = boundaries.plot()
@@ -137,7 +131,6 @@ res = job.evaluate()
 # :meth:`FieldContainer.evaluate.strain <felupe.field.EvaluateFieldContainer.strain>`-
 # method to return the principal stretches. For plotting, these values are projected
 # from quadrature-points to mesh-points.
-
 from felupe.math import dot, eigh, transpose
 
 F = field[0].extract()
@@ -160,7 +153,6 @@ plotter.show()
 # %%
 # The shear force :math:`F_x` vs. the displacements :math:`u_x` and :math:`u_y`, all
 # located at the top plate, are plotted.
-
 import matplotlib.pyplot as plt
 
 fig, ax = plt.subplots(1, 2, sharey=True)

--- a/examples/ex19_taylor-hood.py
+++ b/examples/ex19_taylor-hood.py
@@ -42,7 +42,7 @@ top = fem.ContactRigidPlane(
     items=[solid],
     friction=0.5,
     multiplier=10,  # increase contact normal multiplier
-    multiplier_tangential=1,  # increase contact tangential multiplier
+    multiplier_tangential=2,  # increase contact tangential multiplier
 )
 kwargs = dict(line_width=5, opacity=1, sym=(True, False), size=2)
 mesh.plot(nonlinear_subdivision=4, plotter=top.plot(**kwargs)).show()

--- a/examples/ex19_taylor-hood.py
+++ b/examples/ex19_taylor-hood.py
@@ -21,7 +21,6 @@ mesh = fem.Circle(n=6, sections=[0]).triangulate().add_midpoints_edges()
 mask = np.isclose(mesh.x**2 + mesh.y**2, 1, atol=0.05)
 mesh.points[mask] /= np.linalg.norm(mesh.points[mask], axis=1).reshape(-1, 1)
 mesh.add_points([0, 1.1])
-mesh.clear_points_without_cells()
 
 # %%
 # Let's create a region for quadratic triangles and a mixed-field container with two

--- a/examples/ex19_taylor-hood.py
+++ b/examples/ex19_taylor-hood.py
@@ -42,7 +42,7 @@ top = fem.ContactRigidPlane(
     items=[solid],
     friction=0.5,
     multiplier=10,  # increase contact normal multiplier
-    multiplier_tangential=10,  # increase contact tangential multiplier
+    multiplier_tangential=1,  # increase contact tangential multiplier
 )
 kwargs = dict(line_width=5, opacity=1, sym=(True, False), size=2)
 mesh.plot(nonlinear_subdivision=4, plotter=top.plot(**kwargs)).show()

--- a/examples/ex22_solid_body_thermal.py
+++ b/examples/ex22_solid_body_thermal.py
@@ -8,7 +8,7 @@ Thermal Analysis
      :class:`~felupe.thermal.SolidBodySurfaceHeatTransfer`
 
    * evaluate the surface heat flux at internal and external boundaries
-     with a callback function
+     with a job :class:`~felupe.Plugin`
 
    * view the temperature field
 

--- a/src/felupe/mechanics/_contact.py
+++ b/src/felupe/mechanics/_contact.py
@@ -378,6 +378,9 @@ class ContactRigidPlane(ContactPlane):
         self.points = np.array(points)
         self.centerpoint = centerpoint
 
+        if len(self.points) == 0:
+            self.points = self.points.astype(int)
+
         if self.points.dtype == bool:
             self.points = np.where(self.points)[0]
 

--- a/src/felupe/mechanics/_contact.py
+++ b/src/felupe/mechanics/_contact.py
@@ -375,8 +375,19 @@ class ContactRigidPlane(ContactPlane):
     ):
         self.field = field
         self.mesh = field.region.mesh
-        self.points = np.array(points, dtype=int)
+        self.points = np.array(points)
         self.centerpoint = centerpoint
+
+        if self.points.dtype == bool:
+            self.points = np.where(self.points)[0]
+
+        if self.centerpoint < 0:
+            self.centerpoint = self.mesh.npoints + self.centerpoint
+
+        if self.centerpoint in self.mesh.points_without_cells:
+            self.mesh.points_without_cells = self.mesh.points_without_cells[
+                self.mesh.points_without_cells != self.centerpoint
+            ]
 
         self.normal = np.array(normal, dtype=float)[: self.mesh.dim]
         self.normal /= np.linalg.norm(self.normal)

--- a/src/felupe/mechanics/_multipoint.py
+++ b/src/felupe/mechanics/_multipoint.py
@@ -168,6 +168,9 @@ class MultiPointConstraint:
         self.axes = np.arange(self.mesh.dim)[self.mask]
         self.multiplier = multiplier
 
+        if len(self.points) == 0:
+            self.points = self.points.astype(int)
+
         if self.points.dtype == bool:
             self.points = np.where(self.points)[0]
 
@@ -387,6 +390,9 @@ class MultiPointContact:
         self.mask = ~np.array(skip, dtype=bool)[: self.mesh.dim]
         self.axes = np.arange(self.mesh.dim)[self.mask]
         self.multiplier = multiplier
+
+        if len(self.points) == 0:
+            self.points = self.points.astype(int)
 
         if self.points.dtype == bool:
             self.points = np.where(self.points)[0]

--- a/src/felupe/mechanics/_multipoint.py
+++ b/src/felupe/mechanics/_multipoint.py
@@ -16,6 +16,8 @@ You should have received a copy of the GNU General Public License
 along with FElupe.  If not, see <http://www.gnu.org/licenses/>.
 """
 
+import warnings
+
 import numpy as np
 from scipy.sparse import eye, lil_matrix
 
@@ -160,11 +162,22 @@ class MultiPointConstraint:
     ):
         self.field = field
         self.mesh = field.region.mesh
-        self.points = np.asarray(points)
+        self.points = np.array(points)
         self.centerpoint = centerpoint
         self.mask = ~np.array(skip, dtype=bool)[: self.mesh.dim]
         self.axes = np.arange(self.mesh.dim)[self.mask]
         self.multiplier = multiplier
+
+        if self.points.dtype == bool:
+            self.points = np.where(self.points)[0]
+
+        if self.centerpoint < 0:
+            self.centerpoint = self.mesh.npoints + self.centerpoint
+
+        if self.centerpoint in self.mesh.points_without_cells:
+            self.mesh.points_without_cells = self.mesh.points_without_cells[
+                self.mesh.points_without_cells != self.centerpoint
+            ]
 
         self.results = Results(stress=False, elasticity=False)
         self.assemble = Assemble(vector=self._vector, matrix=self._matrix)
@@ -369,11 +382,22 @@ class MultiPointContact:
     ):
         self.field = field
         self.mesh = field.region.mesh
-        self.points = np.asarray(points)
+        self.points = np.array(points)
         self.centerpoint = centerpoint
         self.mask = ~np.array(skip, dtype=bool)[: self.mesh.dim]
         self.axes = np.arange(self.mesh.dim)[self.mask]
         self.multiplier = multiplier
+
+        if self.points.dtype == bool:
+            self.points = np.where(self.points)[0]
+
+        if self.centerpoint < 0:
+            self.centerpoint = self.mesh.npoints + self.centerpoint
+
+        if self.centerpoint in self.mesh.points_without_cells:
+            self.mesh.points_without_cells = self.mesh.points_without_cells[
+                self.mesh.points_without_cells != self.centerpoint
+            ]
 
         self.results = Results(stress=False, elasticity=False)
         self.assemble = Assemble(vector=self._vector, matrix=self._matrix)

--- a/src/felupe/mechanics/_pointload.py
+++ b/src/felupe/mechanics/_pointload.py
@@ -66,7 +66,10 @@ class PointLoad:
 
     def __init__(self, field, points, values=None, apply_on=0, axisymmetric=False):
         self.field = field
-        self.points = points
+        self.points = np.array(points)
+
+        if self.points.dtype == bool:
+            self.points = np.where(self.points)[0]
 
         if values is None:
             self.values = 0

--- a/src/felupe/mechanics/_pointload.py
+++ b/src/felupe/mechanics/_pointload.py
@@ -68,6 +68,9 @@ class PointLoad:
         self.field = field
         self.points = np.array(points)
 
+        if len(self.points) == 0:
+            self.points = self.points.astype(int)
+
         if self.points.dtype == bool:
             self.points = np.where(self.points)[0]
 

--- a/tests/test_contact.py
+++ b/tests/test_contact.py
@@ -24,6 +24,7 @@ You should have received a copy of the GNU General Public License
 along with Felupe.  If not, see <http://www.gnu.org/licenses/>.
 
 """
+
 import numpy as np
 import pytest
 
@@ -55,10 +56,14 @@ def pre_contact_mixed(point, values):
     boundaries["move"] = fem.Boundary(fields[0], fx=f2, skip=(0, 1, 1), value=0.5)
 
     bnd = fem.Boundary(fields[0], fx=f1).points
-    cpoint = mesh.npoints - 1
+    cpoint = -1
 
     CONT = fem.ContactRigidPlane(
         fields, points=bnd, centerpoint=cpoint, normal=[1, 0, 0], friction=np.inf
+    )
+
+    CONT = fem.ContactRigidPlane(
+        fields, points=f1(mesh.x), centerpoint=cpoint, normal=[1, 0, 0], friction=np.inf
     )
 
     try:

--- a/tests/test_mechanics.py
+++ b/tests/test_mechanics.py
@@ -519,6 +519,7 @@ def test_load():
 
         body = fem.SolidBody(umat, field)
 
+        load = fem.PointLoad(field, [], values=values, axisymmetric=axi)
         load = fem.PointLoad(field, mask, values=values, axisymmetric=axi)
         bounds = {"fix": fem.Boundary(field[0], fx=lambda x: x == 0)}
         dof0, dof1 = fem.dof.partition(field, bounds)

--- a/tests/test_mpc.py
+++ b/tests/test_mpc.py
@@ -240,6 +240,7 @@ def test_mpc_isolated():
 
 def test_mpc_plot_2d():
     mesh = fem.Rectangle(n=3)
+    mesh.add_points([10, 10])
     field = fem.FieldContainer([fem.FieldPlaneStrain(fem.RegionQuad(mesh), dim=2)])
 
     plane = fem.MultiPointContact(field, [], -1, skip=(0, 1))

--- a/tests/test_mpc.py
+++ b/tests/test_mpc.py
@@ -24,6 +24,7 @@ You should have received a copy of the GNU General Public License
 along with Felupe.  If not, see <http://www.gnu.org/licenses/>.
 
 """
+
 import numpy as np
 import pytest
 
@@ -95,10 +96,10 @@ def pre_mpc_mixed(point, values):
     boundaries["move"] = fem.Boundary(fields[0], fx=f2, skip=(0, 1, 1), value=0.5)
 
     mpc = fem.Boundary(fields[0], fx=f1).points
-    cpoint = mesh.npoints - 1
+    cpoint = -1
 
-    RBE2 = fem.MultiPointConstraint(fields, points=mpc, centerpoint=cpoint)
-    CONT = fem.MultiPointContact(fields, points=mpc, centerpoint=cpoint)
+    RBE2 = fem.MultiPointConstraint(fields, points=f1(mesh.x), centerpoint=cpoint)
+    CONT = fem.MultiPointContact(fields, points=f1(mesh.x), centerpoint=cpoint)
 
     try:
         CONT.plot()

--- a/tests/test_mpc.py
+++ b/tests/test_mpc.py
@@ -241,6 +241,8 @@ def test_mpc_isolated():
 def test_mpc_plot_2d():
     mesh = fem.Rectangle(n=3)
     field = fem.FieldContainer([fem.FieldPlaneStrain(fem.RegionQuad(mesh), dim=2)])
+
+    plane = fem.MultiPointContact(field, [], -1, skip=(0, 1))
     plane = fem.MultiPointContact(field, [0, 1], -1, skip=(0, 1))
 
     try:
@@ -249,6 +251,7 @@ def test_mpc_plot_2d():
     except ModuleNotFoundError:
         pass
 
+    mpc = fem.MultiPointConstraint(field, [], -1)
     mpc = fem.MultiPointConstraint(field, [0, 1], -1)
 
     try:


### PR DESCRIPTION
- Clear the centerpoint of `MultiPointContact`, `MultiPointConstraint`, `PointLoad` and `ContactRigidPlane` from `mesh.points_without_cells`. Previously, this had to be done manually and is now checked when creating one of the above objects.
- Allow mask-based `points` in `MultiPointContact`, `MultiPointConstraint`, `PointLoad` and `ContactRigidPlane` in addition to point indices.
- Allow empty list for `points` in `MultiPointContact`, `MultiPointConstraint`, `PointLoad` and `ContactRigidPlane` in addition to point indices.

This is a potential bug fix, but was described everywhere in the docs. Hence, it is considered as a *change*.

closes #1083 