### PR TITLE
Docs: Fix Read-the-Docs build, use `uv` with a dependency-group and install PyTorch CPU-only

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -17,9 +17,8 @@ sphinx:
 
 python:
   install:
-    - method: pip
+    - method: uv
+      command: sync
       path: .
-      extra_requirements:
-        - all
-        - docs
-        - examples
+      groups:
+        - read-the-docs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,6 +101,7 @@ url = "https://download.pytorch.org/whl/cpu"
 [tool.uv.sources]
 setuptools = {index = "pypi"}
 torch = {index = "pytorch-cpu"}
+torchvision = {index = "pytorch-cpu"}
 
 [tool.setuptools.dynamic]
 version = {attr = "felupe.__about__.__version__"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ dependencies = [
 
 [project.optional-dependencies]
 docs = [
+    "sphinx",
     "pydata-sphinx-theme",
     "sphinx-autoapi",
     "sphinx-codeautolink",
@@ -84,6 +85,22 @@ progress = ["tqdm"]
 plot = ["matplotlib"]
 view = ["pyvista[jupyter]"]
 all = ["felupe[autodiff,io,parallel,plot,progress,view]"]
+
+[dependency-groups]
+read-the-docs = ["felupe[all,docs,examples]"]
+
+[[tool.uv.index]]
+name = "pypi"
+url = "https://pypi.org/simple"
+default = true
+
+[[tool.uv.index]]
+name = "pytorch-cpu"
+url = "https://download.pytorch.org/whl/cpu"
+
+[tool.uv.sources]
+setuptools = {index = "pypi"}
+torch = {index = "pytorch-cpu"}
 
 [tool.setuptools.dynamic]
 version = {attr = "felupe.__about__.__version__"}


### PR DESCRIPTION
this PR fixes #1092 (see also #1094)

- [x] use **uv** instead of pip in read the docs (with command: sync)
- [x] add sphinx to **docs** optional-dependencies (extras) in pyproject.toml
- [x] add a dependency-group **read-the-docs** in pyproject.toml
- [x] use *cpu-only* torch with an **extra index url** (this also reduces the build-time, because no nvidia-cuda packages are installed)