### PR TITLE
Store `Region` results in the `region` object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ All notable changes to this project will be documented in this file. The format 
 - Auto-apply `Mesh.as_meshio()` in `Job.evaluate(filename="result.xdmf", mesh=my_mesh)`, if `mesh` is an instance of `Mesh`. Previously, this required a `meshio.Mesh`.
 - Change the description of the package from a simple Python package to an open finite element infrastructure for nonlinear computational mechanics. This should focus on the project's vision more clearly.
 - Return the last converged result if `newtonraphson()` leads to NaN in the solution. 
+- Move the evaluated element shape function / gradient / hessian from `Region.element.h` to `Region.element_h`, from `Region.element_dhdr` to `Region.element_dhdr` and from `Region.element.d2hdrdr` to `Region.element_d2hdrdr`. Now all results, which are generated inside `Region` are stored in a `region = Region(mesh, element, quadrature)` object. No `element` is used to store results.
 
 ### Fixed
 - Fix the typo `Rhapson` and change it to `Raphson`.

--- a/src/felupe/region/_region.py
+++ b/src/felupe/region/_region.py
@@ -342,17 +342,17 @@ class Region:
             or uniform is not None
         ):
             # element shape function
-            region.element.h = np.array(
+            region.element_h = np.array(
                 [region.element.function(q) for q in region.quadrature.points]
             ).T
-            region.h = np.ascontiguousarray(np.expand_dims(region.element.h, -1))
+            region.h = np.ascontiguousarray(np.expand_dims(region.element_h, -1))
 
             # partial derivative of element shape function
-            region.element.dhdr = np.array(
+            region.element_dhdr = np.array(
                 [region.element.gradient(q) for q in region.quadrature.points]
             ).transpose(1, 2, 0)
 
-            region.dhdr = np.ascontiguousarray(np.expand_dims(region.element.dhdr, -1))
+            region.dhdr = np.ascontiguousarray(np.expand_dims(region.element_dhdr, -1))
 
             if region.evaluate_gradient:
                 # geometric gradient
@@ -393,12 +393,12 @@ class Region:
                 # Second partial derivative of element shape function w.r.t. undeformed
                 # coordinates
                 if region.evaluate_hessian:
-                    region.element.d2hdrdr = np.array(
+                    region.element_d2hdrdr = np.array(
                         [region.element.hessian(q) for q in region.quadrature.points]
                     ).transpose(1, 2, 3, 0)
 
                     region.d2hdrdr = np.ascontiguousarray(
-                        np.expand_dims(region.element.d2hdrdr, -1)
+                        np.expand_dims(region.element_d2hdrdr, -1)
                     )
 
                     region.d2hdXdX = np.einsum(


### PR DESCRIPTION
This PR moves the evaluated element shape function / gradient / hessian

* from `Region.element.h` to `Region.element_h`, 
* from `Region.element_dhdr` to `Region.element_dhdr` and 
* from `Region.element.d2hdrdr` to `Region.element_d2hdrdr`. 

Now all results, which are generated inside `Region` are stored in a `region = Region(mesh, element, quadrature)` object. No `element` is used to store results.

This closes #1096 