### PR TITLE
Drop two docstring parameters that are not in the signature

### DIFF
--- a/src/felupe/field/_planestrain.py
+++ b/src/felupe/field/_planestrain.py
@@ -239,13 +239,10 @@ class FieldPlaneStrain(Field):
     def hess(self, dtype=None, out=None, order="C"):
         """3D-Hessian as second partial derivative of field values at points w.r.t.
         the undeformed coordinates, evaluated at the integration points of all
-        cells in the region. Optionally, the symmetric part of the gradient is
-        returned.
+        cells in the region.
 
         Parameters
         ----------
-        sym : bool, optional
-            Calculate the symmetric part of the gradient (default is False).
         dtype : data-type or None, optional
             If provided, forces the calculation to use the data type specified. Default
             is None.

--- a/src/felupe/mesh/_mesh.py
+++ b/src/felupe/mesh/_mesh.py
@@ -735,8 +735,6 @@ class Mesh(DiscreteGeometry):
             expansion and ``n`` is ignored.
         axis : int, optional
             Axis of expansion (default is -1).
-        mask : ndarray or None, optional
-            A boolean mask to select points which are rotated (default is None).
         expand_dim : bool, optional
             Expand the dimension of the point coordinates (default is True).
 


### PR DESCRIPTION
Two docstrings name a parameter the signature does not have.

`PlaneStrain.hess` documents `sym`, which `grad` takes and `hess` does not, and the summary line above it promises a symmetric part the method cannot return, so that sentence goes too. `Mesh.expand` documents a `mask` that belongs to `rotate`; the description still reads "points which are rotated".

Same check as #1099.
