### PR TITLE
Fix docstring parameter names that do not match the signatures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ All notable changes to this project will be documented in this file. The format 
 
 ### Fixed
 - Fix the typo `Rhapson` and change it to `Raphson`.
+- Fix docstring parameter names which do not match the signatures: `kawargs` in `IntegralFormExpression.integrate()` and `IntegralFormExpressionMixed.assemble()`, `cells_neighbours` in `Mesh.get_point_ids_shared()` and `orders` in `FieldContainer.extract()`. Also document the missing `sym` argument of `IntegralFormExpressionMixed.integrate()` and `.assemble()`.
 - Fix per-cell material parameter arrays for `NeoHookeCompressible`.
 
 ### Deprecated

--- a/src/felupe/assembly/expression/_linear.py
+++ b/src/felupe/assembly/expression/_linear.py
@@ -50,7 +50,7 @@ class LinearForm:
         ----------
         weakform : callable
             A callable function ``weakform(v, **kwargs)``.
-        kawargs : dict, optional
+        kwargs : dict, optional
             Optional named arguments for callable weakform
         parallel : bool, optional (default is False)
             Flag to activate parallel threading.

--- a/src/felupe/assembly/expression/_mixed.py
+++ b/src/felupe/assembly/expression/_mixed.py
@@ -149,6 +149,8 @@ class BilinearFormExpression:
             Optional named arguments for callable weakform (default is None).
         parallel : bool, optional (default is False)
             Flag to activate parallel threading.
+        sym : bool, optional
+            Flag to active symmetric integration/assembly (default is False).
 
         Returns
         -------
@@ -171,10 +173,12 @@ class BilinearFormExpression:
         ----------
         weakform : callable
             A callable function ``weakform(v, u, **kwargs)``.
-        kawargs : dict or None, optional
+        kwargs : dict or None, optional
             Optional named arguments for callable weakform (default is None).
         parallel : bool, optional
             Flag to activate parallel threading (default is False).
+        sym : bool, optional
+            Flag to active symmetric integration/assembly (default is False).
 
         Returns
         -------

--- a/src/felupe/field/_container.py
+++ b/src/felupe/field/_container.py
@@ -168,7 +168,7 @@ class FieldContainer:
             A location into which the result is stored. If provided, it must have a
             shape that the inputs broadcast to. If not provided or None, a freshly-
             allocated array is returned (default is None).
-        orders : str or list of str, optional
+        order : str or list of str, optional
             Controls the memory layout of the outputs. 'C' means it should be C
             contiguous. 'F' means it should be Fortran contiguous, 'A' means it should
             be 'F' if the inputs are all 'F', 'C' otherwise. 'K' means it should be as

--- a/src/felupe/mesh/_mesh.py
+++ b/src/felupe/mesh/_mesh.py
@@ -487,7 +487,7 @@ class Mesh(DiscreteGeometry):
 
         Parameters
         ----------
-        cells_neighbours : list or ndarray
+        cell_ids_neighbours : list or ndarray
             Array with cell ids.
 
         Returns


### PR DESCRIPTION
Four docstrings name a parameter the function does not take, and one real argument is undocumented in two places.

**`kawargs`** — `IntegralFormExpression.integrate()` (`_linear.py`) and `IntegralFormExpressionMixed.assemble()` (`_mixed.py`) both spell it with the letters transposed. `_bilinear.py` and the other three blocks in `_mixed.py` spell it `kwargs`.

**`cells_neighbours`** — `Mesh.get_point_ids_shared(cell_ids_neighbours)`. The example inside the same docstring already uses `cell_ids_neighbours`.

**`orders`** — `FieldContainer.extract(..., order="C")`. `orders` is the local variable derived from it inside the method (`orders = order * len(self.fields)`), not the argument.

**`sym`** — a real argument of `IntegralFormExpressionMixed.integrate()` and `.assemble()`, passed straight through to the bilinear forms, but documented in neither. Added using the wording already in `IntegralFormCartesian`-style bilinear `integrate()`.

Docstrings and a changelog line only, no behaviour change.

One thing I left out deliberately: `IntegralFormExpression.integrate()` (`_linear.py:46`) and the bilinear `integrate()` (`_bilinear.py:53`) still have `kwargs={}` as a mutable default, while every other method in the module uses `kwargs=None` with an `if kwargs is None` guard. Nothing mutates the dict today, so it is not a live bug, and it is a signature change rather than a docstring one — happy to send it separately if you would like the module made consistent.
