### PR TITLE
Enhance `FieldContainer.merge()` and implement automatic `x0`-handling in `Job.evaluate()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ All notable changes to this project will be documented in this file. The format 
 - Modify the field containers in `field.merge(fields)` in-place. This greatly simplifies the multi-body workflow.
 - Change `SolidBody.revolve(..., x0=None)` to require an optional x0-argument, if the field of the solid body has an x0-argument.
 - Change `FieldContainer.checkpoint()` and `FieldContainer.restore()`, that they take care of the optional global-field container `x0` attribute.
+- `FieldContainer.merge()` can't merge dual containers with fields and hence, an error is raised. This has not been supported in the past, but no error was raised.
 
 ### Fixed
 - Fix the typo `Rhapson` and change it to `Raphson`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ All notable changes to this project will be documented in this file. The format 
 - Rebase `FieldContainer.merge()` on `field.merge()`. Add `FieldContainer.x0` to all field containers, which are part of the merge.
 - Modify the field containers in `field.merge(fields)` in-place. This greatly simplifies the multi-body workflow.
 - Change `SolidBody.revolve(..., x0=None)` to require an optional x0-argument, if the field of the solid body has an x0-argument.
+- Change `FieldContainer.checkpoint()` and `FieldContainer.restore()`, that they take care of the optional global-field container `x0` attribute.
 
 ### Fixed
 - Fix the typo `Rhapson` and change it to `Raphson`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ All notable changes to this project will be documented in this file. The format 
 - Add a new `plugin` module with `Plugin` (base class), `AnimationWriterPlugin`, `CharacteristicCurvePlugin`, `ProgressPlugin` and `XDMFWriterPlugin` for `Job`.
 - Add `CharacteristicCurvePlugin.to_arrays()` to return the x- and y-data. `CharacteristicCurvePlugin.plot()` uses the `to_arrays()` method internally.
 - Add a `plotter` argument to `MeshContainer.plot(plotter=None)`.
+- Add `field.merge()` to merge a list of field containers to a top-level field container.
+- Add `FieldContainer.is_container` attribute.
 
 ### Changed
 - Don't expand the interpolated function and gradient for `FieldAxisymmetric` for scalar fields.
@@ -31,6 +33,10 @@ All notable changes to this project will be documented in this file. The format 
 - Change the description of the package from a simple Python package to an open finite element infrastructure for nonlinear computational mechanics. This should focus on the project's vision more clearly.
 - Return the last converged result if `newtonraphson()` leads to NaN in the solution. 
 - Move the evaluated element shape function / gradient / hessian from `Region.element.h` to `Region.element_h`, from `Region.element_dhdr` to `Region.element_dhdr` and from `Region.element.d2hdrdr` to `Region.element_d2hdrdr`. Now all results, which are generated inside `Region` are stored in a `region = Region(mesh, element, quadrature)` object. No `element` is used to store results.
+- Change the return of `x0 = FieldContainer.merge()`, was `fields, x0 = FieldContainer.merge()` before.
+- Rebase `FieldContainer.merge()` on `field.merge()`. Add `FieldContainer.x0` to all field containers, which are part of the merge.
+- Modify the field containers in `field.merge(fields)` in-place. This greatly simplifies the multi-body workflow.
+- Change `SolidBody.revolve(..., x0=None)` to require an optional x0-argument, if the field of the solid body has an x0-argument.
 
 ### Fixed
 - Fix the typo `Rhapson` and change it to `Raphson`.

--- a/docs/tutorial/examples/extut03_multiple-solids.py
+++ b/docs/tutorial/examples/extut03_multiple-solids.py
@@ -10,31 +10,33 @@ Multiple solid bodies
 
 This tutorial shows how to handle multiple solid bodies. There are different ways to
 approach this, but the method presented here is by far the most straightforward. We'll
-start with the meshes, regions, and fields. After that, a top-level field container will
-be introduced for the boundary conditions. When creating the solid bodies, make sure to
-use the fields from this merged container.
+start with the meshes, regions, and fields as usual. After that, a top-level field
+container will be introduced for the boundary conditions.
 """
 
 import felupe as fem
 
 mesh_1 = fem.Rectangle(a=(0, 0), b=(0.5, 1), n=(3, 5))
-field_1 = fem.FieldAxisymmetric(region=fem.RegionQuad(mesh_1), dim=2)
+displacement_1 = fem.FieldAxisymmetric(region=fem.RegionQuad(mesh_1), dim=2)
+field_1 = fem.FieldContainer([displacement_1])
 
 mesh_2 = fem.Rectangle(a=(0.5, 0), b=(1.5, 1), n=5)
-field_2 = fem.FieldAxisymmetric(region=fem.RegionQuad(mesh_2), dim=2)
+displacement_2 = fem.FieldAxisymmetric(region=fem.RegionQuad(mesh_2), dim=2)
+field_2 = fem.FieldContainer([displacement_2])
 
 mesh_3 = fem.Rectangle(a=(1.5, 0), b=(2, 1), n=(3, 5))
-field_3 = fem.FieldAxisymmetric(region=fem.RegionQuad(mesh_3), dim=2)
+displacement_3 = fem.FieldAxisymmetric(region=fem.RegionQuad(mesh_3), dim=2)
+field_3 = fem.FieldContainer([displacement_3])
 
-fields, x0 = fem.FieldContainer([field_1, field_2, field_3]).merge()
+x0 = fem.FieldContainer([field_1, field_2, field_3]).merge()
 boundaries = fem.dof.uniaxial(x0, clamped=True, sym=False, return_loadcase=False)
 
 umat_a = fem.NeoHookeCompressible(mu=3, lmbda=6)
 umat_b = fem.NeoHookeCompressible(mu=1, lmbda=2)
 
-solid_1 = fem.SolidBody(umat=umat_a, field=fields[0])
-solid_2 = fem.SolidBody(umat=umat_b, field=fields[1])
-solid_3 = fem.SolidBody(umat=umat_a, field=fields[2])
+solid_1 = fem.SolidBody(umat=umat_a, field=field_1)
+solid_2 = fem.SolidBody(umat=umat_b, field=field_2)
+solid_3 = fem.SolidBody(umat=umat_a, field=field_3)
 
 # %%
 # The ramped prescribed displacements for 5 substeps are created with
@@ -49,10 +51,9 @@ uniaxial = fem.Step(
 )
 
 # %%
-# This step is now added to a :class:`~felupe.Job`. The top-level field ``x0`` is passed
-# to :meth:`~felupe.Job.evaluate`.
+# This step is now added to a :class:`~felupe.Job`.
 job = fem.Job(steps=[uniaxial])
-job.evaluate(x0=x0)
+job.evaluate()
 
 plotter = solid_1.plot(style="wireframe")
 plotter = solid_3.plot(style="wireframe", plotter=plotter)

--- a/examples/ex05_rubber-metal-bushing.py
+++ b/examples/ex05_rubber-metal-bushing.py
@@ -61,7 +61,8 @@ metal = fem.MeshContainer(
 # valued displacement fields. However, the fields must be merged in a top-level field-
 # container. This modifies the sub-fields to be used in the solid bodies.
 regions = [fem.RegionHexahedron(m) for m in [rubber, metal]]
-fields, field = fem.FieldContainer([fem.Field(r, dim=3) for r in regions]).merge()
+fields = [fem.Field(r, dim=3).as_container() for r in regions]
+field = fem.FieldContainer(fields).merge()
 
 # material formulations and solid bodies for the rubber and the metal sheets
 umats = [fem.NeoHooke(mu=1), fem.LinearElasticLargeStrain(E=2.1e5, nu=0.3)]

--- a/examples/ex05_rubber-metal-bushing.py
+++ b/examples/ex05_rubber-metal-bushing.py
@@ -57,9 +57,9 @@ metal = fem.MeshContainer(
 
 # %%
 # Sub-regions are generated for all materials. The same applies to the material
-# formulations as well as the solid bodies. The sub-fields are also created as vector-
-# valued displacement fields. However, the fields must be merged in a top-level field-
-# container. This modifies the sub-fields to be used in the solid bodies.
+# formulations as well as the solid bodies. The sub-fields are created as vector-
+# valued displacement fields. These fields must be merged in a top-level field-
+# container. This modifies the sub-fields in-place to be used in the solid bodies.
 regions = [fem.RegionHexahedron(m) for m in [rubber, metal]]
 fields = [fem.Field(r, dim=3).as_container() for r in regions]
 field = fem.FieldContainer(fields).merge()
@@ -111,7 +111,7 @@ for progress in table:
 # After defining the load step, the simulation model is ready to be solved.
 step = fem.Step(items=solids, ramp={boundaries["inner"]: move}, boundaries=boundaries)
 job = fem.Job(steps=[step])
-job.evaluate(x0=field, parallel=True, solver=pypardiso.spsolve)
+job.evaluate(parallel=True, solver=pypardiso.spsolve)
 
 # %%
 # The maximum principal values of the logarithmic strain are plotted on the total

--- a/examples/ex07_engine-mount.py
+++ b/examples/ex07_engine-mount.py
@@ -42,12 +42,10 @@ air = fem.mesh.read("ex07_engine-mount_mesh-air.vtk", dim=2)[0]
 
 # %%
 # Sub-regions and fields for all materials are generated. The sub-fields must be merged
-# to generate both the displacement fields for metal / rubber / air and a top-level
-# displacement field.
+# to generate a top-level displacement field.
 regions = [fem.RegionQuad(m) for m in [metal, rubber, air]]
-fields, field = fem.FieldContainer(
-    [fem.FieldsMixed(r, n=1, planestrain=True) for r in regions]
-).merge()
+fields = [fem.FieldsMixed(r, n=1, planestrain=True) for r in regions]
+field = fem.FieldContainer(fields).merge()
 
 
 # %%
@@ -103,9 +101,7 @@ vertical = fem.Step(
     boundaries=boundaries,
 )
 curve = fem.CharacteristicCurvePlugin(boundaries["u_y"])
-job = fem.Job(steps=[vertical], plugins=[curve]).evaluate(
-    x0=field, tol=1e-1
-)
+job = fem.Job(steps=[vertical], plugins=[curve]).evaluate(x0=field, tol=1e-1)
 figv, axv = curve.plot(
     xlabel=r"Displacement $u_y$ in mm $\longrightarrow$",
     ylabel=r"Normal Force $F_y$ in kN $\longrightarrow$",
@@ -122,9 +118,7 @@ horizontal = fem.Step(
     boundaries=boundaries,
 )
 curve = fem.CharacteristicCurvePlugin(boundaries["u_y"])
-job = fem.Job(steps=[horizontal], plugins=[curve]).evaluate(
-    x0=field, tol=1e-1
-)
+job = fem.Job(steps=[horizontal], plugins=[curve]).evaluate(x0=field, tol=1e-1)
 figh, axh = curve.plot(
     xlabel=r"Displacement $u_x$ in mm $\longrightarrow$",
     ylabel=r"Normal Force $F_x$ in kN $\longrightarrow$",
@@ -140,9 +134,7 @@ vertical = fem.Step(
     boundaries=boundaries,
 )
 curve = fem.CharacteristicCurvePlugin(boundaries["u_y"])
-job = fem.Job(steps=[vertical], plugins=[curve]).evaluate(
-    x0=field, tol=1e-1
-)
+job = fem.Job(steps=[vertical], plugins=[curve]).evaluate(x0=field, tol=1e-1)
 figv, axv = curve.plot(
     xaxis=1,
     yaxis=1,
@@ -158,9 +150,7 @@ horizontal = fem.Step(
     boundaries=boundaries,
 )
 curve = fem.CharacteristicCurvePlugin(boundaries["u_y"])
-job = fem.Job(steps=[horizontal], plugins=[curve]).evaluate(
-    x0=field, tol=1e-1
-)
+job = fem.Job(steps=[horizontal], plugins=[curve]).evaluate(x0=field, tol=1e-1)
 figh, axh = curve.plot(
     yscale=1 / 1000 * thickness,
     lw=3,

--- a/examples/ex07_engine-mount.py
+++ b/examples/ex07_engine-mount.py
@@ -101,7 +101,7 @@ vertical = fem.Step(
     boundaries=boundaries,
 )
 curve = fem.CharacteristicCurvePlugin(boundaries["u_y"])
-job = fem.Job(steps=[vertical], plugins=[curve]).evaluate(x0=field, tol=1e-1)
+job = fem.Job(steps=[vertical], plugins=[curve]).evaluate(tol=1e-1)
 figv, axv = curve.plot(
     xlabel=r"Displacement $u_y$ in mm $\longrightarrow$",
     ylabel=r"Normal Force $F_y$ in kN $\longrightarrow$",
@@ -118,7 +118,7 @@ horizontal = fem.Step(
     boundaries=boundaries,
 )
 curve = fem.CharacteristicCurvePlugin(boundaries["u_y"])
-job = fem.Job(steps=[horizontal], plugins=[curve]).evaluate(x0=field, tol=1e-1)
+job = fem.Job(steps=[horizontal], plugins=[curve]).evaluate(tol=1e-1)
 figh, axh = curve.plot(
     xlabel=r"Displacement $u_x$ in mm $\longrightarrow$",
     ylabel=r"Normal Force $F_x$ in kN $\longrightarrow$",
@@ -134,7 +134,7 @@ vertical = fem.Step(
     boundaries=boundaries,
 )
 curve = fem.CharacteristicCurvePlugin(boundaries["u_y"])
-job = fem.Job(steps=[vertical], plugins=[curve]).evaluate(x0=field, tol=1e-1)
+job = fem.Job(steps=[vertical], plugins=[curve]).evaluate(tol=1e-1)
 figv, axv = curve.plot(
     xaxis=1,
     yaxis=1,
@@ -150,7 +150,7 @@ horizontal = fem.Step(
     boundaries=boundaries,
 )
 curve = fem.CharacteristicCurvePlugin(boundaries["u_y"])
-job = fem.Job(steps=[horizontal], plugins=[curve]).evaluate(x0=field, tol=1e-1)
+job = fem.Job(steps=[horizontal], plugins=[curve]).evaluate(tol=1e-1)
 figh, axh = curve.plot(
     yscale=1 / 1000 * thickness,
     lw=3,

--- a/examples/ex15_hexmesh-metacone.py
+++ b/examples/ex15_hexmesh-metacone.py
@@ -60,9 +60,8 @@ mesh = fem.MeshContainer(
 # Two solid bodies are created, one for the rubber and one for the metal. The top-level
 # field is passed as the ``x0``-argument to the evaluate-method of the job. The part is
 # displaced along the rotation axis.
-fields, x0 = fem.FieldContainer(
-    [fem.FieldAxisymmetric(fem.RegionQuad(m), dim=2) for m in mesh]
-).merge()
+fields = [fem.FieldAxisymmetric(fem.RegionQuad(m), dim=2).as_container() for m in mesh]
+x0 = fem.FieldContainer(fields).merge()
 
 rubber = fem.NeoHooke(mu=1)
 metal = fem.LinearElasticLargeStrain(E=2.1e5, nu=0.3)

--- a/examples/ex15_hexmesh-metacone.py
+++ b/examples/ex15_hexmesh-metacone.py
@@ -72,7 +72,7 @@ solid2 = fem.SolidBody(metal, fields[1])
 boundaries = fem.dof.uniaxial(x0, clamped=True, sym=False, return_loadcase=False)
 ramp = {boundaries["move"]: fem.math.linsteps([0, 1], num=5) * -1.5}
 step = fem.Step(items=[solid1, solid2], ramp=ramp, boundaries=boundaries)
-job = fem.Job(steps=[step]).evaluate(x0=x0, solver=pypardiso.spsolve)
+job = fem.Job(steps=[step]).evaluate(solver=pypardiso.spsolve)
 
 solid1.plot(
     "Principal Values of Cauchy Stress",
@@ -83,15 +83,15 @@ solid1.plot(
 # In order to obtain a 3d-model, the top-level field and the solid bodies are revolved.
 # For simplicity, the same load case is applied on the 3d-model. This may be used as a
 # starting point for further non-axisymmetric loads applied on the model.
-solid1_3d = solid1.revolve(n=6, phi=90)
-solid2_3d = solid2.revolve(n=6, phi=90)
 x0_3d = x0.revolve(n=6, phi=90)
+solid1_3d = solid1.revolve(n=6, phi=90, x0=x0_3d)
+solid2_3d = solid2.revolve(n=6, phi=90, x0=x0_3d)
 
 boundaries = fem.dof.uniaxial(
     x0_3d, clamped=True, sym=(0, 1, 1), move=-1.5, return_loadcase=False
 )
 step = fem.Step(items=[solid1_3d, solid2_3d], boundaries=boundaries)
-job = fem.Job(steps=[step]).evaluate(x0=x0_3d, solver=pypardiso.spsolve)
+job = fem.Job(steps=[step]).evaluate(solver=pypardiso.spsolve)
 
 solid1_3d.plot(
     "Principal Values of Cauchy Stress",

--- a/src/felupe/field/__init__.py
+++ b/src/felupe/field/__init__.py
@@ -4,6 +4,7 @@ from ._container import FieldContainer
 from ._dual import FieldDual
 from ._evaluate import EvaluateFieldContainer
 from ._fields import FieldsMixed
+from ._merge import merge
 from ._planestrain import FieldPlaneStrain
 
 __all__ = [
@@ -14,4 +15,5 @@ __all__ = [
     "FieldPlaneStrain",
     "FieldDual",
     "EvaluateFieldContainer",
+    "merge",
 ]

--- a/src/felupe/field/_base.py
+++ b/src/felupe/field/_base.py
@@ -146,9 +146,11 @@ class Field:
 
             shape = (self.region.mesh.npoints, self.dim)
             if shape != self.values.shape:
+                pad_width = ((0, shape[0] - self.values.shape[0]), (0, 0))
+
                 self.values = np.pad(
                     self.values,
-                    pad_width=((0, shape[0] - self.values.shape[0]), (0, 0)),
+                    pad_width=pad_width[: len(self.values.shape)],
                     mode=mode,
                     **kwargs,
                 )

--- a/src/felupe/field/_base.py
+++ b/src/felupe/field/_base.py
@@ -129,6 +129,25 @@ class Field:
 
         self.__field__ = Field
 
+    def reload(self, region=None, mode="edge"):
+
+        if region is not None:
+            self.region = region
+            self.shape = self.region.quadrature.npoints, self.region.mesh.ncells
+
+            shape = (self.region.mesh.npoints, self.dim)
+            self.values = np.pad(
+                self.values,
+                pad_width=(
+                    (0, shape[0] - self.values.shape[0]),
+                    (0, shape[1] - self.values.shape[1]),
+                ),
+                mode=mode,
+            )
+
+            eai, ai = self._indices_per_cell(self.region.mesh.cells, self.dim)
+            self.indices = Indices(eai, ai, region, self.dim)
+
     def _indices_per_cell(self, cells, dim):
         "Calculate pre-defined indices for sparse matrices."
 

--- a/src/felupe/field/_base.py
+++ b/src/felupe/field/_base.py
@@ -146,14 +146,22 @@ class Field:
 
             shape = (self.region.mesh.npoints, self.dim)
             if shape != self.values.shape:
-                pad_width = ((0, shape[0] - self.values.shape[0]), (0, 0))
+                length = shape[0] - self.values.shape[0]
 
-                self.values = np.pad(
-                    self.values,
-                    pad_width=pad_width[: len(self.values.shape)],
-                    mode=mode,
-                    **kwargs,
-                )
+                if length >= 0:
+                    pad_width = ((0, length), (0, 0))
+
+                    # expand values
+                    self.values = np.pad(
+                        self.values,
+                        pad_width=pad_width[: len(self.values.shape)],
+                        mode=mode,
+                        **kwargs,
+                    )
+
+                else:  # trim values
+                    self.values = self.values[: length]
+
 
             eai, ai = self._indices_per_cell(self.region.mesh.cells, self.dim)
             self.indices = Indices(eai, ai, region, self.dim)

--- a/src/felupe/field/_base.py
+++ b/src/felupe/field/_base.py
@@ -98,9 +98,7 @@ class Field:
     """
 
     def __init__(self, region, dim=1, values=0.0, dtype=None, **kwargs):
-        self.region = region
-        self.dim = dim
-        self.shape = self.region.quadrature.npoints, self.region.mesh.ncells
+        self.__field__ = Field
 
         # set optional user-defined attributes
         for key, value in kwargs.items():
@@ -124,26 +122,36 @@ class Field:
                 shape=(region.mesh.npoints, dim), fill_value=values, dtype=dtype
             )
 
-        eai, ai = self._indices_per_cell(self.region.mesh.cells, dim)
-        self.indices = Indices(eai, ai, region, dim)
+        self.dim = dim
+        self.reload(region=region)
 
-        self.__field__ = Field
+    def reload(self, region, mode="edge", **kwargs):
+        """Reload the field with a new region in-place. The field values are extended
+        to the new region if necessary.
 
-    def reload(self, region=None, mode="edge"):
+        Parameters
+        ----------
+        region : Region
+            The new region for the field.
+        mode : str, optional
+            The padding mode to use if the field values need to be extended. Default is
+            "edge".
+        **kwargs : dict, optional
+            Additional keyword arguments are passed to :func:`numpy.pad`.
+        """
 
         if region is not None:
             self.region = region
             self.shape = self.region.quadrature.npoints, self.region.mesh.ncells
 
             shape = (self.region.mesh.npoints, self.dim)
-            self.values = np.pad(
-                self.values,
-                pad_width=(
-                    (0, shape[0] - self.values.shape[0]),
-                    (0, shape[1] - self.values.shape[1]),
-                ),
-                mode=mode,
-            )
+            if shape != self.values.shape:
+                self.values = np.pad(
+                    self.values,
+                    pad_width=((0, shape[0] - self.values.shape[0]), (0, 0)),
+                    mode=mode,
+                    **kwargs,
+                )
 
             eai, ai = self._indices_per_cell(self.region.mesh.cells, self.dim)
             self.indices = Indices(eai, ai, region, self.dim)

--- a/src/felupe/field/_container.py
+++ b/src/felupe/field/_container.py
@@ -128,23 +128,24 @@ class FieldContainer:
 
         return "\n".join([header, size, fields_header, *fields])
 
-    def reload(self, fields):
+    def reload(self, fields=None):
         """Reload the Field Container with new fields.
-        
+
         Parameters
         ----------
         fields : list
             List of fields.
 
         """
-        # create list of fields (unpack field containers)
-        self.fields = []
+        if fields is not None:
+            # create list of fields (unpack field containers)
+            self.fields = []
 
-        for field in fields:
-            if isinstance(field, FieldContainer):
-                self.fields.extend(field.fields)
-            else:
-                self.fields.append(field)
+            for field in fields:
+                if isinstance(field, FieldContainer):
+                    self.fields.extend(field.fields)
+                else:
+                    self.fields.append(field)
 
         self.region = self.fields[0].region
 
@@ -426,6 +427,16 @@ class FieldContainer:
 
         container = MeshContainer(meshes, merge=True, decimals=decimals)
 
+        # take the type and the dimension
+        # of the first sub-field of the first field container
+        Field = self.fields[0].__field__
+        dim = self.fields[0].dim
+
+        # create a new top-level (global) vertex field container
+        x0 = Field.from_mesh_container(container, dim=dim).as_container(
+            mesh_container=container
+        )
+
         # take the first new mesh
         new_mesh = container.meshes[0]
 
@@ -436,16 +447,16 @@ class FieldContainer:
             if not "Dual" in type(field).__name__:
                 new_mesh = mesh
 
+            # reload the region of the field with the new mesh
             field.region.reload(mesh=new_mesh)
+
+            # reload the field
             field.reload(field.region)
 
-        # take the type of the first sub-field
-        Field = self.fields[0].__field__
+            # add the top-level field container as attribute x0
+            field.x0 = x0
 
-        # create a new top-level (global) vertex field container
-        return Field.from_mesh_container(
-            container, dim=self.fields[0].dim
-        ).as_container(mesh_container=container)
+        return x0
 
     def view(self, point_data=None, cell_data=None, cell_type=None, project=None):
         """View the field with optional given dicts of point- and cell-data items.

--- a/src/felupe/field/_container.py
+++ b/src/felupe/field/_container.py
@@ -111,6 +111,7 @@ class FieldContainer:
     def __init__(self, fields, **kwargs):
 
         self.evaluate = EvaluateFieldContainer(self)
+        self.is_container = True
 
         # set optional user-defined attributes
         for key, value in kwargs.items():
@@ -401,21 +402,23 @@ class FieldContainer:
             >>> import felupe as fem
             >>>
             >>> mesh1 = fem.Rectangle(n=3)
-            >>> field1 = fem.FieldAxisymmetric(fem.RegionQuad(mesh1), dim=2)
+            >>> displacement1 = fem.FieldAxisymmetric(fem.RegionQuad(mesh1), dim=2)
+            >>> field1 = fem.FieldContainer([displacement1])
             >>>
             >>> mesh2 = fem.Rectangle(a=(1, 0), b=(2, 1), n=3)
-            >>> field2 = fem.FieldAxisymmetric(fem.RegionQuad(mesh2), dim=2)
+            >>> displacement2 = fem.FieldAxisymmetric(fem.RegionQuad(mesh2), dim=2)
+            >>> field2 = fem.FieldContainer([displacement2])
             >>>
-            >>> fields, x0 = (field1 & field2).merge()
+            >>> x0 = (field1 & field2).merge()
             >>>
             >>> umat = fem.NeoHookeCompressible(mu=1, lmbda=2)
-            >>> solid1 = fem.SolidBody(umat, fields[0])
-            >>> solid2 = fem.SolidBody(umat, fields[1])
+            >>> solid1 = fem.SolidBody(umat, field1)
+            >>> solid2 = fem.SolidBody(umat, field2)
             >>>
             >>> boundaries = fem.dof.uniaxial(x0, clamped=True, return_loadcase=False)
             >>>
             >>> step = fem.Step(items=[solid1, solid2], boundaries=boundaries)
-            >>> job = fem.Job(steps=[step]).evaluate(x0=x0)
+            >>> job = fem.Job(steps=[step]).evaluate()
 
         """
 

--- a/src/felupe/field/_container.py
+++ b/src/felupe/field/_container.py
@@ -272,7 +272,13 @@ class FieldContainer:
         felupe.FieldContainer.restore : Restore a checkpoint of a field container
             inplace.
         """
-        return {"field": self.copy()}
+        state = {"field": self.copy()}
+
+        x0 = getattr(self, "x0", None)
+        if x0 is not None:
+            state["field.x0"] = self.x0.copy()
+
+        return state
 
     def restore(self, checkpoint):
         """Restore a checkpoint inplace.
@@ -289,6 +295,11 @@ class FieldContainer:
 
         for field, newfield in zip(self.fields, checkpoint["field"].fields):
             field.values[:] = newfield.values
+
+        x0 = checkpoint.get("field.x0")
+        if x0 is not None:
+            for field, newfield in zip(self.x0.fields, checkpoint["field.x0"].fields):
+                field.values[:] = newfield.values
 
     def revolve(self, n=11, phi=180):
         """Return a revolved field container.

--- a/src/felupe/field/_container.py
+++ b/src/felupe/field/_container.py
@@ -31,6 +31,7 @@ from ..region import (
 )
 from ..view import ViewField
 from ._evaluate import EvaluateFieldContainer
+from ._merge import merge
 
 
 class FieldContainer:
@@ -138,6 +139,8 @@ class FieldContainer:
 
         """
         if fields is not None:
+            self._list_of_fields_and_field_containers = fields
+
             # create list of fields (unpack field containers)
             self.fields = []
 
@@ -385,19 +388,11 @@ class FieldContainer:
 
         Returns
         -------
-        list of FieldContainer
-            A list with field containers to be used in different items (solid bodies).
         FieldContainer
             The top-level field container, to be used as the ``x0``-argument in
-            `meth:`~felupe.Job.evaluate and for the creation of boundary conditions.
-
-        Notes
-        -----
-        ..  note::
-
-            This works only if all regions are template regions, like
-            :class:`~felupe.RegionQuad` or :class:`~felupe.RegionHexahedron`, which are
-            supported by :class:`~felupe.FieldDual`.
+            :meth:`~felupe.Job.evaluate` and for the creation of boundary conditions.
+            The given field containers are modified & reloaded in-place, along with a
+            new attribute ``x0`` that points to this top-level field container.
 
         Examples
         --------
@@ -424,41 +419,11 @@ class FieldContainer:
 
         """
 
-        regions = [field.region for field in self.fields]
-        meshes = [region.mesh for region in regions]
-
-        container = MeshContainer(meshes, merge=True, decimals=decimals, **kwargs)
-
-        # take the type and the dimension
-        # of the first sub-field of the first field container
-        Field = self.fields[0].__field__
-        dim = self.fields[0].dim
-
-        # create a new top-level (global) vertex field container
-        x0 = Field.from_mesh_container(container, dim=dim).as_container(
-            mesh_container=container
+        return merge(
+            self._list_of_fields_and_field_containers,
+            decimals=decimals,
+            **kwargs,
         )
-
-        # take the first new mesh
-        new_mesh = container.meshes[0]
-
-        # reload regions of fields in-place
-        for field, mesh in zip(self.fields, container.meshes):
-
-            # only take and use new meshes of non-dual fields
-            if not "Dual" in type(field).__name__:
-                new_mesh = mesh
-
-            # reload the region of the field with the new mesh
-            field.region.reload(mesh=new_mesh)
-
-            # reload the field
-            field.reload(field.region)
-
-            # add the top-level field container as attribute x0
-            field.x0 = x0
-
-        return x0
 
     def view(self, point_data=None, cell_data=None, cell_type=None, project=None):
         """View the field with optional given dicts of point- and cell-data items.

--- a/src/felupe/field/_container.py
+++ b/src/felupe/field/_container.py
@@ -406,6 +406,10 @@ class FieldContainer:
             The given field containers are modified & reloaded in-place, along with a
             new attribute ``x0`` that points to this top-level field container.
 
+        Notes
+        -----
+        Field containers with dual fields are not supported.
+
         Examples
         --------
         ..  pyvista-plot::

--- a/src/felupe/field/_container.py
+++ b/src/felupe/field/_container.py
@@ -41,9 +41,6 @@ class FieldContainer:
     ----------
     fields : list or tuple of :class:`~felupe.Field`, :class:``~felupe.FieldAxisymmetric`, :class:``~felupe.FieldPlaneStrain` or :class:`~felupe.FieldContainer`
         List with fields. The region is linked to the first field.
-    bundle : FieldContainerBundle or None, optional
-        The field container bundle, if this field container is part of one. Default is
-        None, which means that the field container is not part of a bundle.
     **kwargs : dict, optional
         Extra class attributes for the field container.
 
@@ -110,29 +107,15 @@ class FieldContainer:
 
     """
 
-    def __init__(self, fields, bundle=None, **kwargs):
+    def __init__(self, fields, **kwargs):
 
-        # flatten the given list of fields (unpack field containers)
-        self.fields = []
-        self.bundle = bundle
-
-        for field in fields:
-            if isinstance(field, FieldContainer):
-                self.fields.extend(field.fields)
-            else:
-                self.fields.append(field)
+        self.evaluate = EvaluateFieldContainer(self)
 
         # set optional user-defined attributes
         for key, value in kwargs.items():
             setattr(self, key, value)
 
-        self.region = self.fields[0].region
-
-        # get sizes of fields and calculate offsets
-        self.fieldsizes = [f.indices.dof.size for f in self.fields]
-        self.offsets = np.cumsum(self.fieldsizes)[:-1]
-
-        self.evaluate = EvaluateFieldContainer(self)
+        self.reload(fields)
 
     def __repr__(self):
         header = "<felupe FieldContainer object>"
@@ -144,6 +127,30 @@ class FieldContainer:
         ]
 
         return "\n".join([header, size, fields_header, *fields])
+
+    def reload(self, fields):
+        """Reload the Field Container with new fields.
+        
+        Parameters
+        ----------
+        fields : list
+            List of fields.
+
+        """
+        # create list of fields (unpack field containers)
+        self.fields = []
+
+        for field in fields:
+            if isinstance(field, FieldContainer):
+                self.fields.extend(field.fields)
+            else:
+                self.fields.append(field)
+
+        self.region = self.fields[0].region
+
+        # get sizes of fields and calculate offsets
+        self.fieldsizes = [f.indices.dof.size for f in self.fields]
+        self.offsets = np.cumsum(self.fieldsizes)[:-1]
 
     def extract(
         self, grad=True, sym=False, add_identity=True, dtype=None, out=None, order="C"
@@ -419,20 +426,20 @@ class FieldContainer:
 
         container = MeshContainer(meshes, merge=True, decimals=decimals)
 
-        new_fields = []
-        current_mesh = container.meshes[0]
+        # take the first new mesh
+        new_mesh = container.meshes[0]
 
         # reload regions of fields in-place
         for field, mesh in zip(self.fields, container.meshes):
 
-            # only take meshes of non-dual fields
+            # only take and use new meshes of non-dual fields
             if not "Dual" in type(field).__name__:
-                current_mesh = mesh
+                new_mesh = mesh
 
-            field.region.reload(mesh=current_mesh)
+            field.region.reload(mesh=new_mesh)
             field.reload(field.region)
 
-        # take the dimension of the first sub-field
+        # take the type of the first sub-field
         Field = self.fields[0].__field__
 
         # create a new top-level (global) vertex field container

--- a/src/felupe/field/_container.py
+++ b/src/felupe/field/_container.py
@@ -372,7 +372,7 @@ class FieldContainer:
             [Field(new_region, dim=dim, values=np.array(new_values).reshape(-1, dim))]
         )
 
-    def merge(self, decimals=None):
+    def merge(self, decimals=None, **kwargs):
         """Merge all fields and return a list of field containers as well as the
         top-level field container.
 
@@ -380,6 +380,8 @@ class FieldContainer:
         ----------
         decimals : int or None, optional
             Precision decimals for merging duplicated mesh points. Default is None.
+        **kwargs : dict, optional
+            Additional keyword arguments for :class:`~felupe.MeshContainer`.
 
         Returns
         -------
@@ -425,7 +427,7 @@ class FieldContainer:
         regions = [field.region for field in self.fields]
         meshes = [region.mesh for region in regions]
 
-        container = MeshContainer(meshes, merge=True, decimals=decimals)
+        container = MeshContainer(meshes, merge=True, decimals=decimals, **kwargs)
 
         # take the type and the dimension
         # of the first sub-field of the first field container

--- a/src/felupe/field/_container.py
+++ b/src/felupe/field/_container.py
@@ -420,67 +420,25 @@ class FieldContainer:
         container = MeshContainer(meshes, merge=True, decimals=decimals)
 
         new_fields = []
-
-        # only take meshes of non-dual fields
         current_mesh = container.meshes[0]
 
+        # reload regions of fields in-place
         for field, mesh in zip(self.fields, container.meshes):
 
-            if "Dual" in type(field).__name__:
-                RegionOriginal = type(field.__args__[0])
-                region = RegionOriginal(current_mesh)
-                new_field = type(field)(region, *field.__args__[1:], **field.__kwargs__)
-
-            else:
-
-                # update the current mesh
+            # only take meshes of non-dual fields
+            if not "Dual" in type(field).__name__:
                 current_mesh = mesh
 
-                RegionOriginal = type(field.region)
-                region = RegionOriginal(current_mesh)
-                new_field = type(field)(region, dim=field.dim, dtype=field.values.dtype)
-
-            new_fields.append(new_field)
-
-        def group_dual_fields(fields):
-
-            # init lists for new fields and subfields per container
-            new_fields = []
-            subfields = []
-
-            # loop over fields
-            for field in fields:
-
-                # check if type of field is not FieldDual (without importing FieldDual)
-                if "Dual" not in type(field).__name__:
-
-                    # finalize the subfields to the list of new fields
-                    # if it is not empty
-                    if len(subfields) > 0:
-                        new_fields.append(subfields)
-
-                    # start a new list of subfields
-                    subfields = [field]
-
-                # append the dual field to the list of subfields
-                else:
-                    subfields.append(field)
-
-            # finally add the last subfields to the list of new fields
-            if len(subfields) > 0:
-                new_fields.append(subfields)
-
-            return new_fields
-
-        new_fields_grouped = group_dual_fields(new_fields)
-        Field = self.fields[0].__field__
+            field.region.reload(mesh=current_mesh)
+            field.reload(field.region)
 
         # take the dimension of the first sub-field
-        vertex_field = Field.from_mesh_container(
-            container, dim=new_fields_grouped[0][0].dim
-        ).as_container(mesh_container=container)
+        Field = self.fields[0].__field__
 
-        return [FieldContainer(f) for f in new_fields_grouped], vertex_field
+        # create a new top-level (global) vertex field container
+        return Field.from_mesh_container(
+            container, dim=self.fields[0].dim
+        ).as_container(mesh_container=container)
 
     def view(self, point_data=None, cell_data=None, cell_type=None, project=None):
         """View the field with optional given dicts of point- and cell-data items.

--- a/src/felupe/field/_container.py
+++ b/src/felupe/field/_container.py
@@ -41,6 +41,9 @@ class FieldContainer:
     ----------
     fields : list or tuple of :class:`~felupe.Field`, :class:``~felupe.FieldAxisymmetric`, :class:``~felupe.FieldPlaneStrain` or :class:`~felupe.FieldContainer`
         List with fields. The region is linked to the first field.
+    bundle : FieldContainerBundle or None, optional
+        The field container bundle, if this field container is part of one. Default is
+        None, which means that the field container is not part of a bundle.
     **kwargs : dict, optional
         Extra class attributes for the field container.
 
@@ -107,10 +110,11 @@ class FieldContainer:
 
     """
 
-    def __init__(self, fields, **kwargs):
+    def __init__(self, fields, bundle=None, **kwargs):
 
         # flatten the given list of fields (unpack field containers)
         self.fields = []
+        self.bundle = bundle
 
         for field in fields:
             if isinstance(field, FieldContainer):

--- a/src/felupe/field/_merge.py
+++ b/src/felupe/field/_merge.py
@@ -74,8 +74,15 @@ def merge(fields, decimals=None, **kwargs):
 
     # take the type and the dimension
     # of the first sub-field of the first field container
-    Field = fields[0][0].__field__
-    dim = fields[0][0].dim
+    for field in fields:
+        if not hasattr(field, "is_container"):
+            raise TypeError(
+                "The given fields are not field containers. Please use a list of "
+                "field containers as input for the merge function."
+            )
+
+    Field = field[0].__field__
+    dim = field[0].dim
 
     # create a new top-level (global) vertex field container
     x0 = Field.from_mesh_container(container, dim=dim).as_container(

--- a/src/felupe/field/_merge.py
+++ b/src/felupe/field/_merge.py
@@ -67,6 +67,9 @@ def merge(fields, decimals=None, **kwargs):
 
     """
 
+    if len(fields) < 1:
+        raise ValueError("The list of field containers to be merged is empty.")
+
     regions = [field.region for field in fields]
     meshes = [region.mesh for region in regions]
 
@@ -81,8 +84,8 @@ def merge(fields, decimals=None, **kwargs):
                 "field containers as input for the merge function."
             )
 
-    Field = field[0].__field__
-    dim = field[0].dim
+    Field = fields[0][0].__field__
+    dim = fields[0][0].dim
 
     # create a new top-level (global) vertex field container
     x0 = Field.from_mesh_container(container, dim=dim).as_container(

--- a/src/felupe/field/_merge.py
+++ b/src/felupe/field/_merge.py
@@ -36,7 +36,7 @@ def merge(fields, decimals=None, **kwargs):
     -------
     FieldContainer
         The top-level field container, to be used as the ``x0``-argument in
-        `meth:`~felupe.Job.evaluate and for the creation of boundary conditions. The
+        :meth:`~felupe.Job.evaluate` and for the creation of boundary conditions. The
         given field containers are modified & reloaded in-place, along with a new
         attribute ``x0`` that points to this top-level field container.
 

--- a/src/felupe/field/_merge.py
+++ b/src/felupe/field/_merge.py
@@ -40,6 +40,10 @@ def merge(fields, decimals=None, **kwargs):
         given field containers are modified & reloaded in-place, along with a new
         attribute ``x0`` that points to this top-level field container.
 
+    Notes
+    -----
+    Field containers with dual fields are not supported.
+
     Examples
     --------
     ..  pyvista-plot::
@@ -70,13 +74,6 @@ def merge(fields, decimals=None, **kwargs):
     if len(fields) < 1:
         raise ValueError("The list of field containers to be merged is empty.")
 
-    regions = [field.region for field in fields]
-    meshes = [region.mesh for region in regions]
-
-    container = MeshContainer(meshes, merge=True, decimals=decimals, **kwargs)
-
-    # take the type and the dimension
-    # of the first sub-field of the first field container
     for field in fields:
         if not hasattr(field, "is_container"):
             raise TypeError(
@@ -84,6 +81,22 @@ def merge(fields, decimals=None, **kwargs):
                 "field containers as input for the merge function."
             )
 
+    for field in fields:
+        for f in field.fields:
+            if "Dual" in type(f).__name__:
+                raise TypeError(
+                    "Dual fields can't be merged. "
+                    "Please use a list of field containers without dual fields as "
+                    "input for the merge function."
+                )
+
+    regions = [field.region for field in fields]
+    meshes = [region.mesh for region in regions]
+
+    container = MeshContainer(meshes, merge=True, decimals=decimals, **kwargs)
+
+    # take the type and the dimension
+    # of the first sub-field of the first field container
     Field = fields[0][0].__field__
     dim = fields[0][0].dim
 
@@ -95,12 +108,8 @@ def merge(fields, decimals=None, **kwargs):
     # take the first new mesh
     new_mesh = container.meshes[0]
 
-    # reload regions of fields in-place
-    for field, mesh in zip(fields, container.meshes):
-
-        # only take and use new meshes of non-dual fields
-        if not "Dual" in type(field).__name__:
-            new_mesh = mesh
+    # reload regions of field containers in-place
+    for field, new_mesh in zip(fields, container.meshes):
 
         # reload the region of the field container with the new mesh
         field.region.reload(mesh=new_mesh)

--- a/src/felupe/field/_merge.py
+++ b/src/felupe/field/_merge.py
@@ -1,0 +1,105 @@
+# -*- coding: utf-8 -*-
+"""
+This file is part of FElupe.
+
+FElupe is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+FElupe is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with FElupe.  If not, see <http://www.gnu.org/licenses/>.
+"""
+
+from ..mesh import MeshContainer
+
+
+def merge(fields, decimals=None, **kwargs):
+    """Merge a list of field containers into a single top-level field container and
+    modify the field containers and the underlying fields in-place.
+
+    Parameters
+    ----------
+    fields : list of FieldContainer
+        The list of field containers to be merged.
+    decimals : int or None, optional
+        Precision decimals for merging duplicated mesh points. Default is None.
+
+    Returns
+    -------
+    FieldContainer
+        The top-level field container, to be used as the ``x0``-argument in
+        `meth:`~felupe.Job.evaluate and for the creation of boundary conditions. The
+        given field containers are modified & reloaded in-place, along with a new
+        attribute ``x0`` that points to this top-level field container.
+
+    Examples
+    --------
+    ..  pyvista-plot::
+
+        >>> import felupe as fem
+        >>>
+        >>> mesh1 = fem.Rectangle(n=3)
+        >>> displacement1 = fem.FieldAxisymmetric(fem.RegionQuad(mesh1), dim=2)
+        >>> field1 = fem.FieldContainer([displacement1])
+        >>>
+        >>> mesh2 = fem.Rectangle(a=(1, 0), b=(2, 1), n=3)
+        >>> displacement2 = fem.FieldAxisymmetric(fem.RegionQuad(mesh2), dim=2)
+        >>> field2 = fem.FieldContainer([displacement2])
+        >>>
+        >>> field = fem.field.merge([field1, field2])
+        >>>
+        >>> umat = fem.NeoHookeCompressible(mu=1, lmbda=2)
+        >>> solid1 = fem.SolidBody(umat, field1)
+        >>> solid2 = fem.SolidBody(umat, field2)
+        >>>
+        >>> boundaries = fem.dof.uniaxial(field, clamped=True, return_loadcase=False)
+        >>>
+        >>> step = fem.Step(items=[solid1, solid2], boundaries=boundaries)
+        >>> job = fem.Job(steps=[step]).evaluate()
+
+    """
+
+    regions = [field.region for field in fields]
+    meshes = [region.mesh for region in regions]
+
+    container = MeshContainer(meshes, merge=True, decimals=decimals)
+
+    # take the type and the dimension
+    # of the first sub-field of the first field container
+    Field = fields[0][0].__field__
+    dim = fields[0][0].dim
+
+    # create a new top-level (global) vertex field container
+    x0 = Field.from_mesh_container(container, dim=dim).as_container(
+        mesh_container=container
+    )
+
+    # take the first new mesh
+    new_mesh = container.meshes[0]
+
+    # reload regions of fields in-place
+    for field, mesh in zip(fields, container.meshes):
+
+        # only take and use new meshes of non-dual fields
+        if not "Dual" in type(field).__name__:
+            new_mesh = mesh
+
+        # reload the region of the field container with the new mesh
+        field.region.reload(mesh=new_mesh)
+
+        # reload the field container (indices and offsets)
+        field.reload()
+
+        # add the top-level field container as attribute x0
+        field.x0 = x0
+
+        for f in field.fields:
+            f.reload(region=field.region)
+
+    return x0

--- a/src/felupe/field/_merge.py
+++ b/src/felupe/field/_merge.py
@@ -105,9 +105,6 @@ def merge(fields, decimals=None, **kwargs):
         mesh_container=container
     )
 
-    # take the first new mesh
-    new_mesh = container.meshes[0]
-
     # reload regions of field containers in-place
     for field, new_mesh in zip(fields, container.meshes):
 

--- a/src/felupe/field/_merge.py
+++ b/src/felupe/field/_merge.py
@@ -105,13 +105,14 @@ def merge(fields, decimals=None, **kwargs):
         # reload the region of the field container with the new mesh
         field.region.reload(mesh=new_mesh)
 
+        # reload the underlying fields of the current field container
+        for f in field.fields:
+            f.reload(region=field.region)
+
         # reload the field container (indices and offsets)
         field.reload()
 
         # add the top-level field container as attribute x0
         field.x0 = x0
-
-        for f in field.fields:
-            f.reload(region=field.region)
 
     return x0

--- a/src/felupe/field/_merge.py
+++ b/src/felupe/field/_merge.py
@@ -29,6 +29,8 @@ def merge(fields, decimals=None, **kwargs):
         The list of field containers to be merged.
     decimals : int or None, optional
         Precision decimals for merging duplicated mesh points. Default is None.
+    **kwargs : dict, optional
+        Additional keyword arguments for :class:`~felupe.MeshContainer`.
 
     Returns
     -------
@@ -68,7 +70,7 @@ def merge(fields, decimals=None, **kwargs):
     regions = [field.region for field in fields]
     meshes = [region.mesh for region in regions]
 
-    container = MeshContainer(meshes, merge=True, decimals=decimals)
+    container = MeshContainer(meshes, merge=True, decimals=decimals, **kwargs)
 
     # take the type and the dimension
     # of the first sub-field of the first field container

--- a/src/felupe/mechanics/_job.py
+++ b/src/felupe/mechanics/_job.py
@@ -222,6 +222,23 @@ class Job:
                 kwargs["kwargs"] = {}
             kwargs["kwargs"]["parallel"] = True
 
+        # use x0-attribute of first field of first step for kwargs["x0"]
+        if "x0" not in kwargs.keys():
+
+            first_field = self.steps[0].items[0].field
+            kwargs["x0"] = getattr(first_field, "x0", first_field)
+
+            # check if all items have the same top-level field (x0-attribute)
+            if hasattr(first_field, "x0"):
+
+                for step in self.steps:
+                    for item in step.items:
+
+                        if not (kwargs["x0"] is getattr(item.field, "x0", None)):
+                            raise ValueError(
+                                "All items must have the same top-level field."
+                            )
+
         time = 0
 
         for j, step in enumerate(self.steps):

--- a/src/felupe/mechanics/_job.py
+++ b/src/felupe/mechanics/_job.py
@@ -224,20 +224,8 @@ class Job:
 
         # use x0-attribute of first field of first step for kwargs["x0"]
         if "x0" not in kwargs.keys():
-
             first_field = self.steps[0].items[0].field
             kwargs["x0"] = getattr(first_field, "x0", first_field)
-
-            # check if all items have the same top-level field (x0-attribute)
-            if hasattr(first_field, "x0"):
-
-                for step in self.steps:
-                    for item in step.items:
-
-                        if not (kwargs["x0"] is getattr(item.field, "x0", None)):
-                            raise ValueError(
-                                "All items must have the same top-level field."
-                            )
 
         time = 0
 

--- a/src/felupe/mechanics/_job.py
+++ b/src/felupe/mechanics/_job.py
@@ -223,7 +223,7 @@ class Job:
             kwargs["kwargs"]["parallel"] = True
 
         # use x0-attribute of first field of first step for kwargs["x0"]
-        if "x0" not in kwargs.keys():
+        if kwargs.get("x0") is None:
             first_field = self.steps[0].items[0].field
             kwargs["x0"] = getattr(first_field, "x0", first_field)
 

--- a/src/felupe/mechanics/_solidbody.py
+++ b/src/felupe/mechanics/_solidbody.py
@@ -393,7 +393,7 @@ class SolidBody(Solid):
         self.results.force = None
         self.results.stiffness = None
 
-    def revolve(self, n=11, phi=180):
+    def revolve(self, n=11, phi=180, x0=None):
         """Return a revolved solid body.
 
         Parameters
@@ -402,6 +402,8 @@ class SolidBody(Solid):
             Number of n-point revolutions (or (n-1) cell revolutions), default is 11.
         phi : float or ndarray, optional
             Revolution angle in degree (default is 180).
+        x0 : FieldContainer or None, optional
+            The revolved top-level field container. Default is None.
 
         Returns
         -------
@@ -458,6 +460,13 @@ class SolidBody(Solid):
         """
 
         new_field = self.field.revolve(n=n, phi=phi)
+        if hasattr(self.field, "x0"):
+            if x0 is None:
+                raise ValueError(
+                    "The revolved top-level field container must be provided as the"
+                    " x0-argument."
+                )
+            new_field.x0 = x0
 
         # create a new solid body
         new_solid = SolidBody(

--- a/src/felupe/mechanics/_solidbody_incompressible.py
+++ b/src/felupe/mechanics/_solidbody_incompressible.py
@@ -478,7 +478,7 @@ class SolidBodyNearlyIncompressible(Solid):
         self.results.force = None
         self.results.stiffness = None
 
-    def revolve(self, n=11, phi=180):
+    def revolve(self, n=11, phi=180, x0=None):
         """Return a revolved solid body.
 
         Parameters
@@ -487,6 +487,8 @@ class SolidBodyNearlyIncompressible(Solid):
             Number of n-point revolutions (or (n-1) cell revolutions), default is 11.
         phi : float or ndarray, optional
             Revolution angle in degree (default is 180).
+        x0 : FieldContainer or None, optional
+            The revolved top-level field container. Default is None.
 
         Returns
         -------
@@ -500,6 +502,13 @@ class SolidBodyNearlyIncompressible(Solid):
         """
 
         new_field = self.field.revolve(n=n, phi=phi)
+        if hasattr(self.field, "x0"):
+            if x0 is None:
+                raise ValueError(
+                    "The revolved top-level field container must be provided as the"
+                    " x0-argument."
+                )
+            new_field.x0 = x0
 
         # create a new solid body
         new_solid = SolidBodyNearlyIncompressible(

--- a/src/felupe/mechanics/_step.py
+++ b/src/felupe/mechanics/_step.py
@@ -87,23 +87,7 @@ class Step:
         "Yield all generated substeps."
 
         substeps = np.arange(self.nsubsteps)
-
-        if "x0" not in kwargs.keys():
-            # use x0 attribute of first field if it exists
-            # otherwise use the field itself
-            # register this field as x0 in kwargs
-            first_field = self.items[0].field
-            field = kwargs["x0"] = getattr(first_field, "x0", first_field)
-
-            # check if all items have the same top-level field (x0-attribute)
-            if hasattr(first_field, "x0"):
-                for item in self.items:
-                    if not (field is getattr(item.field, "x0", None)):
-                        raise ValueError(
-                            "All items must have the same top-level field."
-                        )
-        else:
-            field = kwargs["x0"]
+        field = kwargs["x0"]
 
         stop = False
         for substep in substeps:

--- a/src/felupe/mechanics/_step.py
+++ b/src/felupe/mechanics/_step.py
@@ -89,7 +89,19 @@ class Step:
         substeps = np.arange(self.nsubsteps)
 
         if "x0" not in kwargs.keys():
-            field = self.items[0].field
+            # use x0 attribute of first field if it exists
+            # otherwise use the field itself
+            # register this field as x0 in kwargs
+            first_field = self.items[0].field
+            field = kwargs["x0"] = getattr(first_field, "x0", first_field)
+
+            # check if all items have the same top-level field (x0-attribute)
+            if hasattr(first_field, "x0"):
+                for item in self.items:
+                    if not (field is getattr(item.field, "x0", None)):
+                        raise ValueError(
+                            "All items must have the same top-level field."
+                        )
         else:
             field = kwargs["x0"]
 

--- a/src/felupe/region/_region.py
+++ b/src/felupe/region/_region.py
@@ -211,14 +211,14 @@ class Region:
         quadrature: Quadrature or None, optional
             An element-compatible numeric integration scheme with points and weights
             (default is None).
-        grad : bool, optional
-            A flag to invoke gradient evaluation (default is True). If True, the partial
+        grad : bool or None, optional
+            A flag to invoke gradient evaluation (default is None). If True, the partial
             derivatives of the element shape functions w.r.t. undeformed coordinates
             :math:`\frac{\partial \boldsymbol{h}}{\partial \boldsymbol{X}}`
             and the differential volumes :math:`dV` are evaluated.
-        hess : bool, optional
+        hess : bool or None, optional
             A flag to invoke hessian evaluation in addition to the gradient (default is
-            False). If True, the second partial derivatives of the element shape functions
+            None). If True, the second partial derivatives of the element shape functions
             w.r.t. undeformed coordinates
             :math:`\frac{\partial^2 \boldsymbol{h}}{\partial \boldsymbol{X}\ \partial \boldsymbol{X}}`
             are evaluated.
@@ -269,14 +269,14 @@ class Region:
         quadrature: Quadrature or None, optional
             An element-compatible numeric integration scheme with points and weights
             (default is None).
-        grad : bool, optional
-            A flag to invoke gradient evaluation (default is True). If True, the partial
+        grad : bool or None, optional
+            A flag to invoke gradient evaluation (default is None). If True, the partial
             derivatives of the element shape functions w.r.t. undeformed coordinates
             :math:`\frac{\partial \boldsymbol{h}}{\partial \boldsymbol{X}}`
             and the differential volumes :math:`dV` are evaluated.
-        hess : bool, optional
+        hess : bool or None, optional
             A flag to invoke hessian evaluation in addition to the gradient (default is
-            False). If True, the second partial derivatives of the element shape functions
+            None). If True, the second partial derivatives of the element shape functions
             w.r.t. undeformed coordinates
             :math:`\frac{\partial^2 \boldsymbol{h}}{\partial \boldsymbol{X}\ \partial \boldsymbol{X}}`
             are evaluated.

--- a/tests/test_field.py
+++ b/tests/test_field.py
@@ -297,7 +297,8 @@ def test_toplevel():
 def test_toplevel_merge():
 
     mesh1 = fem.Rectangle(n=3)
-    field1 = fem.FieldsMixed(fem.RegionQuad(mesh1), n=3, axisymmetric=True)
+    displacement1 = fem.FieldAxisymmetric(fem.RegionQuad(mesh1), dim=2)
+    field1 = fem.FieldContainer([displacement1])
 
     mesh2 = fem.Rectangle(a=(1, 0), b=(2, 1), n=3)
     displacement2 = fem.FieldAxisymmetric(fem.RegionQuad(mesh2), dim=2)
@@ -309,7 +310,7 @@ def test_toplevel_merge():
     x0 = (field1 & field2).merge()
 
     umat = fem.NeoHookeCompressible(mu=1, lmbda=2)
-    solid1 = fem.SolidBody(fem.ThreeFieldVariation(umat), field1)
+    solid1 = fem.SolidBody(umat, field1)
     solid2 = fem.SolidBody(umat, field2)
 
     boundaries = fem.dof.uniaxial(x0, clamped=True, return_loadcase=False)
@@ -318,9 +319,19 @@ def test_toplevel_merge():
     fem.Job(steps=[step]).evaluate(x0=x0)
 
 
-def test_merge_empty():
+def test_merge():
+
+    # empty list of field containers can't be merged
     with pytest.raises(ValueError):
         fem.field.merge([])
+
+    mesh = fem.Rectangle(n=3)
+    field = fem.FieldsMixed(fem.RegionQuad(mesh), n=3, axisymmetric=True)
+
+    # field containers with dual fields can't be merged
+    with pytest.raises(TypeError):
+        fem.field.merge([field])
+
 
 if __name__ == "__main__":
     test_axi()
@@ -331,4 +342,4 @@ if __name__ == "__main__":
     test_link()
     test_toplevel()
     test_toplevel_merge()
-    test_merge_empty()
+    test_merge()

--- a/tests/test_field.py
+++ b/tests/test_field.py
@@ -333,6 +333,18 @@ def test_merge():
         fem.field.merge([field])
 
 
+def test_merge_fewer_points():
+
+    mesh = fem.Rectangle(n=2)
+    mesh.points[2] = mesh.points[0]
+
+    displacement = fem.FieldAxisymmetric(fem.RegionQuad(mesh), dim=2)
+    field = fem.FieldContainer([displacement])
+
+    x0 = fem.field.merge([field])
+    assert len(field[0].values) == len(x0[0].values) == 3
+
+
 if __name__ == "__main__":
     test_axi()
     test_3d()
@@ -343,3 +355,4 @@ if __name__ == "__main__":
     test_toplevel()
     test_toplevel_merge()
     test_merge()
+    test_merge_fewer_points()

--- a/tests/test_field.py
+++ b/tests/test_field.py
@@ -318,6 +318,10 @@ def test_toplevel_merge():
     fem.Job(steps=[step]).evaluate(x0=x0)
 
 
+def test_merge_empty():
+    with pytest.raises(ValueError):
+        fem.field.merge([])
+
 if __name__ == "__main__":
     test_axi()
     test_3d()
@@ -327,3 +331,4 @@ if __name__ == "__main__":
     test_link()
     test_toplevel()
     test_toplevel_merge()
+    test_merge_empty()

--- a/tests/test_field.py
+++ b/tests/test_field.py
@@ -300,13 +300,17 @@ def test_toplevel_merge():
     field1 = fem.FieldsMixed(fem.RegionQuad(mesh1), n=3, axisymmetric=True)
 
     mesh2 = fem.Rectangle(a=(1, 0), b=(2, 1), n=3)
-    field2 = fem.FieldAxisymmetric(fem.RegionQuad(mesh2), dim=2)
+    displacement2 = fem.FieldAxisymmetric(fem.RegionQuad(mesh2), dim=2)
+    field2 = fem.FieldContainer([displacement2])
 
-    fields, x0 = (field1 & field2).merge()
+    with pytest.raises(TypeError):
+        x0 = (field1 & displacement2).merge()
+
+    x0 = (field1 & field2).merge()
 
     umat = fem.NeoHookeCompressible(mu=1, lmbda=2)
-    solid1 = fem.SolidBody(fem.ThreeFieldVariation(umat), fields[0])
-    solid2 = fem.SolidBody(umat, fields[1])
+    solid1 = fem.SolidBody(fem.ThreeFieldVariation(umat), field1)
+    solid2 = fem.SolidBody(umat, field2)
 
     boundaries = fem.dof.uniaxial(x0, clamped=True, return_loadcase=False)
 

--- a/tests/test_mechanics.py
+++ b/tests/test_mechanics.py
@@ -751,7 +751,8 @@ def test_axi_to_3d():
     step = fem.Step(items=[new_solid], boundaries=boundaries)
     fem.Job(steps=[step]).evaluate()
 
-    solid.field.x0 = None
+    solid.field.x0 = solid.field
+    solid.revolve(n=11, phi=180, x0=solid.field.revolve(n=11, phi=180))
     with pytest.raises(ValueError):
         solid.revolve(n=11, phi=180)
 
@@ -800,6 +801,7 @@ def test_axi_to_3d_incompressible():
     fem.Job(steps=[step]).evaluate()
 
     solid.field.x0 = None
+    solid.revolve(n=11, phi=180, x0=solid.field.revolve(n=11, phi=180))
     with pytest.raises(ValueError):
         solid.revolve(n=11, phi=180)
 

--- a/tests/test_mechanics.py
+++ b/tests/test_mechanics.py
@@ -643,8 +643,6 @@ def test_truss():
 
 def test_checkpoint():
 
-    import felupe as fem
-
     mesh = fem.Rectangle(b=(3, 1), n=(7, 3))
     region = fem.RegionQuad(mesh)
     field = fem.FieldContainer([fem.FieldPlaneStrain(region, dim=2)])
@@ -683,9 +681,36 @@ def test_checkpoint():
     fem.Job(steps=[step]).evaluate()
 
 
-def test_checkpoint_incompressible():
+def test_checkpoint_x0():
 
-    import felupe as fem
+    mesh = fem.Rectangle(n=2)
+    region = fem.RegionQuad(mesh)
+    field = fem.FieldContainer([fem.FieldPlaneStrain(region, dim=2)])
+
+    global_field = fem.field.merge([field])
+
+    umat = fem.NeoHooke(mu=1, bulk=2)
+    solid = fem.SolidBody(umat=umat, field=field)
+
+    # test checkpoint/restore with a global field x0
+    checkpoint = solid.checkpoint()
+    
+    boundaries = fem.dof.uniaxial(global_field, return_loadcase=False)
+    step = fem.Step(items=[solid], boundaries=boundaries)
+    fem.Job(steps=[step]).evaluate()
+
+    solid.restore(checkpoint)
+
+    # test if global field x0 is restored: solid --> field --> x0
+    assert np.allclose(global_field[0].values, 0)
+
+    # run the same job again
+    boundaries = fem.dof.uniaxial(global_field, return_loadcase=False, move=-0.2)
+    step = fem.Step(items=[solid], boundaries=boundaries)
+    fem.Job(steps=[step]).evaluate()
+
+
+def test_checkpoint_incompressible():
 
     mesh = fem.Rectangle(b=(3, 1), n=(7, 3))
     region = fem.RegionQuad(mesh)
@@ -726,8 +751,6 @@ def test_checkpoint_incompressible():
 
 
 def test_axi_to_3d():
-
-    import felupe as fem
 
     mesh = fem.Rectangle(n=6)
     field = fem.FieldContainer([fem.FieldAxisymmetric(fem.RegionQuad(mesh), dim=2)])
@@ -923,6 +946,7 @@ if __name__ == "__main__":
     test_threefield()
     test_truss
     test_checkpoint()
+    test_checkpoint_x0()
     test_checkpoint_incompressible()
     test_axi_to_3d()
     test_axi_to_3d_incompressible()

--- a/tests/test_mechanics.py
+++ b/tests/test_mechanics.py
@@ -694,7 +694,7 @@ def test_checkpoint_x0():
 
     # test checkpoint/restore with a global field x0
     checkpoint = solid.checkpoint()
-    
+
     boundaries = fem.dof.uniaxial(global_field, return_loadcase=False)
     step = fem.Step(items=[solid], boundaries=boundaries)
     fem.Job(steps=[step]).evaluate()

--- a/tests/test_mechanics.py
+++ b/tests/test_mechanics.py
@@ -751,6 +751,10 @@ def test_axi_to_3d():
     step = fem.Step(items=[new_solid], boundaries=boundaries)
     fem.Job(steps=[step]).evaluate()
 
+    solid.field.x0 = None
+    with pytest.raises(ValueError):
+        solid.revolve(n=11, phi=180)
+
 
 def test_axi_to_3d_mixed():
 
@@ -794,6 +798,10 @@ def test_axi_to_3d_incompressible():
 
     step = fem.Step(items=[new_solid], boundaries=boundaries)
     fem.Job(steps=[step]).evaluate()
+
+    solid.field.x0 = None
+    with pytest.raises(ValueError):
+        solid.revolve(n=11, phi=180)
 
 
 def test_axi_to_3d_quadratic():


### PR DESCRIPTION
This PR changes how `FieldContainer.merge()` works. 

* Instead of returning the top-level field and a list of sub-field containers, it only returns the top-level field now. **This is a breaking change.**
* The given field containers are modified in-place. **Also considered as breaking change.**
* All field container items for merging must be field containers, no fields are allowed. Field container as input, field container as output. No more implicit conversion.
* Field containers with dual fields included can't be merged. This was also the case in the past, but now an error is raised.

### Enhancement
User experience will benefit from this change, because in case of multiple solid bodies, a mesh/region/field/solid can be created as usual, and only `field = (field_1 & field_2).merge()` or `field = fem.field.merge(fields=[field_1, field_2])` is required for the boundary conditions. The `x0`-argument in `Job.evaluate()` will be detected automatically.

### Notes
- [x] A small caveat was detected when revolving a solid body. But it is checked if the field container has the x0-attribute and then the revolved global field (x0) must be given when the body is revolved.

### Open tasks
- [x] Checkpoint / restore functionality still needs to be checked. Checkpoint/restore now supports field containers with an `x0` attribute.